### PR TITLE
[Privacy] Don't send referrer information when clicking links

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -324,6 +324,7 @@ class Hm_Output_header_start extends Hm_Output_Module {
         $class = $dir."_page";
         return '<!DOCTYPE html><html dir="'.$this->html_safe($dir).'" class="'.
             $this->html_safe($class).'" lang='.$this->html_safe($lang).'><head>'.
+            '<meta name="referrer" content="no-referrer" />'.
             '<meta name="apple-mobile-web-app-capable" content="yes" />'.
             '<meta name="mobile-web-app-capable" content="yes" />'.
             '<meta name="apple-mobile-web-app-status-bar-style" content="black" />'.

--- a/tests/phpunit/modules/core/modules.php
+++ b/tests/phpunit/modules/core/modules.php
@@ -741,7 +741,7 @@ class Hm_Test_Core_Output_Modules extends PHPUnit_Framework_TestCase {
     public function test_header_start() {
         $test = new Output_Test('header_start', 'core');
         $res = $test->run();
-        $this->assertEquals(array('<!DOCTYPE html><html dir="ltr" class="ltr_page" lang=en><head><meta name="apple-mobile-web-app-capable" content="yes" /><meta name="mobile-web-app-capable" content="yes" /><meta name="apple-mobile-web-app-status-bar-style" content="black" /><meta name="theme-color" content="#888888" /><meta charset="utf-8" />'), $res->output_response);
+        $this->assertEquals(array('<!DOCTYPE html><html dir="ltr" class="ltr_page" lang=en><head><meta name="referrer" content="no-referrer" /><meta name="apple-mobile-web-app-capable" content="yes" /><meta name="mobile-web-app-capable" content="yes" /><meta name="apple-mobile-web-app-status-bar-style" content="black" /><meta name="theme-color" content="#888888" /><meta charset="utf-8" />'), $res->output_response);
     }
     /**
      * @preserveGlobalState disabled


### PR DESCRIPTION
## Pullrequest
This PR adds a meta tag to pages that prevents referrer information from being transmitted in HTTP request headers when you click links, such as links in emails. Sending that information to external sites unnecessarily exposes the full URL of the cypht page you were on, which includes your cypht instance domain/address, message ID, and other IDs which might be usable for unknown nefarious purposes. The URL often looks something like this: `https://cypht.example.com/?page=message&uid=12345&list_path=imap_0_1234567890&list_parent=imap_0_1234567890&list_page=1`