### PR TITLE
Replace loading gradient icon with spinner

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -1399,7 +1399,7 @@ class Hm_Output_content_section_start extends Hm_Output_Module {
      * Opens a main tag for the primary content section
      */
     protected function output() {
-        return '<main class="content_cell"><div class="offline">'.$this->trans('Offline').'</div>';
+        return '<main class="content_cell"><div class="main_content_overlay"></div><div class="offline">'.$this->trans('Offline').'</div>';
     }
 }
 

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -256,3 +256,54 @@ div.unseen, .unseen .subject { font-weight: 700; }
 @media print {
     .sys_messages, .next, .prev, .folder_list, .msg_parts, .header_links, .content_title, .add_contact_row, .unsaved_icon, .add_vcal { display: none !important; }
 }
+
+
+/*! bulma.io v0.8.0 | MIT License | github.com/jgthms/bulma */@-webkit-keyframes spinAround {
+ from {
+  transform:rotate(0)
+ }
+ to {
+  transform:rotate(359deg)
+ }
+}
+@keyframes spinAround {
+ from {
+  transform:rotate(0)
+ }
+ to {
+  transform:rotate(359deg)
+ }
+}
+
+
+.main_content_overlay {
+	display: none;
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	background: rgba(0,0,0,0.7);
+	z-index: 999999;
+}
+
+.main_content_overlay::after {
+	-webkit-animation: spinAround .5s infinite linear;
+	animation: spinAround .5s infinite linear;
+	border: 2px solid #dbdbdb;
+	border-top-color: rgb(219, 219, 219);
+	border-right-color: rgb(219, 219, 219);
+	border-bottom-color: rgb(219, 219, 219);
+	border-left-color: rgb(219, 219, 219);
+	border-radius: 290486px;
+	border-right-color: transparent;
+	border-top-color: transparent;
+	content: "";
+	display: block;
+	height: 2em;
+	position: relative;
+	width: 2em;
+	position: absolute;
+	left: calc(50vw - (1em / 2));
+	top: calc(50vh - (1em / 2));
+	position: absolute !important;
+}
+

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -113,6 +113,11 @@ var Hm_Ajax = {
         }
         var hm_loading_pos = $('.loading_icon').width()/40;
         $('.loading_icon').show();
+        $('.main_content_overlay').show();
+        $('.main_content_overlay').on('click', function() {
+            Hm_Ajax.stop_loading_icon();
+        });
+
         function move_background_image() {
             hm_loading_pos = hm_loading_pos + 50;
             $('.loading_icon').css('background-position', hm_loading_pos+'px 0');
@@ -124,6 +129,7 @@ var Hm_Ajax = {
     stop_loading_icon : function(loading_id) {
         clearTimeout(loading_id);
         $('.loading_icon').hide();
+        $('.main_content_overlay').hide();
         Hm_Ajax.icon_loading_id = false;
     },
 


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->
To replace the loading gradient which appear each time cypht performs some background action to load message. I made some update to integrate a spinner which will more visible than the loading gradient

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] Configure a mail server
- [X] Open an inbox and the spinner will appear

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
