### PR TITLE
make copy/move buttons work in advanced search

### DIFF
--- a/modules/advanced_search/site.js
+++ b/modules/advanced_search/site.js
@@ -384,6 +384,9 @@ var send_requests = function(requests) {
                     $('.core_msg_control').off('click');
                     $('.core_msg_control').on("click", function() { return Hm_Message_List.message_action($(this).data('action')); });
                     Hm_Message_List.set_checkbox_callback();
+                    if (typeof check_select_for_imap !== 'undefined') {
+                        check_select_for_imap();
+                    }
                 }
                 Hm_Message_List.check_empty_list();
             },
@@ -541,6 +544,9 @@ $(function() {
             $('.core_msg_control').off('click');
             $('.core_msg_control').on("click", function() { return Hm_Message_List.message_action($(this).data('action')); });
             Hm_Message_List.set_checkbox_callback();
+            if (typeof check_select_for_imap !== 'undefined') {
+                check_select_for_imap();
+            }
         }
         Hm_Message_List.check_empty_list();
     }


### PR DESCRIPTION
In connection with 
https://github.com/jasonmunro/cypht/pull/374

Copy/Move buttons were missing their event handlers in advanced search. This PR should add those.
