### PR TITLE
Fix problems adding imap, smtp and probably more

### DIFF
--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -27,7 +27,7 @@ $.fn.serializeArray = function() {
         parts = args[i].split('=');
         res.push({'name': parts[0], 'value': parts[1]});
     }
-    return res;
+    return res.map(x => {return {name: x.name, value: decodeURIComponent(x.value)}});
 };
 $.fn.sort = function(sort_function) {
     var list = [];


### PR DESCRIPTION
## Pullrequest
When saving a new imap/smtp the email address is encoded ( @ is converted in %40 ) and because of this the authentication fails and it cannot be saved. This is an elegant solutions, otherwise every $form['field'] in every module should be urldecode() -ed.