### PR TITLE
make actions copy and move available on mobile devices

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -531,7 +531,7 @@ class Hm_Output_filter_expanded_folder_data extends Hm_Output_Module {
  */
 class Hm_Output_move_copy_controls extends Hm_Output_Module {
     protected function output() {
-        if (!$this->get('is_mobile') && $this->get('move_copy_controls', false)) {
+        if ($this->get('move_copy_controls', false)) {
             $res = '<span class="ctr_divider"></span> <a class="imap_move disabled_input" href="#" data-action="copy">'.$this->trans('Copy').'</a>';
             $res .= '<a class="imap_move disabled_input" href="#" data-action="move">'.$this->trans('Move').'</a>';
             $res .= '<div class="move_to_location"></div>';


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->
When select message in on the page message_list, copy and move action are not available as It's on wide screen, I made update to remove code which check if the page is viewed on mobile device to not render copy and move actions.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] Open cypht on a mobile device browse to any mailbox and select one or multiple message
- [X] You'll notice the presence of copy and move buttons in the action list

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
