### PR TITLE
add default sort order for imap folders - arrival or sent date

### DIFF
--- a/modules/core/functions.php
+++ b/modules/core/functions.php
@@ -517,6 +517,18 @@ function start_page_opts() {
 }}
 
 /**
+ * List of valid default sort order options
+ * @return array
+ */
+if (!hm_exists('default_sort_order_opts')) {
+function default_sort_order_opts() {
+    return array(
+        'arrival' => 'Arrival Date',
+        'date' => 'Sent Date',
+    );
+}}
+
+/**
  * See if a host + username is already in a server list
  * @param class $list class to check
  * @param int $id server id to get hostname from

--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -243,6 +243,25 @@ class Hm_Handler_process_start_page_setting extends Hm_Handler_Module {
 }
 
 /**
+ * Process input from the the default sort order setting in the general settings section.
+ * @subpackage core/handler
+ */
+class Hm_Handler_process_default_sort_order_setting extends Hm_Handler_Module {
+    /**
+     * Can be one of the values in start_page_opts()
+     */
+    public function process() {
+        function default_sort_order_callback($val) {
+            if (in_array($val, array_keys(default_sort_order_opts()), true)) {
+                return $val;
+            }
+            return false;
+        }
+        process_site_setting('default_sort_order', $this, 'default_sort_order_callback');
+    }
+}
+
+/**
  * Process "hide folder list icons" setting 
  * @subpackage core/handler
  */

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -606,6 +606,39 @@ class Hm_Output_start_page_setting extends Hm_Output_Module {
 }
 
 /**
+ * Outputs the default sort order option on the settings page
+ * @subpackage core/output
+ */
+class Hm_Output_default_sort_order_setting extends Hm_Output_Module {
+    /**
+     * Can be any of the main combined pages
+     */
+    protected function output() {
+        $options = default_sort_order_opts();
+        $settings = $this->get('user_settings', array());
+
+        if (array_key_exists('default_sort_order', $settings)) {
+            $default_sort_order = $settings['default_sort_order'];
+        }
+        else {
+            $default_sort_order = null;
+        }
+        $res = '<tr class="general_setting"><td><label for="default_sort_order">'.
+            $this->trans('Default message sort order').'</label></td>'.
+            '<td><select id="start_page" name="default_sort_order">';
+        foreach ($options as $val => $label) {
+            $res .= '<option ';
+            if ($default_sort_order == $val) {
+                $res .= 'selected="selected" ';
+            }
+            $res .= 'value="'.$val.'">'.$this->trans($label).'</option>';
+        }
+        $res .= '</select></td></tr>';
+        return $res;
+    }
+}
+
+/**
  * Outputs the list style option on the settings page
  * @subpackage core/output
  */

--- a/modules/core/setup.php
+++ b/modules/core/setup.php
@@ -48,6 +48,7 @@ add_handler('settings', 'process_hide_folder_icons', true, 'core', 'date', 'afte
 add_handler('settings', 'process_delete_prompt_setting', true, 'core', 'date', 'after');
 add_handler('settings', 'process_no_password_setting', true, 'core', 'date', 'after');
 add_handler('settings', 'process_start_page_setting', true, 'core', 'date', 'after');
+add_handler('settings', 'process_default_sort_order_setting', true, 'core', 'date', 'after');
 add_handler('settings', 'process_mailto_handler_setting', true, 'core', 'date', 'after');
 add_handler('settings', 'process_show_list_icons', true, 'core', 'date', 'after');
 add_handler('settings', 'save_user_settings', true, 'core', 'save_user_data', 'before');
@@ -64,7 +65,8 @@ add_output('settings', 'msg_list_icons_setting', true, 'core', 'list_style_setti
 add_output('settings', 'delete_prompt_setting', true, 'core', 'list_style_setting', 'after');
 add_output('settings', 'no_password_setting', true, 'core', 'delete_prompt_setting', 'after');
 add_output('settings', 'start_page_setting', true, 'core', 'no_password_setting', 'after');
-add_output('settings', 'start_unread_settings', true, 'core', 'start_page_setting', 'after');
+add_output('settings', 'default_sort_order_setting', true, 'core', 'start_page_setting', 'after');
+add_output('settings', 'start_unread_settings', true, 'core', 'default_sort_order_setting', 'after');
 add_output('settings', 'unread_since_setting', true, 'core', 'start_unread_settings', 'after');
 add_output('settings', 'unread_source_max_setting', true, 'core', 'unread_since_setting', 'after');
 add_output('settings', 'start_flagged_settings', true, 'core', 'unread_source_max_setting', 'after');
@@ -256,6 +258,7 @@ return array(
         'message_list_since' => FILTER_SANITIZE_STRING,
         'no_password_save' => FILTER_VALIDATE_BOOLEAN,
         'start_page' => FILTER_SANITIZE_STRING,
+        'default_sort_order' => FILTER_SANITIZE_STRING,
         'stay_logged_in' => FILTER_VALIDATE_BOOLEAN
     )
 );

--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -202,8 +202,13 @@ function format_imap_message_list($msg_list, $output_module, $parent_list=false,
             $from = '[No From]';
             $nofrom = ' nofrom';
         }
-        $timestamp = strtotime($msg['internal_date']);
-        $date = translate_time_str(human_readable_interval($msg['internal_date']), $output_module);
+        if ($list_sort == 'date') {
+            $date_field = 'date';
+        } else {
+            $date_field = 'internal_date';
+        }
+        $timestamp = strtotime($msg[$date_field]);
+        $date = translate_time_str(human_readable_interval($msg[$date_field]), $output_module);
         $flags = array();
         if (!stristr($msg['flags'], 'seen')) {
             $flags[] = 'unseen';
@@ -908,9 +913,10 @@ function imap_authed($imap) {
  * @subpackage imap/functions
  */
 if (!hm_exists('process_sort_arg')) {
-function process_sort_arg($sort) {
+function process_sort_arg($sort, $default = 'arrival') {
     if (!$sort) {
-        return array('ARRIVAL', true);
+        $default = strtoupper($default);
+        return array($default, true);
     }
     $rev = false;
     if (substr($sort, 0, 1) == '-') {

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -441,6 +441,19 @@ class Hm_Handler_imap_download_message extends Hm_Handler_Module {
 }
 
 /**
+ * Check the default sort order
+ * @subpackage core/handler
+ */
+class Hm_Handler_default_sort_order_setting extends Hm_Handler_Module {
+    /***
+     * retrieve default sort order of messages
+     */
+    public function process() {
+        $this->out('default_sort_order', $this->user_config->get('default_sort_order_setting', false));
+    }
+}
+
+/**
  * Process the list_path input argument
  * @subpackage imap/handler
  */
@@ -479,6 +492,8 @@ class Hm_Handler_imap_message_list_type extends Hm_Handler_Module {
                         'date', 'to', '-arrival', '-from', '-subject', '-date', '-to'), true)) {
                         $this->out('list_sort', $this->request->get['sort']);
                     }
+                } elseif ($default_sort_order = $this->user_config->get('default_sort_order_setting', false)) {
+                    $this->out('list_sort', $default_sort_order);
                 }
                 if (!empty($details)) {
                     if (array_key_exists('folder_label', $this->request->get)) {
@@ -568,7 +583,7 @@ class Hm_Handler_imap_folder_page extends Hm_Handler_Module {
             $filter = strtoupper($this->get('list_filter'));
         }
         $keyword = $this->get('list_keyword', '');
-        list($sort, $rev) = process_sort_arg($this->get('list_sort'));
+        list($sort, $rev) = process_sort_arg($this->get('list_sort'), $this->user_config->get('default_sort_order_setting', false));
         $limit = $this->user_config->get('imap_per_page_setting', DEFAULT_PER_SOURCE);
         $offset = 0;
         $msgs = array();

--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -1098,13 +1098,13 @@ class Hm_IMAP extends Hm_IMAP_Cache {
             return array();
         }
         if ($message_part == 1 || !$message_part) {
-            $command = "UID FETCH $uid (FLAGS BODY[HEADER])\r\n";
+            $command = "UID FETCH $uid (FLAGS INTERNALDATE BODY[HEADER])\r\n";
         }
         else {
             if (!$this->is_clean($message_part, 'msg_part')) {
                 return array();
             }
-            $command = "UID FETCH $uid (FLAGS BODY[$message_part.HEADER])\r\n";
+            $command = "UID FETCH $uid (FLAGS INTERNALDATE BODY[$message_part.HEADER])\r\n";
         }
         $cache_command = $command.(string)$raw;
         $cache = $this->check_cache($cache_command);
@@ -1116,6 +1116,7 @@ class Hm_IMAP extends Hm_IMAP_Cache {
         $status = $this->check_response($result, true);
         $headers = array();
         $flags = array();
+        $internal_date = '';
         if ($status) {
             foreach ($result as $vals) {
                 if ($vals[0] != '*') {
@@ -1123,7 +1124,13 @@ class Hm_IMAP extends Hm_IMAP_Cache {
                 }
                 $search = true;
                 $flag_search = false;
-                foreach ($vals as $v) {
+                for ($j = 0; $j < count($vals); $j++) {
+                    $v = $vals[$j];
+                    if (stristr(strtoupper($v), 'INTERNALDATE')) {
+                        $internal_date = $vals[$j+1];
+                        $j++;
+                        continue;
+                    }
                     if ($flag_search) {
                         if ($v == ')') {
                             $flag_search = false;
@@ -1167,6 +1174,9 @@ class Hm_IMAP extends Hm_IMAP_Cache {
             }
             if (!empty($flags)) {
                 $headers[] = array('Flags', implode(' ', $flags));
+            }
+            if (!empty($internal_date)) {
+                $headers[] = array('Arrival Date', $internal_date);
             }
         }
         $results = array();

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -26,8 +26,14 @@ class Hm_Output_imap_custom_controls extends Hm_Output_Module {
                 'unflagged' => $this->trans('Unflagged'), 'answered' => $this->trans('Answered'),
                 'unanswered' => $this->trans('Unanswered'));
 
-            $sorts = array('arrival' => $this->trans('Arrival Date'), 'from' => $this->trans('From'),
-                'to' => $this->trans('To'), 'subject' => $this->trans('Subject'), 'date' => $this->trans('Sent Date'));
+            $default_sort_order = $this->get('default_sort_order');
+            if ($default_sort_order == 'arrival') {
+                $sorts = array('arrival' => $this->trans('Arrival Date'), 'from' => $this->trans('From'),
+                    'to' => $this->trans('To'), 'subject' => $this->trans('Subject'), 'date' => $this->trans('Sent Date'));
+            } else {
+                $sorts = array('date' => $this->trans('Sent Date'), 'from' => $this->trans('From'),
+                    'to' => $this->trans('To'), 'subject' => $this->trans('Subject'), 'arrival' => $this->trans('Arrival Date'));
+            }
 
             if (!$this->get('is_mobile', false)) {
                 $custom = '<form id="imap_filter_form" method="GET">';

--- a/modules/imap/setup.php
+++ b/modules/imap/setup.php
@@ -57,6 +57,7 @@ add_handler('search', 'imap_message_list_type', true, 'imap', 'message_list_type
 
 /* message list pages */
 add_handler('message_list', 'imap_message_list_type', true, 'imap', 'message_list_type', 'after');
+add_handler('message_list', 'default_sort_order_setting', true, 'imap', 'imap_message_list_type', 'after');
 add_output('message_list', 'imap_custom_controls', true, 'imap', 'message_list_heading', 'before');
 add_output('message_list', 'move_copy_controls', true, 'imap', 'message_list_heading', 'before');
 

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -340,6 +340,12 @@ var cache_imap_page = function() {
     Hm_Utils.save_to_local_storage(key+'_page_links', $('.page_links').html());
 }
 
+var clear_imap_page_cache = function() {
+    var key = 'imap_'+Hm_Utils.get_url_page_number()+'_'+hm_list_path();
+    Hm_Utils.save_to_local_storage(key, '');
+    Hm_Utils.save_to_local_storage(key+'_page_links', '');
+}
+
 var fetch_cached_imap_page = function() {
     var key = 'imap_'+Hm_Utils.get_url_page_number()+'_'+hm_list_path();
     var page = Hm_Utils.get_from_local_storage(key);
@@ -384,7 +390,10 @@ var setup_imap_folder_page = function() {
         }
     });
     $('.imap_filter').on("change", function() { $('#imap_filter_form').submit(); });
-    $('.imap_sort').on("change", function() { $('#imap_filter_form').submit(); });
+    $('.imap_sort').on("change", function() {
+        clear_imap_page_cache();
+        $('#imap_filter_form').submit();
+    });
     $('.imap_keyword').on('search', function() {
         $('#imap_filter_form').submit();
     });


### PR DESCRIPTION
This PR actually tries to solve 3 issues coming from discussion: https://github.com/jasonmunro/cypht/issues/378

1. Add a site setting for default date sort order - up to now it defaults to arrival date but in some cases, the actual sent date (date from msg header) is preferred. Now it can be configured.

2. Show arrival date in extended headers. We were only showing date header which is a bit confusing when coming from message list where it lists the arrival date.

3. Fix sorting by sent date. Server correctly sorted messages and returned them in a formatted message list. However, there was one more sorting on the client side which used the timestamp of each row which came from the arrival date. Thus, sorting by sent date did not actually produce any different results - it was still sorting by arrival date. I have fixed this by actually changing the date column in the message list to display sent date when sorting by sent date. This requires clearing the imap page cache before reloading the form as the returned formatted message list is going to be different.

Let me know if you see any issues.