### PR TITLE
Site.js in Core Module compatibility for IE11

### DIFF
--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -27,7 +27,7 @@ $.fn.serializeArray = function() {
         parts = args[i].split('=');
         res.push({'name': parts[0], 'value': parts[1]});
     }
-    return res.map(x => {return {name: x.name, value: decodeURIComponent(x.value)}});
+    return res.map(function(x) {return {name: x.name, value: decodeURIComponent(x.value)}});
 };
 $.fn.sort = function(sort_function) {
     var list = [];


### PR DESCRIPTION
## Pullrequest
Removed `=>`-Notation which is part of ES6 because it's not supported by IE11.

### Issues
- [X] None

### Checklist
- [X] None

### How2Test
- [X] Use Internet Explorer 11.0.9600.19596 / Updateversion 11.0.170 (KB4534251) to open the Cypht main page (after login). Before the change, line 71 of site.js would throw a syntax error on `res.map(x => {return ...})`. Changing this to `function(x) {return ...}` fixed this problem.

### Todo
- [x] None

### Source
- [X] https://stackoverflow.com/questions/42080078/javascript-syntax-error-on-internet-explorer
