### PR TITLE
add WEB_ROOT constant to allow theme and static asset files loaded fr…

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,6 +14,7 @@
  */
 define('APP_PATH', '');
 define('VENDOR_PATH', APP_PATH.'vendor/');
+define('WEB_ROOT', '');
 define('DEBUG_MODE', true);
 define('CACHE_ID', '');
 define('SITE_ID', '');

--- a/modules/api_login/api.php
+++ b/modules/api_login/api.php
@@ -8,6 +8,8 @@
 /* Constants */
 define('DEBUG_MODE', false);
 define('APP_PATH', dirname(dirname(dirname(__FILE__))).'/');
+define('VENDOR_PATH', APP_PATH.'vendor/');
+define('WEB_ROOT', '');
 define('CONFIG_FILE', APP_PATH.'hm3.rc');
 
 /* Init the framework */

--- a/modules/pgp/modules.php
+++ b/modules/pgp/modules.php
@@ -107,7 +107,7 @@ class Hm_Output_pgp_compose_controls extends Hm_Output_Module {
             return;
         }
         $pub_keys = $this->get('pgp_public_keys', array());
-        $res = '<script type="text/javascript" src="modules/pgp/assets/openpgp.min.js"></script>';
+        $res = '<script type="text/javascript" src="'.WEB_ROOT.'modules/pgp/assets/openpgp.min.js"></script>';
         $res .= '<div class="pgp_section">';
 
         $res .= '<span class="pgp_sign"><label for="pgp_sign">'.$this->trans('PGP Sign as').'</label>';
@@ -132,7 +132,7 @@ class Hm_Output_pgp_compose_controls extends Hm_Output_Module {
 class Hm_Output_pgp_settings_start extends Hm_Output_Module {
     protected function output() {
         $res = '<div class="pgp_settings"><div class="content_title">'.$this->trans('PGP Settings').'</div>';
-        $res .= '<script type="text/javascript" src="modules/pgp/assets/openpgp.min.js"></script>';
+        $res .= '<script type="text/javascript" src="'.WEB_ROOT.'modules/pgp/assets/openpgp.min.js"></script>';
         return $res;
     }
 }
@@ -199,7 +199,7 @@ class Hm_Output_pgp_settings_end extends Hm_Output_Module {
  */
 class Hm_Output_pgp_msg_controls extends Hm_Output_Module {
     protected function output() {
-        return '<script type="text/javascript" src="modules/pgp/assets/openpgp.min.js"></script>'.
+        return '<script type="text/javascript" src="'.WEB_ROOT.'modules/pgp/assets/openpgp.min.js"></script>'.
         '<div class="pgp_msg_controls"><select class="pgp_private_keys"></select> <input type="button" class="pgp_btn" value="Decrypt" /></div>'.prompt_for_passhrase($this);
     }
 }

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -652,8 +652,8 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
         }
         $res = '';
         if ($html == 1) {
-            $res .= '<script type="text/javascript" src="modules/smtp/assets/kindeditor/kindeditor-all-min.js"></script>'.
-                '<link href="modules/smtp/assets/kindeditor/themes/default/default.css" rel="stylesheet" />'.
+            $res .= '<script type="text/javascript" src="'.WEB_ROOT.'modules/smtp/assets/kindeditor/kindeditor-all-min.js"></script>'.
+                '<link href="'.WEB_ROOT.'modules/smtp/assets/kindeditor/themes/default/default.css" rel="stylesheet" />'.
                 '<script type="text/javascript">KindEditor.ready(function(K) { K.create("#compose_body", {items:'.
                 "['formatblock', 'fontname', 'fontsize', 'forecolor', 'hilitecolor', 'bold',".
                 "'italic', 'underline', 'strikethrough', 'lineheight', 'table', 'hr', 'pagebreak', 'link', 'unlink',".
@@ -661,7 +661,7 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
                 "'justifyfull', 'insertorderedlist', 'insertunorderedlist', 'indent', 'outdent', '|',".
                 "'undo', 'redo', 'preview', 'print', '|', 'selectall', 'cut', 'copy', 'paste',".
                 "'plainpaste', 'wordpaste', '|', 'source', 'fullscreen']".
-                ",basePath: 'modules/smtp/assets/kindeditor/'".
+                ",basePath: '".WEB_ROOT."modules/smtp/assets/kindeditor/'".
                 '})});;</script>';
         }
         $res .= '<input type="hidden" name="hm_page_key" value="'.$this->html_safe(Hm_Request_Key::generate()).'" />'.
@@ -681,9 +681,9 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
             $this->trans('Subject').'" /><textarea id="compose_body" name="compose_body" class="compose_body">'.
             $this->html_safe($body).'</textarea>';
         if ($html == 2) {
-            $res .= '<link href="modules/smtp/assets/markdown/editor.css" rel="stylesheet" />'.
-                '<script type="text/javascript" src="modules/smtp/assets/markdown/editor.js"></script>'.
-                '<script type="text/javascript" src="modules/smtp/assets/markdown/marked.js"></script>'.
+            $res .= '<link href="'.WEB_ROOT.'modules/smtp/assets/markdown/editor.css" rel="stylesheet" />'.
+                '<script type="text/javascript" src="'.WEB_ROOT.'modules/smtp/assets/markdown/editor.js"></script>'.
+                '<script type="text/javascript" src="'.WEB_ROOT.'modules/smtp/assets/markdown/marked.js"></script>'.
                 '<script type="text/javascript">var editor = new Editor(); editor.render();</script>';
         }
         $res .= '<table class="uploaded_files">';

--- a/modules/themes/modules.php
+++ b/modules/themes/modules.php
@@ -62,7 +62,7 @@ class Hm_Output_theme_css extends Hm_Output_Module {
      */
     protected function output() {
         if ($this->get('theme') && in_array($this->get('theme'), array_keys($this->get('themes', array())), true) && $this->get('theme') != 'default') {
-            return '<link href="modules/themes/assets/'.$this->html_safe($this->get('theme')).'.css?v='.CACHE_ID.'" media="all" rel="stylesheet" type="text/css" />';
+            return '<link href="'.WEB_ROOT.'modules/themes/assets/'.$this->html_safe($this->get('theme')).'.css?v='.CACHE_ID.'" media="all" rel="stylesheet" type="text/css" />';
         }
     }
 }

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -14,6 +14,7 @@ define('DEBUG_MODE', false);
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('VENDOR_PATH', APP_PATH.'vendor/');
+define('WEB_ROOT', '');
 chdir(APP_PATH);
 
 /* get the framework */

--- a/scripts/create_account.php
+++ b/scripts/create_account.php
@@ -21,6 +21,7 @@ define('DEBUG_MODE', false);
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('VENDOR_PATH', APP_PATH.'vendor/');
+define('WEB_ROOT', '');
 
 /* get the framework */
 require APP_PATH.'lib/framework.php';

--- a/scripts/create_config.php
+++ b/scripts/create_config.php
@@ -9,6 +9,7 @@ define('DEBUG_MODE', false);
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('VENDOR_PATH', APP_PATH.'vendor/');
+define('WEB_ROOT', '');
 
 /* get the framework */
 require APP_PATH.'lib/framework.php';

--- a/scripts/delete_account.php
+++ b/scripts/delete_account.php
@@ -20,6 +20,7 @@ define('DEBUG_MODE', false);
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('VENDOR_PATH', APP_PATH.'vendor/');
+define('WEB_ROOT', '');
 
 /* get the framework */
 require APP_PATH.'lib/framework.php';

--- a/scripts/update_password.php
+++ b/scripts/update_password.php
@@ -21,6 +21,7 @@ define('DEBUG_MODE', false);
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('VENDOR_PATH', APP_PATH.'vendor/');
+define('WEB_ROOT', '');
 
 /* get the framework */
 require APP_PATH.'lib/framework.php';

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -11,6 +11,7 @@ if (!defined('DEBUG_MODE')) {
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(dirname(__FILE__))).'/');
 define('VENDOR_PATH', APP_PATH.'vendor/');
+define('WEB_ROOT', '');
 
 /* random id */
 define('SITE_ID', 'randomid');


### PR DESCRIPTION
…om a different web root URL

Hey Jason,

Just realized that static assets from smtp module were not properly integrated into Tiki as we serve cypht from a different URL than the site/ one you assume as the default URL. I had to add an empty WEB_ROOT constant and prepend all those <link> and <script> tag urls. By default, it stays empty, so previous behavior stays intact. For us with Tiki, I override it to point to the proper vendor place where cypht resides.

Let me know if you see any issues with that!

Not sure we need it for all scripts/*.php files but added there just in case. Also spotted a missing VENDOR_PATH in the api and added that as well.

Btw, running unit tests with phpunit 5 and 6 fails for different reasons. Which version of phpunit do you use to run tests?