### PR TITLE
add cookie_path configuration parameter

### DIFF
--- a/hm3.sample.ini
+++ b/hm3.sample.ini
@@ -203,11 +203,22 @@ admin_users=
 ; By default Cypht uses the server name used in the request to determine
 ; the domain name to set the cookie for. Configurations that use a reverse
 ; proxy might need to define the domain name used for cookies. Leave this
-; blank to let Cypht auotmatically determine the domain. You can also use
+; blank to let Cypht automatically determine the domain. You can also use
 ; the special value of "none" to force Cypht to NOT set the cookie domain
 ; property at all. This is not recommended unless you know what you are
 ; doing!
 cookie_domain=
+
+
+; Cookie Path
+; -------------
+; By default Cypht uses the request URI to determine the cookie path to set
+; the cookie for. Configurations that use mod_rewrite might need to define
+; the path used for cookies. Leave this blank to let Cypht automatically
+; determine the path. You can also use the special value of "none" to force
+; Cypht to NOT set the cookie path property at all. This is not recommended
+; unless you know what you are doing!
+cookie_path=
 
 
 ; Outbound E-mail Domain

--- a/hm3.sample.ini
+++ b/hm3.sample.ini
@@ -214,7 +214,9 @@ cookie_domain=
 ; -------------
 ; By default Cypht uses the request URI to determine the cookie path to set
 ; the cookie for. Configurations that use mod_rewrite might need to define
-; the path used for cookies. Leave this blank to let Cypht automatically
+; the path used for cookies. E.g. /cypht/embedded?page=compose will set path
+; to /cypht/embedded/ which won't send the cookies back to the server. In that
+; case set cookie_path=/cypht/. Leave this blank to let Cypht automatically
 ; determine the path. You can also use the special value of "none" to force
 ; Cypht to NOT set the cookie path property at all. This is not recommended
 ; unless you know what you are doing!

--- a/lib/session_base.php
+++ b/lib/session_base.php
@@ -305,6 +305,22 @@ abstract class Hm_Session {
     }
 
     /**
+     * @param Hm_Request $request request object
+     * @return string
+     */
+    private function cookie_path($request) {
+        $path = $this->site_config->get('cookie_path', false);
+        if (!$path) {
+            $path = $request->path;
+        }
+        if ($path == 'none') {
+            $path = '';
+        }
+        return $path;
+    }
+
+
+    /**
      * Set a cookie, secure if possible
      * @param object $request request details
      * @param string $name cookie name
@@ -332,7 +348,7 @@ abstract class Hm_Session {
             $html_only = false;
         }
         if ($name != 'hm_reload_folders' && !$path && isset($request->path)) {
-            $path = $request->path;
+            $path = $this->cookie_path($request);
         }
         if (!$domain) {
             $domain = $this->cookie_domain($request);


### PR DESCRIPTION
## Pullrequest
Add ability to specify the cookie path the same way cookie domain can be specified through configuration. It is useful in scenarios where mod_rewrite is used and current Cypht cookie path retrieval mechanism incorrectly puts the cookie inside a directory which is actually a webpage, hence the inability to access those cookies later. E.g. request URI like /tiki-git/Webmail?page=compose will end up with cookie path /tiki-git/Webmail/ which is incorrect as the path is /tiki-git/ only.

### Issues
- [X] None

### Checklist
- [ ] Config Update

### How2Test
Specify a specific cookie path and check cookies are still set - e.g. compose message returns back the proper Message Sent response.

### Todo
- [ ] Changelog
