### PR TITLE
prevent last recipient from disappearing

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -251,12 +251,9 @@ function process_address_fld($fld) {
         }
         if (!$email) {
             foreach ($vals as $i => $v) {
-                $v = trim($v, '<>\'"');
-                if (is_email_address($v)) {
-                    $email = trim($v, '<>\'"');
-                    $email_pos = $i;
-                    break;
-                }
+                $email = trim($v, '<>\'"');
+                $email_pos = $i;
+                break;
             }
         }
         if ($email) {
@@ -269,7 +266,14 @@ function process_address_fld($fld) {
                     $parts['comment'] = $v;
                 }
                 else {
-                    $label[] = $v;
+                    $v = trim($v);
+                    if (is_email_address($v)) {
+                        $email = trim($v, '<>\'"');
+                        $parts['email'] = $email;
+                    } else {
+                        $label[] = $v;
+                    }
+                    
                 }
             }
             $parts['label'] = str_replace(array('"', "'"), '', implode(' ', $label));


### PR DESCRIPTION
## Pullrequest
When we click on REPLY-ALL, all recipients at **To** should remain on the mailing list.

### Issues
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
- [ ] Configure a mail server
- [ ] Open an inbox ( View a message )
- [ ] Click on the REPLY-ALL link and and there, on the page for sending a new email, all recipients should be in the mailing list.
