### PR TITLE
Remove mobile media queries

### DIFF
--- a/modules/2fa/site.css
+++ b/modules/2fa/site.css
@@ -1,6 +1,4 @@
 .tfa_error, .tfa_input { margin-left: 20px; }
 .tfa_error { color: red; margin-right: 20px; margin-bottom: 10px; }
 .tfa_setting { display: none; }
-@media screen and (max-device-width:480px) and (orientation : portrait) {
-    .tfa_input { max-width: 340px; margin-bottom: 10px; }
-}
+.mobile .tfa_input { max-width: 340px; margin-bottom: 10px; }

--- a/modules/advanced_search/site.css
+++ b/modules/advanced_search/site.css
@@ -20,6 +20,4 @@
 .adv_search_link { margin-left: 20px; }
 .adv_terms { margin-left: 10px; }
 
-@media screen and (max-device-width:480px) and (orientation : portrait) {
-    .search_result_title { position: relative !important; z-index: 99 !important;}
-}
+.mobile .search_result_title { position: relative !important; z-index: 99 !important;}

--- a/modules/calendar/site.css
+++ b/modules/calendar/site.css
@@ -1,7 +1,7 @@
 .calendar { width: 100%; }
 .event_form { margin-left: 40px; }
 .calendar_week th, .calendar_month th { font-weight: normal; padding-top: 10px; border-bottom: solid 1px #eee; padding-bottom: 10px; border-right: solid 1px #eee; }
-@media screen and (max-device-width:480px) and (orientation : portrait) { .calendar_month th { max-width: 30px; overflow: hidden; } }
+.mobile .calendar_month th { max-width: 30px; overflow: hidden; }
 .calendar_month td { width: 14%; height: 120px; text-align: left; padding: 10px; border-bottom: solid 1px #eee; vertical-align: top; border-right: solid 1px #eee; }
 .calendar_week, .calendar_month { padding-bottom: 50px; width: 100%; }
 .calendar_week .today, .calendar_month .today { background-color: #f5f5f5; }

--- a/modules/contacts/site.css
+++ b/modules/contacts/site.css
@@ -28,4 +28,9 @@
 .show_contact { margin-right: 15px; }
 .contact_detail th { font-weight: normal; text-align: left; padding-right: 20px; }
 .contact_fld { max-width: 300px; overflow-x: hidden; text-overflow: ellipsis; }
-@media screen and (max-device-width:480px) and (orientation : portrait) { .contact_list { margin-left: 0px; font-size: 125%; width: 100%; } .contact_controls img { width: 20px; height: 20px; } .contact_list_title, .add_contact { display: none; } .contact_fld { display: none; } .contact_src { display: none; } .add_contact_row { display: none; } }
+
+.mobile .contact_list { margin-left: 0px; font-size: 125%; width: 100%; }
+.mobile .contact_controls img { width: 20px; height: 20px; }
+.mobile .contact_list_title, .mobile .add_contact { display: none; }
+.mobile .contact_fld { display: none; } .contact_src { display: none; }
+.mobile .add_contact_row { display: none; }

--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -565,6 +565,7 @@ class Hm_Handler_login extends Hm_Handler_Module {
      */
     public $validate_request = true;
     public function process() {
+        $this->out('is_mobile', $this->request->mobile);
         if ($this->get('create_username', false)) {
             return;
         }

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -351,7 +351,7 @@ class Hm_Output_content_start extends Hm_Output_Module {
      * if not logged in, or adds a page wide key used by ajax requests
      */
     protected function output() {
-        $res = '<body><noscript class="noscript">'.
+        $res = '<body class="'.($this->get('is_mobile', false) ? 'mobile' : '').'"><noscript class="noscript">'.
             sprintf($this->trans('You need to have Javascript enabled to use %s, sorry about that!'),
                 $this->html_safe($this->get('router_app_name'))).'</noscript>';
         if (!$this->get('router_login_state')) {

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -233,7 +233,7 @@ div.unseen, .unseen .subject { font-weight: 700; }
 .mobile .search_content .refresh_list { display: none; }
 .mobile .search_content .content_title { max-height: 500px; }
 .mobile .search_form select { width: 30px; }
-.mobile .search_terms { max-width: 250px; }*/
+.mobile .search_terms { max-width: 250px; }
 .mobile .search_content { padding-top: 30px; }
 .mobile .unsaved_reminder { display: none; }
 .mobile .checkbox_cell { width: 35px; }

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -200,13 +200,16 @@ div.unseen, .unseen .subject { font-weight: 700; }
 .mobile .save_settings { margin-left: 0px !important; }
 .mobile .save_settings_password { margin-right: 10px; }
 .mobile .list_meta { display: block; }
-.mobile .checkbox_cell { padding-right: 0px !important; padding-left: 0px !important; }
-.mobile .mailbox_list_title { font-size: 80%; }
+.mobile .checkbox_cell { padding-right: 0px !important; padding-left: 3px !important; }
+.mobile .mailbox_list_title { font-size: 95%; }
 .mobile .folder_cell { display: block; max-width: 96%; width: 96%; padding: 0px !important;}
-.mobile .folder_list { padding: 0px !important; font-size: 120%; margin-right: 0px; display: none; width: 100%; }
+.mobile .folder_list { padding: 0px !important; font-size: 130%; margin-right: 0px; display: none; width: 100%; }
+.mobile .folder_list li a { font-size: 110%; padding-top: 10px; }
+.mobile .folder_list li { padding-top: 5px; padding-bottom: 5px; }
+.mobile .src_name { padding-top: 20px; padding-bottom: 20px; }
 .mobile .content_cell { padding-top: 60px; display: block; width: 100%; }
-.mobile .content_title { z-index: 100; top: 0px; background-color: #fff; position: fixed; padding-left: 40px; padding-top: 20px; margin-bottom: 5px; left: 0px; right: 0px; padding-bottom: 17px; }
-.mobile .folder_toggle { display: block; top: 19px; left: 5px; }
+.mobile .content_title { z-index: 100; top: 0px; background-color: #fff; position: fixed; padding-left: 45px; padding-top: 20px; margin-bottom: 5px; left: 0px; right: 0px; padding-bottom: 17px; }
+.mobile .folder_toggle { display: block; top: 19px; left: 8px; }
 .mobile .account_icon { width: 16px; height: 16px; vertical-align: -5px; }
 .mobile .message_table { padding-left: 5px !important; }
 .mobile .list_settings_link, .mobile .refresh_list { width: 24px; height: 24px; vertical-align: -13px; }
@@ -227,10 +230,10 @@ div.unseen, .unseen .subject { font-weight: 700; }
 .mobile .search_form select, .mobile .search_form button, .mobile .search_form input { margin-left: 0px !important; margin: 0px; margin-top: 5px; }
 .mobile .search_form label { display: none; }
 .mobile .search_update { clear: both; }
-.mobile .search_content , .mobile .refresh_list { display: none; }
-.mobile .search_content .mobile .content_title { max-height: 500px; }
+.mobile .search_content .refresh_list { display: none; }
+.mobile .search_content .content_title { max-height: 500px; }
 .mobile .search_form select { width: 30px; }
-.mobile .search_terms { width: 100px; }
+.mobile .search_terms { max-width: 250px; }*/
 .mobile .search_content { padding-top: 30px; }
 .mobile .unsaved_reminder { display: none; }
 .mobile .checkbox_cell { width: 35px; }
@@ -247,6 +250,7 @@ div.unseen, .unseen .subject { font-weight: 700; }
 .mobile .compose_form { padding: 0px !important; padding-left: 5px !important; width: 92% !important; }
 .mobile .toggle_recipients { top: 8px !important; right: 0px !important; }
 .mobile .prevnext, .mobile .news_cell .subject div img { width: 20px; height: 20px; }
+.mobile .long_session { float: left; clear: both; }
 
 @media print {
     .folder_list, .msg_parts, .header_links, .content_title, .add_contact_row, .unsaved_icon, .add_vcal { display: none !important; }

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -193,101 +193,61 @@ div.unseen, .unseen .subject { font-weight: 700; }
 .rtl_page .toggle_link { margin-right: 5px !important; margin-left: 15px !important; }
 .rtl_page .msg_controls { margin-right: 0px !important; padding-right: 5px !important; margin-left: 15px !important; }
 
-@media screen and (max-device-width:1080px) and (orientation : portrait) {
-    .account_icon { width: 24px; height: 24px; vertical-align: -5px; }
-    .list_settings_link, .refresh_list { width: 38px; height: 38px; margin-top: -3px; }
-    .folder_toggle img { width: 36px; height: 42px; }
-    .folder_toggle{ top: 24px; left: 0px; }
-    .folders a { font-size: 125%; }
-    .folders li { padding-bottom: 5px; padding-top: 5px; }
-    .content_title { padding-left: 35px; }
-    .checkbox_cell { padding-left: 15px !important; }
-    .folder_list { min-width: 150px; }
-    .src_name, .content_title { font-size: 140%; padding-bottom: 15px; padding-top: 25px; max-height: 50px; }
-    body { font-size: 150%; }
-    .msg_text { font-size: 125%; }
-    .msg_text_inner { font-size: 140%; }
-    .list_meta { display: none; }
-    .user_settings table { white-space: normal; word-break: normal !important; table-layout: auto; }
-    .header_subject th { max-width: 360px; white-space: normal !important; word-break: break-all; word-wrap: break-word; overflow: hidden !important; }
-    .msg_headers th { padding-left: 10px !important; }
-    .msg_headers td { white-space: normal; word-break: break-all; word-wrap: break-word; }
-    .unsaved_reminder { display: none; }
-}
-@media screen and (max-device-width:1080px) and (orientation : landscape) {
-    .account_icon { width: 16px; height: 16px; vertical-align: -5px; }
-    .list_settings_link, .refresh_list { width: 24px; height: 24px; }
-    .folder_toggle img { width: 24px; height: 24px; }
-    .folder_toggle{ display: block; top: 16px; left: 0px; }
-    .folders a { font-size: 115%; }
-    .content_title { padding-left: 35px; }
-    .checkbox_cell { padding-left: 15px !important; }
-    .folder_list { display: none; width: 150px; }
-    .src_name, .content_title { font-size: 125%; max-height: 50px; }
-    .msg_text_inner { font-size: 140%; }
-    .msg_controls { position: absolute; background-color: #fff !important; }
-    .user_settings table { white-space: normal; word-break: normal !important; table-layout: auto; }
-    .header_subject th { max-width: 360px; white-space: normal !important; word-break: break-all; word-wrap: break-word; overflow: hidden !important; }
-    .msg_headers th { padding-left: 10px !important; }
-    .msg_headers td { white-space: normal; word-break: break-all; word-wrap: break-word; }
-    .unsaved_reminder { display: none; }
-}
-@media screen and (max-device-width:480px) and (orientation : portrait) {
-    .sys_messages { position: absolute; z-index: 1002; }
-    .account_icon { width: 24px; height: 24px; padding-bottom: 4px; }
-    .save_settings { margin-left: 0px !important; }
-    .save_settings_password { margin-right: 10px; }
-    body { font-size: 90%; min-width: 100%; }
-    .list_meta { display: block; }
-    .checkbox_cell { padding-right: 0px !important; padding-left: 0px !important; }
-    .mailbox_list_title { font-size: 80%; }
-    .folder_cell { display: block; max-width: 96%; width: 96%; padding: 0px !important;}
-    .folder_list { padding: 0px !important; font-size: 120%; margin-right: 0px; display: none; width: 100%; }
-    .content_cell { padding-top: 60px; display: block; width: 100%; }
-    .content_title { z-index: 100; top: 0px; background-color: #fff; position: fixed; padding-left: 40px; padding-top: 20px; margin-bottom: 5px; left: 0px; right: 0px; }
-    .folder_toggle { display: block; top: 19px; left: 5px; }
-    .account_icon { width: 16px; height: 16px; vertical-align: -5px; }
-    .message_table { padding-left: 5px !important; }
-    .list_settings_link, .refresh_list { width: 24px; height: 24px; vertical-align: -13px; }
-    .refresh_list { margin-right: 5px; }
-    .folder_toggle img { width: 30px; height: 36px; margin-top: -7px; }
-    .folder_toggle { position: fixed; z-index: 101; }
-    .update_message_list { margin-right: 20px; }
-    .msg_text { width: 100%; max-width: 480px !important; word-break: break-all; word-wrap: break-word; font-size: 100%; }
-    .msg_controls { background: linear-gradient(180deg, #fff, #fff, #f7f2ef) !important; z-index: 100; position: fixed; right: -20px; height: 29px; font-size: 115%; padding-left: 10px; padding-top: 9px; top: 10px; left: 70px !important; }
-    .offline { height: 23px; padding-left: 38px; padding-right: 38px; }
-    .header_subject th { white-space: normal !important; word-break: break-all !important; word-wrap: break-word !important; }
-    .msg_headers th { padding-left: 10px !important; }
-    .nlink, .plink, .msg_headers td { white-space: normal; word-break: break-all; word-wrap: break-word; }
-    .msg_text_inner { padding-left: 10px !important; font-size: 120%; padding: 10px !important; }
-    .list_meta { display: none; }
-    .user_settings table { white-space: normal; word-break: normal !important; table-layout: auto; }
-    .header_links, .nlink { white-space: normal !important; word-break: break-all; word-wrap: break-word; }
-    .search_form select, .search_form button, .search_form input { margin-left: 0px !important; margin: 0px; margin-top: 5px; }
-    .search_form label { display: none; }
-    .search_update { clear: both; }
-    .search_content .refresh_list { display: none; }
-    .search_content .content_title { max-height: 500px; }
-    .search_form select { width: 30px; }
-    .search_terms { width: 100px; }
-    .search_content { padding-top: 30px; }
-    .unsaved_reminder { display: none; }
-    .checkbox_cell { width: 35px; }
-    .checkbox_cell label { width: 30px; height: 30px; }
-    .github_para { white-space: normal !important; }
-    .login_form { margin-top: 60px; display: block; float: none; width: 100%; background-color: #fff; font-size: 130%; height: auto; }
-    #username, #password { width: 75%; }
-    .account_icon { width: 20px; height: 20px; }
-    .imap_filter { display: none; }
-    .list_controls { color: #777; background: linear-gradient(180deg, #fff, #fff, #f7f2ef); border-bottom: solid 1px #ede8e6; height: 48px; padding-left: 5px; padding-right: 5px; }
-    .page_links { font-size: 150%; }
-    .page_links a img { width: 24px; height: 24px; }
-    .toggle_link { padding: 5px !important; line-height: auto !important; margin-left: 5px !important; }
-    .toggle_link img { vertical-align: -3px !important; width: 16px; height: 16px; }
-    .compose_form { padding: 0px !important; padding-left: 5px !important; width: 92% !important; }
-    .toggle_recipients { top: 8px !important; right: 0px !important; }
-    .prevnext, .news_cell .subject div img { width: 20px; height: 20px; }
-}
+/* mobile */
+.mobile { font-size: 90%; min-width: 100%; background: none; }
+.mobile .sys_messages { position: absolute; z-index: 1002; }
+.mobile .account_icon { width: 24px; height: 24px; padding-bottom: 4px; }
+.mobile .save_settings { margin-left: 0px !important; }
+.mobile .save_settings_password { margin-right: 10px; }
+.mobile .list_meta { display: block; }
+.mobile .checkbox_cell { padding-right: 0px !important; padding-left: 0px !important; }
+.mobile .mailbox_list_title { font-size: 80%; }
+.mobile .folder_cell { display: block; max-width: 96%; width: 96%; padding: 0px !important;}
+.mobile .folder_list { padding: 0px !important; font-size: 120%; margin-right: 0px; display: none; width: 100%; }
+.mobile .content_cell { padding-top: 60px; display: block; width: 100%; }
+.mobile .content_title { z-index: 100; top: 0px; background-color: #fff; position: fixed; padding-left: 40px; padding-top: 20px; margin-bottom: 5px; left: 0px; right: 0px; padding-bottom: 17px; }
+.mobile .folder_toggle { display: block; top: 19px; left: 5px; }
+.mobile .account_icon { width: 16px; height: 16px; vertical-align: -5px; }
+.mobile .message_table { padding-left: 5px !important; }
+.mobile .list_settings_link, .mobile .refresh_list { width: 24px; height: 24px; vertical-align: -13px; }
+.mobile .refresh_list { margin-right: 5px; }
+.mobile .folder_toggle img { width: 30px; height: 36px; margin-top: -7px; }
+.mobile .folder_toggle { position: fixed; z-index: 101; }
+.mobile .update_message_list { margin-right: 20px; }
+.mobile .msg_text { width: 100%; max-width: 480px !important; word-break: break-all; word-wrap: break-word; font-size: 100%; }
+.mobile .msg_controls { background: linear-gradient(180deg, #fff, #fff, #f7f2ef) !important; z-index: 100; position: fixed; right: -20px; height: 29px; font-size: 115%; padding-left: 10px; padding-top: 9px; top: 10px; left: 70px !important; }
+.mobile .offline { height: 23px; padding-left: 38px; padding-right: 38px; }
+.mobile .header_subject th { white-space: normal !important; word-break: break-all !important; word-wrap: break-word !important; }
+.mobile .msg_headers th { padding-left: 10px !important; }
+.mobile .nlink, .mobile .plink, .mobile .msg_headers td { white-space: normal; word-break: break-all; word-wrap: break-word; }
+.mobile .msg_text_inner { padding-left: 10px !important; font-size: 120%; padding: 10px !important; }
+.mobile .list_meta { display: none; }
+.mobile .user_settings table { white-space: normal; word-break: normal !important; table-layout: auto; }
+.mobile .header_links, .mobile .nlink { white-space: normal !important; word-break: break-all; word-wrap: break-word; }
+.mobile .search_form select, .mobile .search_form button, .mobile .search_form input { margin-left: 0px !important; margin: 0px; margin-top: 5px; }
+.mobile .search_form label { display: none; }
+.mobile .search_update { clear: both; }
+.mobile .search_content , .mobile .refresh_list { display: none; }
+.mobile .search_content .mobile .content_title { max-height: 500px; }
+.mobile .search_form select { width: 30px; }
+.mobile .search_terms { width: 100px; }
+.mobile .search_content { padding-top: 30px; }
+.mobile .unsaved_reminder { display: none; }
+.mobile .checkbox_cell { width: 35px; }
+.mobile .checkbox_cell label { width: 30px; height: 30px; }
+.mobile .github_para { white-space: normal !important; }
+.mobile .login_form { margin-top: 60px; display: block; float: none; width: 100%; background-color: #fff; font-size: 130%; height: auto; }
+.mobile .account_icon { width: 20px; height: 20px; }
+.mobile .imap_filter { display: none; }
+.mobile .list_controls { color: #777; background: linear-gradient(180deg, #fff, #fff, #f7f2ef); border-bottom: solid 1px #ede8e6; height: 48px; padding-left: 5px; padding-right: 5px; }
+.mobile .page_links { font-size: 150%; }
+.mobile .page_links a img { width: 24px; height: 24px; }
+.mobile .toggle_link { padding: 5px !important; line-height: auto !important; margin-left: 5px !important; }
+.mobile .toggle_link img { vertical-align: -3px !important; width: 16px; height: 16px; }
+.mobile .compose_form { padding: 0px !important; padding-left: 5px !important; width: 92% !important; }
+.mobile .toggle_recipients { top: 8px !important; right: 0px !important; }
+.mobile .prevnext, .mobile .news_cell .subject div img { width: 20px; height: 20px; }
+
 @media print {
     .folder_list, .msg_parts, .header_links, .content_title, .add_contact_row, .unsaved_icon, .add_vcal { display: none !important; }
 }

--- a/modules/imap/site.css
+++ b/modules/imap/site.css
@@ -75,5 +75,11 @@
 .msg_part_encoding { width: 7%; }
 .msg_part_charset { width: 8%; }
 .msg_part_download { width: 10%; }
-@media screen and (max-device-width:480px) and (orientation : portrait) { .msg_parts td { padding-bottom: 5px !important; width: 25%; padding-left: 3px !important;} .part_size { width: 50px !important; } .part_encoding { display: none; } .part_charset { display: none; } .download_link { width: 50px !important; overflow: visible !important; margin-left: 25px; } .part_desc, .part_size { margin-left: 25px; } }
-.unflag_send_div { float: right; clear: right; margin-top: 10px; }
+
+.mobile .msg_parts td { padding-bottom: 5px !important; width: 25%; padding-left: 3px !important;}
+.mobile .part_size { width: 50px !important; }
+.mobile .part_encoding { display: none; }
+.mobile .part_charset { display: none; }
+.mobile .download_link { width: 50px !important; overflow: visible !important; margin-left: 25px; }
+.mobile .part_desc, .mobile .part_size { margin-left: 25px; }
+.mobile .unflag_send_div { float: right; clear: right; margin-top: 10px; }

--- a/modules/keyboard_shortcuts/site.css
+++ b/modules/keyboard_shortcuts/site.css
@@ -9,9 +9,8 @@
 .shortcut_table td { padding-top: 5px; }
 .shortcut_table .settings_subtitle { cursor: auto; }
 .shortcut_table .keys {white-space: nowrap; width: 1%; font-size: 105%; color: #666; }
-@media screen and (max-device-width:480px) and (orientation : portrait) {
-    .shortcut_table { width: 100%; }
-    .shortcut_table img { width: 20px; height: 20px; }
-    .shortcut_table th { padding-left: 10px; }
-    .shortcut_table { padding-right: 10px; }
-}
+
+.mobile .shortcut_table { width: 100%; }
+.mobile .shortcut_table img { width: 20px; height: 20px; }
+.mobile .shortcut_table th { padding-left: 10px; }
+.mobile .shortcut_table { padding-right: 10px; }

--- a/modules/nux/site.css
+++ b/modules/nux/site.css
@@ -22,6 +22,6 @@
 .nux_empty_combined_view { display: none; text-align: center; padding-top: 100px; color: #666; }
 
 .mobile .quick_add_section { padding-left: 0px; }
-.mobile .nux_dev_news, .mobile .nux_help, .mobile .nux_welcome {width: 90%; margin: 10px  auto; padding-left: 10px; padding-right: 5px; float: none; min-height: 200px; }
+.mobile .nux_dev_news, .mobile .nux_help, .mobile .nux_welcome { max-width: 90%; width: 90%; margin: 10px  auto; padding-left: 10px; padding-right: 5px; float: none; min-height: 200px; }
 .mobile .nux_dev_news { width: 90%; overflow: hidden; }
 .mobile .nux_welcome ul { padding-left: 10px; }

--- a/modules/nux/site.css
+++ b/modules/nux/site.css
@@ -20,4 +20,8 @@
 .nux_try_out { display: block; text-align: center; margin: auto; margin-top: 10px; }
 .nux_tz {  margin-top: 30px; }
 .nux_empty_combined_view { display: none; text-align: center; padding-top: 100px; color: #666; }
-@media screen and (max-device-width:480px) and (orientation : portrait) { .quick_add_section { padding-left: 0px; } .nux_dev_news, .nux_help, .nux_welcome {width: 90%; margin: 10px  auto; padding-left: 10px; padding-right: 5px; float: none; min-height: 200px; } .nux_dev_news { width: 90%; overflow: hidden; } .nux_welcome ul { padding-left: 10px; } }
+
+.mobile .quick_add_section { padding-left: 0px; }
+.mobile .nux_dev_news, .mobile .nux_help, .mobile .nux_welcome {width: 90%; margin: 10px  auto; padding-left: 10px; padding-right: 5px; float: none; min-height: 200px; }
+.mobile .nux_dev_news { width: 90%; overflow: hidden; }
+.mobile .nux_welcome ul { padding-left: 10px; }

--- a/modules/profiles/site.css
+++ b/modules/profiles/site.css
@@ -7,7 +7,5 @@
 .edit_profile table th, .edit_profile table td { padding-bottom: 10px; }
 .compose_sign { cursor: pointer; margin-left: 10px; float: right; margin-top: 10px; }
 .profiles_empty { text-align: center; padding-top: 100px; color: #666; }
-@media screen and (max-device-width:480px) and (orientation : portrait) {
-    .profile_fld { display: none; }
-}
+.mobile .profile_fld { display: none; }
 .add_profile { position: absolute; top: 10px; right: 10px; }

--- a/modules/recaptcha/site.css
+++ b/modules/recaptcha/site.css
@@ -1,4 +1,2 @@
 .g-recaptcha { margin-left: -12px; }
-@media screen and (max-device-width:480px) and (orientation : portrait) {
-    .g-recaptcha { clear: left; margin-left: 20px; }
-}
+.mobile .g-recaptcha { clear: left; margin-left: 20px; }

--- a/modules/saved_searches/site.css
+++ b/modules/saved_searches/site.css
@@ -2,4 +2,5 @@
 .saved_searches_form input { margin-left: 3px; margin-right: 3px; }
 .save_search img, .delete_search img { opacity: .5; position: absolute; right: 75px; top: 21px; }
 .update_search img { opacity: .5; position: absolute; right: 75px; top: 22px; }
-@media screen and (max-device-width:480px) and (orientation : portrait) { .save_search, .delete_search, .add_search { display: none !important; } }
+
+.mobile .save_search, .mobile .delete_search, .mobile .add_search { display: none !important; }

--- a/modules/tags/site.css
+++ b/modules/tags/site.css
@@ -1,2 +1,2 @@
 .tag_icon { position: absolute; right: 50px; top: 18px; }
-@media screen and (max-device-width:480px) and (orientation : portrait) { .tag_icon { display: none; } }
+.mobile .tag_icon { display: none; }

--- a/tests/phpunit/modules/core/modules.php
+++ b/tests/phpunit/modules/core/modules.php
@@ -760,10 +760,10 @@ class Hm_Test_Core_Output_Modules extends PHPUnit_Framework_TestCase {
     public function test_content_start() {
         $test = new Output_Test('content_start', 'core');
         $res = $test->run();
-        $this->assertEquals(array('<body><noscript class="noscript">You need to have Javascript enabled to use , sorry about that!</noscript><script type="text/javascript">sessionStorage.clear();</script>'), $res->output_response);
+        $this->assertEquals(array('<body class=""><noscript class="noscript">You need to have Javascript enabled to use , sorry about that!</noscript><script type="text/javascript">sessionStorage.clear();</script>'), $res->output_response);
         $test->handler_response = array('changed_settings' => array(0), 'router_login_state' => true);
         $res = $test->run();
-        $this->assertEquals(array('<body><noscript class="noscript">You need to have Javascript enabled to use , sorry about that!</noscript><input type="hidden" id="hm_page_key" value="" /><a class="unsaved_icon" href="?page=save" title="Unsaved Changes"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AgSFQseE+bgxAAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAS0lEQVQ4y6WTSQoAMAgDk/z/z+21lK6ON5UZEIklNdXLIbAkhcBVgccmBP4VeDUMgV8FPi1D4JvAL7eFwDuBf/4aAs8CV0NB0sirA+jtAijusTaJAAAAAElFTkSuQmCC" alt="Unsaved changes" class="unsaved_reminder" /></a>'), $res->output_response);
+        $this->assertEquals(array('<body class=""><noscript class="noscript">You need to have Javascript enabled to use , sorry about that!</noscript><input type="hidden" id="hm_page_key" value="" /><a class="unsaved_icon" href="?page=save" title="Unsaved Changes"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AgSFQseE+bgxAAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAS0lEQVQ4y6WTSQoAMAgDk/z/z+21lK6ON5UZEIklNdXLIbAkhcBVgccmBP4VeDUMgV8FPi1D4JvAL7eFwDuBf/4aAs8CV0NB0sirA+jtAijusTaJAAAAAElFTkSuQmCC" alt="Unsaved changes" class="unsaved_reminder" /></a>'), $res->output_response);
     }
     /**
      * @preserveGlobalState disabled


### PR DESCRIPTION
Instead of using media queries use css selectors to enable mobile layout. This is controlled by a server side check on the user agent which injects a top level class into the page. By removing media queries the mobile UI is limited to a single source of truth and we more control over the use of the mobile UI.