### PR TITLE
allow easier integration into 3rd party systems

### DIFF
--- a/lib/dispatch.php
+++ b/lib/dispatch.php
@@ -156,6 +156,7 @@ class Hm_Dispatch {
     public $session;
     public $module_exec;
     public $page;
+    public $output;
 
     /**
      * Setup object needed to process a request
@@ -257,9 +258,10 @@ class Hm_Dispatch {
      */
     private function render_output() {
         $formatter = new $this->request->format($this->site_config);
-        $renderer = new Hm_Output_HTTP();
+        $class = $this->site_config->get('output_class', 'Hm_Output_HTTP');
+        $renderer = new $class;
         $content = $formatter->content($this->module_exec->output_response, $this->request->allowed_output);
-        $renderer->send_response($content, $this->module_exec->output_data);
+        $this->output = $renderer->send_response($content, $this->module_exec->output_data);
     }
 
     /**

--- a/lib/session_base.php
+++ b/lib/session_base.php
@@ -394,6 +394,7 @@ class Hm_Session_Setup {
      * @return string
      */
     private function get_session_class() {
+        $custom_session_class = $this->config->get('session_class', 'Custom_Session');
         if ($this->session_type == 'DB') {
             $session_class = 'Hm_DB_Session';
         }
@@ -403,8 +404,8 @@ class Hm_Session_Setup {
         elseif ($this->session_type == 'REDIS') {
             $session_class = 'Hm_Redis_Session';
         }
-        elseif ($this->session_type == 'custom' && class_exists('Custom_Session')) {
-            $session_class = 'Custom_Session';
+        elseif ($this->session_type == 'custom' && class_exists($custom_session_class)) {
+            $session_class = $custom_session_class;
         }
         else {
             $session_class = 'Hm_PHP_Session';


### PR DESCRIPTION
Hi Jason,

Thanks for the great work on Cypht! We are integrating Cypht into [Tiki](https://tiki.org/) with Marc Laporte. I have found some missing pieces in the core, so we can embed Cypht into Tiki or reuse Tiki classes for session handling, authentication and similar tasks.

In essence, this PR solves 2 issues:
- inability to override session class. Yes, we have site module lib but it is located in Cypht modules dir which we plan to install via composer and do not want to change anything once installed - i.e. don't want to override Custom_Session class there with our own but specify another session class from another location. This is solved via injected config variable containing the session class name.
- inability to return the output of the dispatcher and decide what to do with it on a later stage of the script execution. We need this in order to embed Cypht into Tiki pages as a wiki plugin where we cannot simply echo the contents of Cypht output modules but need to hold on until the whole page is constructed.

I have done the rest of the modifications through config tweaks (mainly turning off specific modules/functions), as to keep the needed changes to Cypht core at the minimum. I think Marc Laporte can show you a demo of the resulting product if you are interested.

If you see any problems with the code or improvements are necessary, I will be glad to discuss!

Regards,
Victor