### PR TITLE
hm3.sample.ini: fix ldap_base_dn to ldap_auth_base_dn

### DIFF
--- a/hm3.sample.ini
+++ b/hm3.sample.ini
@@ -66,7 +66,7 @@ ldap_auth_port=389
 ldap_auth_tls=
 
 ; The "base dn" of the LDAP server
-ldap_base_dn="example,dc=com"
+ldap_auth_base_dn="example,dc=com"
 
 
 ; IMAP Authentication


### PR DESCRIPTION
Hi Jason,

Found a typo in hm3.sample.ini: ldap_base_dn should actually be ldap_auth_base_dn.
See lib/auth.php:378.

Thanks for providing Cypht!