### PR TITLE
fix compose page handler module precedence

### DIFF
--- a/modules/profiles/setup.php
+++ b/modules/profiles/setup.php
@@ -18,7 +18,7 @@ add_output('profiles', 'profile_content', true, 'profiles', 'profile_edit_form',
 add_output('ajax_hm_folders', 'profile_page_link', true, 'profiles', 'settings_menu_end', 'before');
 add_output('compose', 'compose_signature_button', true, 'profiles', 'compose_form_end', 'before');
 add_output('compose', 'compose_signature_values', true, 'profiles', 'compose_form_start', 'before');
-add_handler('compose', 'compose_profile_data', true, 'profiles', 'load_user_data', 'after');
+add_handler('compose', 'compose_profile_data', true, 'profiles', 'load_smtp_servers_from_config', 'after');
 
 return array(
     'allowed_pages' => array(


### PR DESCRIPTION
This is a minor fix for the following bug:
- profiles page had the smtp module load_smtp_servers_from_config function executed before profile_data which correctly loaded the smtp server list from config
- compose page was executing load_smtp_servers_from_config after compose_profile_data and thus defined servers in config did not correctly auto-created the default profile when we had exactly one smtp and imap server

Both pages defined the relevant modules to be executed after load_user_data, however alphabetic sort of the names or something else prevented compose page to get the right order.
I merely changed compose_profile_data load requirement to be after load_smtp_servers_from_config as it depends on it to function correctly.