### PR TITLE
attempt to fix draft versions, missing attachments when sending email

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -54,8 +54,9 @@ class Hm_Handler_imap_forward_attachments extends Hm_Handler_Module {
             'no_encoding' => true,
             'size' => strlen($content)
         );
-        $draft_id = count($this->session->get('compose_drafts', array()));
+        $draft_id = next_draft_key($this->session);
         attach_file($content, $file, $filepath, $draft_id, $this);
+        $this->out('compose_draft_id', $draft_id);
     }
 }
 

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -235,5 +235,10 @@ $(function() {
         if (window.location.href.search('&reply=1') !== -1 || window.location.href.search('&reply_all=1') !== -1) {
             replace_cursor_positon ($('textarea[name="compose_body"]'));
         }
+        if (window.location.href.search('&forward=1') !== -1) {
+            setTimeout(function() {
+                save_compose_state();
+            }, 100);
+        }
     }  
 });


### PR DESCRIPTION
This attempts to fix #421 and #436. The problem I see is with draft version numbers and the fact that new attachments are tied to a draft that is not actually saved in the session, so interactions with cypht in another browser tab could eventually destroy the attachment.

The changes implemented here are making a slight change in behavior which I think is logical. Here are they:
1. Attaching a file from the compose page to a draft that has not yet been saved automatically saves the draft. This should allow working on other reply/forward/compose pages in the same session in another tab without loosing or interfering with the file you just uploaded.
2. Fixed numbering issue when deleting drafts - if you had drafts with IDs 0, 1 and 2, deleted 1 and added another one, it would have added that as 2 replacing the previous version 2 because of using the count() method on the drafts array. Instead, we are now using the max key and incrementing that with 1.
3. Forwarding messages automatically creates an attachment but also automatically creates a draft. It is also automatically saved as soon as the forward compose form is loaded, so we have all the details in the draft itself (rather than just the attached email). This will fix #436 by creating new drafts for each forwarding operation you do.

A side-effect of this change is the auto-saving of drafts happening on 30 seconds interval by default. We now save all draft contents even when no subject is entered (so we can keep the attachments in the drafts without subjects). I think this is behavior similar to other mail clients that won't let you quit an unsaved/unsent compose page even if there is no subject entered. We can improve here by ignoring saving of drafts that are completely empty, so opening the compose page but not doing anything should not actually save as draft.

Jason, let me know your thoughts and what else to improve here!