### PR TITLE
add a default text to the combined inbox page

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -722,6 +722,7 @@ class Hm_Output_filter_combined_inbox extends Hm_Output_Module {
     protected function output() {
         if ($this->get('imap_combined_inbox_data')) {
             prepare_imap_message_list($this->get('imap_combined_inbox_data'), $this, 'combined_inbox');
+            $this->out('page_links', 'There is no pagination is this view, please visit the individual mail boxes.');
         }
         else {
             $this->out('formatted_message_list', array());

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -298,6 +298,8 @@ var imap_message_list_content = function(id, folder, hook, batch_callback) {
                 add_auto_folder(res.auto_sent_folder);
             }
             Hm_Message_List.update(ids, res.formatted_message_list, 'imap');
+            $('.page_links').html(res.page_links);
+            cache_imap_page();
         },
         [],
         false,
@@ -412,6 +414,16 @@ var select_imap_folder = function(path, callback) {
         );
     }
     return false;
+};
+
+var setup_imap_message_list_content_page = function() {
+    var cache_details = fetch_cached_imap_page();
+    if (cache_details[0]) {
+        $('.message_table tbody').html(cache_details[0]);
+    }
+    if (cache_details[1]) {
+        $('.page_links').html(cache_details[1]);
+    }
 };
 
 var setup_imap_folder_page = function() {
@@ -959,6 +971,9 @@ if (hm_list_path() == 'sent') {
 $(function() {
     if (hm_page_name() === 'message_list' && hm_list_path().substr(0, 4) === 'imap') {
         setup_imap_folder_page();
+    }
+    else if (hm_page_name() === 'message_list' && hm_list_path() === 'combined_inbox') {
+        setup_imap_message_list_content_page();
     }
     else if (hm_page_name() === 'message' && hm_list_path().substr(0, 4) === 'imap') {
         imap_setup_message_view_page();


### PR DESCRIPTION
Hi, I am azibom from tikiwiki company
I done this task "https://avan.tech/item38376-Cypht-in-Tiki-no-page-2-for-messages-in-combined-view-in-one-mailbox-is-OK"
with is about adding a default text in the end of the combined index page and I add it now and you can test it with going to "Everything" page ("/?page=message_list&list_path=combined_inbox")


![Screenshot from 2021-04-04 18-27-03](https://user-images.githubusercontent.com/34370960/113511172-bbd4df80-9573-11eb-9452-10fd56f6114e.png)
