### PR TITLE
make sure to exclude delivered to address from reply-all link

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -105,18 +105,22 @@ function reply_to_address($headers, $type) {
     $msg_cc = '';
     $headers = lc_headers($headers);
     $parsed = array();
+    $delivered_address = array('email' => $headers['delivered-to'], 
+        'comment' => '', 'label' => '');
+
     if ($type == 'forward') {
         return $msg_to;
     }
     foreach (array('reply-to', 'from', 'sender', 'return-path') as $fld) {
         if (array_key_exists($fld, $headers)) { 
-            list($parsed, $msg_to) = format_reply_address($headers[$fld], array());
+            list($parsed, $msg_to) = format_reply_address($headers[$fld], $parsed);
             if ($msg_to) {
                 break;
             }
         }
     }
     if ($type == 'reply_all') {
+        $parsed[] = $delivered_address;
         if (array_key_exists('cc', $headers)) {
             list($cc_parsed, $msg_cc) = format_reply_address($headers['cc'], $parsed);
             $parsed += $cc_parsed;


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->
By clicking on the REPLY-ALL link, the user's email must not appear in the list of recipients.
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [x] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
- [ ] Configure a mail server
- [ ] Open an inbox ( View a message )
- [ ] Click on the REPLY-ALL link and the sender's email will no longer appear in the list of recipients.


### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None