### PR TITLE
Fix reply to issue

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -114,11 +114,16 @@ function reply_to_address($headers, $type) {
     if ($type == 'forward') {
         return $msg_to;
     }
-    foreach (array('reply-to', 'from', 'sender', 'return-path') as $fld) {
-        if (array_key_exists($fld, $headers)) { 
-            list($parsed, $msg_to) = format_reply_address($headers[$fld], $parsed);
-            if ($msg_to) {
-                break;
+    if (count($headers["return-path"]) == 1) {
+        $msg_to = $headers["to"];
+    }
+    else {
+        foreach (array('reply-to', 'from', 'sender', 'return-path') as $fld) {
+            if (array_key_exists($fld, $headers)) { 
+                list($parsed, $msg_to) = format_reply_address($headers[$fld], $parsed);
+                if ($msg_to) {
+                    break;
+                }
             }
         }
     }

--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -114,7 +114,7 @@ function reply_to_address($headers, $type) {
     if ($type == 'forward') {
         return $msg_to;
     }
-    if (count($headers["return-path"]) == 1) {
+    if (array_key_exists("return-path", $headers) && count($headers["return-path"]) == 1) {
         $msg_to = $headers["to"];
     }
     else {


### PR DESCRIPTION
Hello, I am Revisto from WikiSuite project.
I did this [Cypht: When we reply to an email we have sent, it proposes our address](https://avan.tech/item60589-Cypht-When-we-reply-to-an-email-we-have-sent-it-proposes-our-address) which was related to this [issue](https://github.com/jasonmunro/cypht/issues/384). I handled the situation when replying to myself, it shows the other person's email in the 'message to' section.
![](https://user-images.githubusercontent.com/60847212/125439250-2b4dd38e-fa29-4693-955c-fc872d722292.gif)
