### PR TITLE
fix a command in installation which required root access

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -84,7 +84,7 @@ sudo mkdir /var/lib/hm3/attachments
 sudo mkdir /var/lib/hm3/users
 sudo mkdir /var/lib/hm3/app_data
 
-chown -R www-data /var/lib/hm3/
+sudo chown -R www-data /var/lib/hm3/
       
 The /var/lib/hm3/users directory is only required if you are using the
 file-system and not a database to store user settings (user_config_type = file


### PR DESCRIPTION
## Pull request
Hello, this is Revisto from Wikisuite Project.
I changed this command line "chown -R www-data /var/lib/hm3/" which required root access so it has to be used with a "sudo" at the start.