### PR TITLE
show alert when trying to sign message without existing profile

### DIFF
--- a/modules/profiles/site.js
+++ b/modules/profiles/site.js
@@ -12,6 +12,8 @@ if (hm_page_name() == 'compose') {
                 ta = $('#compose_body');
                 insert_sig(ta[0], profile_signatures[server_id]);
             }
+        } else {
+            Hm_Notices.show(['ERRYou need at least one configured profile to sign messages']);
         }
     });
 }


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->

When composing a message under the message textarea there are "Sign" button which as purpose to add signature to a message but, the button isn't self explanatore. So to add some explanation when the button is clicked instead of showing nothing to showcase some interaction of the button. I add an alert which tell the user what to do before that feature to be avalable.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] compose a new message without defining any profile in cypht. And under the message textarea click on the sign button.

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
