### PR TITLE
Add alert when attaching a file which size exceeded uploadable file size on server 

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -104,16 +104,24 @@ class Hm_Handler_smtp_attach_file extends Hm_Handler_Module {
             return;
         }
         if (!is_readable($file['tmp_name'])) {
+            if($file['error'] == 1) {
+                $upload_max_filesize = ini_get('upload_max_filesize');
+                Hm_Msgs::add('ERRYour upload failed because you reached the limit of ' . $upload_max_filesize . '.');    
+                return;
+            }
             Hm_Msgs::add('ERRAn error occurred saving the uploaded file.');
             return;
         }
+
         $content = file_get_contents($file['tmp_name']);
         if (!$content) {
             Hm_Msgs::add('ERRAn error occurred reading the uploaded file.');
             return;
         }
+
         if (!attach_file($content, $file, $filepath, $draft_id, $this)) {
             Hm_Msgs::add('ERRAn error occurred attaching the uploaded file.');
+            return;
         }
     }
 }


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->
Add an alert which warn the user when he try to attach a file which size exceed the pre configured value of upload_max_filesize.
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] Check the value of upload_max_filesize in the php.ini configuration file
- [X] Compose a new message and attach file which size exceed the value of upload_max_filesize

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
