### PR TITLE
Fix user reply to all

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -156,9 +156,9 @@ function format_reply_address($fld, $excluded, $delivered_to) {
             }
         }
         if (!$skip) {
-			if ($v['email'] != $delivered_to) {
-				$res[] = $v;
-			}
+            if ($v['email'] != $delivered_to) {
+                $res[] = $v;
+            }
         }
     }
     if ($res) {

--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -105,7 +105,7 @@ function reply_to_address($headers, $type) {
     $msg_to = '';
     $msg_cc = '';
     $headers = lc_headers($headers);
-	$delivered_to = $headers['delivered-to'];
+    $delivered_to = $headers['delivered-to'];
     if ($type == 'forward') {
         return $msg_to;
     }

--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -156,9 +156,9 @@ function format_reply_address($fld, $excluded, $delivered_to) {
             }
         }
         if (!$skip) {
-            if ($v['email'] != $delivered_to) {
-                $res[] = $v;
-            }
+			if ($v['email'] != $delivered_to) {
+				$res[] = $v;
+			}
         }
     }
     if ($res) {

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -209,13 +209,12 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
                 $txt .= format_list_headers($this);
             }
 
-			$cc = false;
-			if (array_key_exists('cc', lc_headers($headers))) {
-				$cc = true;
-			}
-
-			$to = explode(', ',$headers['To']);
-			$to_size = sizeof($to);
+            $cc = false;
+            if (array_key_exists('cc', lc_headers($headers))) {
+                $cc = true;
+            } 
+            $to = explode(', ', $headers['To']);
+            $to_size = sizeof($to);
 
             $txt .= '<tr><td class="header_space" colspan="2"></td></tr>';
             $txt .= '<tr><th colspan="2" class="header_links">';
@@ -223,10 +222,10 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
                 '<a href="#" class="hlink all_headers">'.$this->trans('All headers').'</a>'.
                 '<a class="hlink small_headers" style="display: none;" href="#">'.$this->trans('Small headers').'</a>'.
                 ' | <a class="reply_link hlink" href="?page=compose&amp;reply=1'.$reply_args.'">'.$this->trans('Reply').'</a>';
-				if ($cc || $to_size > 1) {
-					$txt .= ' | <a class="reply_all_link hlink" href="?page=compose&amp;reply_all=1'.$reply_args.'">'.$this->trans('Reply-all').'</a>';
-				}
-			$txt .= ' | <a class="forward_link hlink" href="?page=compose&amp;forward=1'.$reply_args.'">'.$this->trans('Forward').'</a>';
+                if ($cc || $to_size > 1) {
+                    $txt .= ' | <a class="reply_all_link hlink" href="?page=compose&amp;reply_all=1'.$reply_args.'">'.$this->trans('Reply-all').'</a>';
+                }
+            $txt .= ' | <a class="forward_link hlink" href="?page=compose&amp;forward=1'.$reply_args.'">'.$this->trans('Forward').'</a>';
             if ($msg_part === '0') {
                 $txt .= ' | <a class="normal_link hlink msg_part_link normal_link" data-message-part="" href="#">'.$this->trans('normal').'</a>';
             }

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -208,14 +208,25 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
             if ($this->get('list_headers')) {
                 $txt .= format_list_headers($this);
             }
+
+			$cc = false;
+			if (array_key_exists('cc', lc_headers($headers))) {
+				$cc = true;
+			}
+
+			$to = explode(', ',$headers['To']);
+			$to_size = sizeof($to);
+
             $txt .= '<tr><td class="header_space" colspan="2"></td></tr>';
             $txt .= '<tr><th colspan="2" class="header_links">';
             $txt .= '<div class="msg_move_to">'.
                 '<a href="#" class="hlink all_headers">'.$this->trans('All headers').'</a>'.
                 '<a class="hlink small_headers" style="display: none;" href="#">'.$this->trans('Small headers').'</a>'.
-                ' | <a class="reply_link hlink" href="?page=compose&amp;reply=1'.$reply_args.'">'.$this->trans('Reply').'</a>'.
-                ' | <a class="reply_all_link hlink" href="?page=compose&amp;reply_all=1'.$reply_args.'">'.$this->trans('Reply-all').'</a>'.
-                ' | <a class="forward_link hlink" href="?page=compose&amp;forward=1'.$reply_args.'">'.$this->trans('Forward').'</a>';
+                ' | <a class="reply_link hlink" href="?page=compose&amp;reply=1'.$reply_args.'">'.$this->trans('Reply').'</a>';
+				if ($cc || $to_size > 1) {
+					$txt .= ' | <a class="reply_all_link hlink" href="?page=compose&amp;reply_all=1'.$reply_args.'">'.$this->trans('Reply-all').'</a>';
+				}
+			$txt .= ' | <a class="forward_link hlink" href="?page=compose&amp;forward=1'.$reply_args.'">'.$this->trans('Forward').'</a>';
             if ($msg_part === '0') {
                 $txt .= ' | <a class="normal_link hlink msg_part_link normal_link" data-message-part="" href="#">'.$this->trans('normal').'</a>';
             }

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -216,10 +216,6 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
 
 			$to = explode(', ',$headers['To']);
 			$to_size = sizeof($to);
-            $cc = false;
-            if (array_key_exists('cc', lc_headers($headers))) {
-                $cc = true;
-            }
 
             $txt .= '<tr><td class="header_space" colspan="2"></td></tr>';
             $txt .= '<tr><th colspan="2" class="header_links">';

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -216,6 +216,10 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
 
 			$to = explode(', ',$headers['To']);
 			$to_size = sizeof($to);
+            $cc = false;
+            if (array_key_exists('cc', lc_headers($headers))) {
+                $cc = true;
+            }
 
             $txt .= '<tr><td class="header_space" colspan="2"></td></tr>';
             $txt .= '<tr><th colspan="2" class="header_links">';


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->
Remove the REPLY-ALL link when the message comes from a single sender or when the TO and/or CC option has only one email address. By clicking on the REPLY-ALL button, the user's email must not appear in the list of recipients.
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
- [ ] Configure a mail server
- [ ] Open an inbox ( View a message )
- [ ] Click on the REPLY-ALL link and the sender's email will no longer appear in the list of recipients.


### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
