### PR TITLE
make copy/move buttons work everywhere :All Mails, simple search and …

### DIFF
--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -815,7 +815,14 @@ var imap_perform_move_copy = function(dest_id, context) {
                             window.location.href = nlink.attr('href');
                         }
                         else {
-                            window.location.href = "?page=message_list&list_path="+hm_list_parent();
+                            if(hm_page_name() == 'search'){
+                                window.location.reload();
+                            }
+                            else if(hm_page_name() == 'advanced_search'){
+                                process_advanced_search();
+                            }else{
+                                window.location.href = "?page=message_list&list_path="+hm_list_parent();
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Pullrequest
when picking emails in lists, Copy and Move should work everywhere: All Mails, simple search and advanced search.
https://github.com/jasonmunro/cypht/issues/371

There has been two related pull requests:
https://github.com/jasonmunro/cypht/pull/374
https://github.com/jasonmunro/cypht/pull/422



