### PR TITLE
fix copy/move folder list when checking a message from the list before all sources have loaded

### DIFF
--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -727,8 +727,8 @@ var imap_background_unread_content_result = function(res) {
 };
 
 var check_select_for_imap = function() {
-    $('input[type=checkbox]').off('change'); 
-    $('input[type=checkbox]').on("change", function(e) { search_selected_for_imap(); });
+    $('body').off('change', 'input[type=checkbox]');
+    $('body').on('change', 'input[type=checkbox]', function(e) { search_selected_for_imap(); });
 };
 
 var search_selected_for_imap = function() {


### PR DESCRIPTION
Case: you have multiple imap sources. Nothing is cached in local browser's session cache. Click Everything (combined inbox). Check a message while sources are loaded (one or two have loaded  but the rest have not).
Result: Copy/Move buttons are disabled and no folders appear inside.
This PR fixes the issue by attaching the event handles to the body.

However, there is a deeper issue I was not able to resolve. When a checkbox is checked while other sources are loading, Hm_Ajax.abort flag is set and the rest of the sources never complete loading - their results don't appear in the combined inbox. Even if you reload via the refresh button at the top, the results don't appear until you deselect all checkboxes. Is there a reason why further ajax calls are aborted if a checkbox is checked? I think we should still process their results as they were queued and it doesn't matter if user clicks something quickly or not. @jasonmunro let me know your thoughts here.