### PR TITLE
Remove Hm_Ajax.abort when checkboxes are checked

### DIFF
--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -426,7 +426,6 @@ function Message_List() {
         }
         if ($('input[type=checkbox]', $('.message_table')).filter(function() {return this.checked; }).length > 0) {
             this.run_callbacks(completed);
-            Hm_Ajax.aborted = true;
             return 0;
         }
         if (msgs[0] === "") {


### PR DESCRIPTION
As requested in https://github.com/jasonmunro/cypht/pull/461, I removed the Hm_Ajax.abort line when checkboxes are checked to prevent further ajax call from being aborted.