### PR TITLE
use default sort order for search/advanced search pages

### DIFF
--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -173,7 +173,7 @@ function format_imap_message_list($msg_list, $output_module, $parent_list=false,
     }
     $show_icons = $output_module->get('msg_list_icons');
     $list_page = $output_module->get('list_page', 0);
-    $list_sort = $output_module->get('list_sort');
+    $list_sort = $output_module->get('list_sort', $output_module->get('default_sort_order'));
     $list_filter = $output_module->get('list_filter');
     foreach($msg_list as $msg) {
         $row_class = 'email';

--- a/modules/imap/setup.php
+++ b/modules/imap/setup.php
@@ -228,6 +228,7 @@ add_output('ajax_imap_folder_display', 'filter_folder_page', true);
 
 /* search results */
 setup_base_ajax_page('ajax_imap_search', 'core');
+add_handler('ajax_imap_search', 'default_sort_order_setting', true, 'core', 'load_user_data', 'after');
 add_handler('ajax_imap_search', 'message_list_type', true, 'core');
 add_handler('ajax_imap_search', 'imap_message_list_type', true);
 add_handler('ajax_imap_search', 'load_imap_servers_from_config',  true);
@@ -237,6 +238,7 @@ add_handler('ajax_imap_search', 'imap_search',  true);
 add_output('ajax_imap_search', 'filter_imap_search', true);
 
 /* advanced search results */
+add_handler('ajax_adv_search', 'default_sort_order_setting', true, 'core', 'load_user_data', 'after');
 add_handler('ajax_adv_search', 'load_imap_servers_from_config',  true, 'imap', 'load_user_data', 'after');
 add_handler('ajax_adv_search', 'imap_oauth2_token_check', true, 'imap', 'load_imap_servers_from_config', 'after');
 


### PR DESCRIPTION
Search and Advanced Search ajax pages did not correctly load the default sort order setting and thus were still using Arrival date instead of Sent date even if the setting was enabled. This PR tries to correct the problem by exposing default sort order in case list_sort is empty - e.g. when search pages are using the imap message list functions.