### PR TITLE
fix default sort order label (Arrival vs Sent Date) throughout the codebase

### DIFF
--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -243,6 +243,19 @@ class Hm_Handler_process_start_page_setting extends Hm_Handler_Module {
 }
 
 /**
+ * Check the default sort order
+ * @subpackage core/handler
+ */
+class Hm_Handler_default_sort_order_setting extends Hm_Handler_Module {
+    /***
+     * retrieve default sort order of messages
+     */
+    public function process() {
+        $this->out('default_sort_order', $this->user_config->get('default_sort_order_setting', 'arrival'));
+    }
+}
+
+/**
  * Process input from the the default sort order setting in the general settings section.
  * @subpackage core/handler
  */

--- a/modules/core/setup.php
+++ b/modules/core/setup.php
@@ -82,12 +82,14 @@ add_output('settings', 'end_settings_form', true, 'core', 'content_section_end',
 
 /* message list page */
 setup_base_page('message_list');
+add_handler('message_list', 'default_sort_order_setting', true, 'core', 'load_user_data', 'after');
 add_output('message_list', 'message_list_heading', true, 'core', 'content_section_start', 'after');
 add_output('message_list', 'message_list_start', true, 'core', 'message_list_heading', 'after');
 add_output('message_list', 'message_list_end', true, 'core', 'message_list_start', 'after');
 
 /* search page */
 setup_base_page('search');
+add_handler('search', 'default_sort_order_setting', true, 'core', 'load_user_data', 'after');
 add_output('search', 'search_content_start', true, 'core', 'content_section_start', 'after');
 add_output('search', 'search_form_start', true, 'core', 'search_content_start', 'after');
 add_output('search', 'search_form_content', true, 'core', 'search_form_start', 'after');
@@ -98,6 +100,7 @@ add_output('search', 'search_content_end', true, 'core', 'search_results_table_e
 add_output('search', 'search_move_copy_controls', true, 'core', 'search_content_start', 'before');
 
 /* advanced search page */
+add_handler('advanced_search', 'default_sort_order_setting', true, 'core', 'load_user_data', 'after');
 add_output('advanced_search', 'search_move_copy_controls', true, 'core', 'advanced_search_content_start', 'before');
 
 /* reset search form */

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -441,19 +441,6 @@ class Hm_Handler_imap_download_message extends Hm_Handler_Module {
 }
 
 /**
- * Check the default sort order
- * @subpackage core/handler
- */
-class Hm_Handler_default_sort_order_setting extends Hm_Handler_Module {
-    /***
-     * retrieve default sort order of messages
-     */
-    public function process() {
-        $this->out('default_sort_order', $this->user_config->get('default_sort_order_setting', 'arrival'));
-    }
-}
-
-/**
  * Process the list_path input argument
  * @subpackage imap/handler
  */

--- a/modules/imap/setup.php
+++ b/modules/imap/setup.php
@@ -57,7 +57,6 @@ add_handler('search', 'imap_message_list_type', true, 'imap', 'message_list_type
 
 /* message list pages */
 add_handler('message_list', 'imap_message_list_type', true, 'imap', 'message_list_type', 'after');
-add_handler('message_list', 'default_sort_order_setting', true, 'imap', 'imap_message_list_type', 'after');
 add_output('message_list', 'imap_custom_controls', true, 'imap', 'message_list_heading', 'before');
 add_output('message_list', 'move_copy_controls', true, 'imap', 'message_list_heading', 'before');
 


### PR DESCRIPTION
We need to load the default sort order setting in several output modules and  thus I moved it out from imap module into the core module and loaded it where needed - search, advanced search, message list headings, etc. - all forms that contain the sort dropdown. This PR complements #418 and should be the final one to finish this update.