### PR TITLE
Hotfix for the default email in the SMTP list when using the mailing and base IMAP draft implementation

### DIFF
--- a/modules/core/message_list_functions.php
+++ b/modules/core/message_list_functions.php
@@ -296,6 +296,10 @@ function icon_callback($vals, $style, $output_mod) {
         $icons .= $show_icons ? '<img src="'.Hm_Image_Sources::$star.'" width="16" height="16" alt="'.$output_mod->trans('Flagged').'" />' : ' F';
         $title[] = $output_mod->trans('Flagged');
     }
+    if (in_array('draft', $vals[0])) {
+        $icons .= $show_icons ? '<img src="'.Hm_Image_Sources::$star.'" width="16" height="16" alt="'.$output_mod->trans('Draft').'" />' : ' D';
+        $title[] = $output_mod->trans('Draft');
+    }
     if (in_array('answered', $vals[0])) {
         $icons .= $show_icons ? '<img src="'.Hm_Image_Sources::$circle_check.'" width="16" height="16" alt="'.$output_mod->trans('Answered').'" />' : ' A';
         $title[] = $output_mod->trans('Answered');

--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -221,7 +221,7 @@ function format_imap_message_list($msg_list, $output_module, $parent_list=false,
             $from = preg_replace("/(\<.+\>)/U", '', $msg['to']);
             $icon = 'sent';
         }
-        foreach (array('attachment', 'deleted', 'flagged', 'answered') as $flag) {
+        foreach (array('attachment', 'deleted', 'flagged', 'answered', 'draft') as $flag) {
             if (stristr($msg['flags'], $flag)) {
                 $flags[] = $flag;
             }
@@ -244,6 +244,11 @@ function format_imap_message_list($msg_list, $output_module, $parent_list=false,
         if (!$show_icons) {
             $icon = false;
         }
+
+        if (in_array('draft', $flags)) {
+            $url = '?page=compose&list_path='.sprintf('imap_%s_%s', $msg['server_id'], $msg['folder']).'&uid='.$msg['uid'].'&imap_draft=1';
+        }
+
         if ($style == 'news') {
             $res[$id] = message_list_row(array(
                     array('checkbox_callback', $id),

--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -897,7 +897,6 @@ class Hm_IMAP extends Hm_IMAP_Cache {
      * get content for a message part
      * @param int $uid a single IMAP message UID
      * @param string $message_part the IMAP message part number
-     * @param bool $raw flag to enabled fetching the entire message as text
      * @param int $max maximum read length to allow.
      * @param mixed $struct a message part structure array for decoding and
      *                      charset conversion. bool true for auto discovery
@@ -1595,7 +1594,7 @@ class Hm_IMAP extends Hm_IMAP_Cache {
      * @param bool $seen flag to mark the message seen
      * $return bool true on success
      */
-    public function append_start($mailbox, $size, $seen=true) {
+    public function append_start($mailbox, $size, $seen=true, $draft=false) {
         if (!$this->is_clean($mailbox, 'mailbox') || !$this->is_clean($size, 'uid')) {
             return false;
         }
@@ -1604,6 +1603,9 @@ class Hm_IMAP extends Hm_IMAP_Cache {
         }
         else {
             $command = 'APPEND "'.$this->utf7_encode($mailbox).'" () {'.$size."}\r\n";
+        }
+        if ($draft) {
+            $command = 'APPEND "'.$this->utf7_encode($mailbox).'" (\Draft) {'.$size."}\r\n";
         }
         $this->send_command($command);
         $result = $this->fgets();

--- a/modules/imap_folders/setup.php
+++ b/modules/imap_folders/setup.php
@@ -26,7 +26,7 @@ add_handler('ajax_imap_folder_expand', 'add_folder_manage_link', true, 'imap_fol
 add_output('folders', 'folders_trash_dialog', true, 'imap_folders', 'folders_delete_dialog', 'after');
 add_output('folders', 'folders_sent_dialog', true, 'imap_folders', 'folders_trash_dialog', 'after');
 add_output('folders', 'folders_archive_dialog', true, 'imap_folders', 'folders_sent_dialog', 'after');
-//add_output('folders', 'folders_draft_dialog', true, 'imap_folders', 'folders_sent_dialog', 'after');
+add_output('folders', 'folders_draft_dialog', true, 'imap_folders', 'folders_sent_dialog', 'after');
 
 add_handler('compose', 'special_folders', true, 'imap_folders', 'load_user_data', 'after');
 

--- a/modules/smtp/hm-mime-message.php
+++ b/modules/smtp/hm-mime-message.php
@@ -50,6 +50,11 @@ class Hm_MIME_Msg {
         $this->body = $body;
     }
 
+    /* return headers array */
+    function get_headers() {
+      return $this->headers;
+    }
+
     /* add attachments */
     function add_attachments($files) {
         $this->attachments = $files;
@@ -267,4 +272,3 @@ class Hm_MIME_Msg {
         return str_replace('.', '=2E', quoted_printable_encode($string));
     }
 }
-

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1207,7 +1207,7 @@ function save_imap_draft($atts, $id, $session, $mod, $mod_cache) {
         if ($imap->append_start($specials[$imap_profile['id']]['draft'], strlen($msg), true)) {
             $imap->append_feed($msg."\r\n");
             if (!$imap->append_end()) {
-                Hm_Msgs::add('ERRAn error occurred saving the sent message');
+                Hm_Msgs::add('ERRAn error occurred saving the draft message');
             }
         }
         return 1;

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -708,10 +708,28 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
             $res .= format_attachment_row($file, $this);
         }
 
-        // If compose_from GET parameter is set, force $recip replacement.
-        // This ensures any module can force the selected dropdown SMTP server
+        // If compose_from GET parameter is set, search for the correct smtp_id
+        // within the SMTP profiles.
+        //
+        // Added latency reduction 'break' for big smtp profile lists
         if ($from) {
-            $recip = $from;
+            $profiles = $this->module_output()['smtp_servers'];
+            foreach ($profiles as $id => $profile) {
+                if ($profile['user'] == $from) {
+                    $smtp_id = $id;
+                    break;
+                }
+                // Profile users without the domain
+                if ($profile['user'] == explode('@', $from)[0]) {
+                    $smtp_id = $id;
+                    break;
+                }
+                // Some users might use the profile name as the full email
+                if ($profile['name'] == $from) {
+                    $smtp_id = $id;
+                    break;
+                }
+            }
         }
 
         $res .= '</table>'.

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -717,16 +717,16 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
             foreach ($profiles as $id => $profile) {
                 if ($profile['user'] == $from) {
                     $smtp_id = $id;
-                    break;
                 }
                 // Profile users without the domain
                 if ($profile['user'] == explode('@', $from)[0]) {
                     $smtp_id = $id;
-                    break;
                 }
                 // Some users might use the profile name as the full email
                 if ($profile['name'] == $from) {
                     $smtp_id = $id;
+                }
+                if ($smtp_id) {
                     break;
                 }
             }

--- a/modules/smtp/setup.php
+++ b/modules/smtp/setup.php
@@ -50,6 +50,7 @@ add_handler('ajax_smtp_debug', 'date', true, 'core');
 add_handler('ajax_smtp_debug', 'http_headers', true, 'core');
 
 /* save draft ajax request */
+add_handler('ajax_smtp_save_draft', 'load_imap_servers_from_config', true, 'imap', 'load_user_data', 'after');
 add_handler('ajax_smtp_save_draft', 'login', false, 'core');
 add_handler('ajax_smtp_save_draft', 'load_user_data',  true, 'core');
 add_handler('ajax_smtp_save_draft', 'smtp_save_draft',  true);

--- a/modules/smtp/setup.php
+++ b/modules/smtp/setup.php
@@ -7,6 +7,7 @@ output_source('smtp');
 
 add_module_to_all_pages('handler', 'smtp_default_server', true, 'smtp', 'load_user_data', 'after');
 add_handler('compose', 'load_smtp_reply_to_details', true, 'smtp', 'load_user_data', 'after');
+add_handler('compose', 'load_smtp_is_imap_draft', true, 'smtp', 'load_user_data', 'after');
 add_handler('compose', 'smtp_from_replace', true, 'smtp', 'load_user_data', 'after');
 add_handler('compose', 'load_smtp_servers_from_config', true, 'smtp', 'load_smtp_reply_to_details', 'after');
 add_handler('compose', 'add_smtp_servers_to_page_data', true, 'smtp', 'load_smtp_servers_from_config', 'after');
@@ -93,6 +94,7 @@ return array(
         'ajax_smtp_delete_draft'
     ),
     'allowed_get' => array(
+        'imap_draft' => FILTER_VALIDATE_INT,
         'reply' => FILTER_VALIDATE_INT,
         'reply_all' => FILTER_VALIDATE_INT,
         'forward' => FILTER_VALIDATE_INT,

--- a/modules/smtp/setup.php
+++ b/modules/smtp/setup.php
@@ -134,7 +134,7 @@ return array(
         'draft_body' => FILTER_UNSAFE_RAW,
         'draft_subject' => FILTER_UNSAFE_RAW,
         'draft_to' => FILTER_UNSAFE_RAW,
-        'draft_smtp' => FILTER_VALIDATE_FLOAT,
+        'draft_smtp' => FILTER_SANITIZE_STRING,
         'draft_cc' => FILTER_UNSAFE_RAW,
         'draft_bcc' => FILTER_UNSAFE_RAW,
         'draft_in_reply_to' => FILTER_UNSAFE_RAW,

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -127,6 +127,9 @@ var save_compose_state = function(no_files, notice) {
         function(res) {
             $('.smtp_send').prop('disabled', false);
             $('.smtp_send').removeClass('disabled_input');
+            if (res.draft_id) {
+                $('.compose_draft_id').val(res.draft_id);
+            }
             if (res.draft_subject) {
                 $('.draft_list .draft_'+draft_id+' a').text(res.draft_subject);
             }
@@ -180,7 +183,7 @@ var upload_file = function(file) {
     xhr.open('POST', '', true);
     xhr.setRequestHeader('X-Requested-With', 'xmlhttprequest');
     xhr.onreadystatechange = function() {
-        if (xhr.readyState == 4){ 
+        if (xhr.readyState == 4){
             if (hm_encrypt_ajax_requests()) {
                 res = Hm_Utils.json_decode(xhr.responseText);
                 res = Hm_Utils.json_decode(Hm_Crypt.decrypt(res.payload));
@@ -210,10 +213,10 @@ var delete_attachment = function(file, link) {
     return false;
 };
 
-var replace_cursor_positon = function (txtElement) { 
+var replace_cursor_positon = function (txtElement) {
     txtElement.val('\r\n\r\n\r\n'+txtElement.val());
     txtElement.prop('selectionEnd',0);
-    txtElement.focus(); 
+    txtElement.focus();
 }
 
 $(function() {
@@ -240,5 +243,5 @@ $(function() {
                 save_compose_state();
             }, 100);
         }
-    }  
+    }
 });


### PR DESCRIPTION
## Pullrequest
**Hotfix for** https://github.com/jasonmunro/cypht/pull/463

In the previous pull request, the SMTP profile user must have a domain to be found and selected. With this update, the SMTP module will try other ways of comparison to identify which SMTP profile to use.

I used a more direct way and put the responsibility of searching for the profile in the SMTP module itself instead of the IMAP module as discussed on Gitter.

**IMAP Draft Support**

When Draft Folders are configured for a specific IMAP account, the save button will use imap append to save the draft in the specific folder. Check todo list for upcoming necessary updates.


### Issues
- [X] https://github.com/jasonmunro/cypht/issues/257
- [X] https://github.com/jasonmunro/cypht/issues/465


### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
- [x] Configure a Draft folder for a specific draft account
- [x] Compose a new message
- [x] Save your composed message
- [x] Check if message shows in the configured Draft folder