### PR TITLE
Remove all click listeners before adding

### DIFF
--- a/modules/inline_message/site.js
+++ b/modules/inline_message/site.js
@@ -86,6 +86,7 @@ var get_inline_msg_details = function(link) {
 };
 
 var capture_subject_click = function() {
+    $('a', $('.subject')).off('click');
     $('a', $('.subject')).click(function(e) {
         var msg_details = get_inline_msg_details(this); 
         var uid = msg_details[0];


### PR DESCRIPTION
Not sure if this would be the best solution, but every time a click-event loads it adds another listener making a simple scroll through N mails gives N² requests on the server. Removing all listeners on click before adding solves this problem.