### PR TITLE
allow usage of custom class for implemeting user configuration persistence

### DIFF
--- a/hm3.sample.ini
+++ b/hm3.sample.ini
@@ -141,16 +141,19 @@ default_smtp_no_auth=
 
 ; Settings Storage
 ; ----------------
-; Cypht supports 2 methods for saving user settings between logins. File based
-; settings or in a database table. To store settings in a database, it must be
-; configured in the "DB Support" section and the hm_user_settings table must be
-; created. To store settings on the filesystem, the user_settings_dir must be
-; created and the webserver software must be able to write to it.
+; Cypht supports 3 methods for saving user settings between logins. File based
+; settings, database table or custom implementation. To store settings in a
+; database, it must be configured in the "DB Support" section and the
+; hm_user_settings table must be created. To store settings on the filesystem,
+; the user_settings_dir must be created and the webserver software must be able
+; to write to it. For custom implementations, see Hm_User_Config_File.
 ; 
 ; Valid values for this setting:
 ;
 ;  file    Store user settings in the filesystem
 ;  DB      Store user settings in a database
+;  custom  Store user settings via custom implementation. Specify class name
+;          after colon, e.g. custom:Custom_User_Config
 ;
 user_config_type=file
 

--- a/lib/config.php
+++ b/lib/config.php
@@ -484,11 +484,22 @@ class Hm_Site_Config_File extends Hm_Config {
  */
 function load_user_config_object($config) {
     $type = $config->get('user_config_type', 'file');
+    if (strstr($type, ':')) {
+        list($type, $class) = explode(':', $type);
+    }
     switch ($type) {
         case 'DB':
             $user_config = new Hm_User_Config_DB($config);
             Hm_Debug::add("Using DB user configuration");
             break;
+        case 'custom':
+            if (class_exists($class)) {
+                $user_config = new $class($config);
+                Hm_Debug::add("Using custom user configuration: $class");
+                break;
+            } else {
+                Hm_Debug::add("User configuration class does not exist: $class");
+            }
         default:
             $user_config = new Hm_User_Config_File($config);
             Hm_Debug::add("Using file based user configuration");

--- a/tests/phpunit/config.php
+++ b/tests/phpunit/config.php
@@ -306,6 +306,8 @@ class Hm_Test_User_Config_Functions extends PHPUnit_Framework_TestCase {
         $this->assertEquals('Hm_User_Config_File', get_class(load_user_config_object($mock_config)));
         $mock_config->set('user_config_type', 'DB');
         $this->assertEquals('Hm_User_Config_DB', get_class(load_user_config_object($mock_config)));
+        $mock_config->set('user_config_type', 'custom:Hm_Mock_Config');
+        $this->assertEquals('Hm_Mock_Config', get_class(load_user_config_object($mock_config)));
     }
     /**
      * @preserveGlobalState disabled


### PR DESCRIPTION
We needed a way to store user configuration inside Tiki database as user preferences as we already control authentication using Tiki. Saving to a separate table using DB method did not accomplish what we needed as we didn't go through the normal authentication login form (to trigger initial configuration load) and we also didn't use save settings page. Basically, I needed a way to override `load_user_config_object` function but there was no easy way to do it. I added another configuration option for custom implementation of the user configuration persistence class. Also extended the unit test for that function. Hope all this makes sense!