### PR TITLE
IMAP drafts not being saved when the selected SMTP server is a profile

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1251,6 +1251,11 @@ function find_imap_by_smtp($imap_profiles, $smtp_profile)
  */
 if (!hm_exists('save_imap_draft')) {
 function save_imap_draft($atts, $id, $session, $mod, $mod_cache) {
+    // Check if it is a profile
+    if (strstr($atts['draft_smtp'], '.')) {
+        $atts['draft_smtp'] = reset(explode('.', $atts['draft_smtp']));
+    }
+
     $imap_profile = find_imap_by_smtp($mod->user_config->get('imap_servers'),
         $mod->user_config->get('smtp_servers')[$atts['draft_smtp']]);
 


### PR DESCRIPTION
## Hotfix for IMAP Drafts

In the compose page, when the selected SMTP server was a Profile, the IMAP draft folder was ignored. This Pull Request fix the issue.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] None

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None