### PR TITLE
Autocrypt base implementation

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -276,9 +276,23 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
             $txt .= '<input type="hidden" class="move_to_string1" value="'.$this->trans('Move to ...').'" />';
             $txt .= '<input type="hidden" class="move_to_string2" value="'.$this->trans('Copy to ...').'" />';
             $txt .= '<input type="hidden" class="move_to_string3" value="'.$this->trans('Removed non-IMAP messages from selection. They cannot be moved or copied').'" />';
-            $txt .= '</th></tr>';
-            $txt .= '</table>';
+            $txt .= '</th></tr>';       
 
+
+            $headers = $this->get('msg_headers', array());
+            if (array_key_exists('Autocrypt', $headers)) {
+                $exploded_autocrypt_header = explode('keydata=', $headers['Autocrypt']);
+                $exploded_autocrypt_email_header = explode('addr=', $headers['Autocrypt']);
+                if (count($exploded_autocrypt_header) >= 1) {
+                    $pgp_key = end($exploded_autocrypt_header);
+                    $key_email = reset(explode(';', end($exploded_autocrypt_email_header)));
+                    $txt .= '<tr class="autocrypt_key_header_import_warning"><td colspan="2"><div>The sender sent their public key in the message header ';
+                    $txt .= '<form id="import_public_key_form" method="POST" action="?page=pgp#public_keys"><input type="hidden" id="key_import_email" value="'.$key_email.'" /><input id="hm_page_key" type="hidden" name="hm_page_key" value="'.$this->html_safe(Hm_Request_Key::generate()).'" /><input type="hidden" id="public_key_header_field" value="'.$pgp_key.'" name="public_key"><button type="submit" id="import_public_button">Import</button></form>';
+                    $txt .= '</div></td></tr>';
+                }                
+            }     
+
+            $txt .= '</table>';
             $this->out('msg_headers', $txt, false);
         }
     }

--- a/modules/imap/site.css
+++ b/modules/imap/site.css
@@ -87,3 +87,7 @@
 
 .attached_image { margin-right: 20px; margin-bottom: 20px; height: 200px; }
 .attached_image_box { display: flex; flex-wrap: wrap; border-top: solid 1px #ddd; padding-top: 20px; padding-left: 20px; width: 100%; padding-bottom: 40px; }
+
+.autocrypt_key_header_import_warning { font-size: 12px; color: black; }
+.autocrypt_key_header_import_warning > td { padding-left: 35px;}
+.autocrypt_key_header_import_warning > td > span { background-color: #aaa;  }

--- a/modules/pgp/setup.php
+++ b/modules/pgp/setup.php
@@ -18,11 +18,14 @@ add_output('message', 'pgp_msg_controls', true, 'pgp', 'message_start', 'before'
 add_handler('ajax_imap_message_content', 'pgp_message_check',  true, 'pgp', 'imap_message_content', 'after');
 add_output('ajax_hm_folders', 'pgp_settings_link', true, 'pgp', 'settings_menu_end', 'before');
 
+add_handler('ajax_public_key_import_string', 'login', false, 'core');
+add_handler('ajax_public_key_import_string', 'ajax_public_key_import_string', true);
+
 add_handler('compose', 'pgp_compose_data', true, 'pgp', 'load_user_data', 'after');
 add_output('compose', 'pgp_compose_controls', true, 'pgp', 'compose_form_end', 'after');
 
 return array(
-    'allowed_pages' => array('pgp'),
+    'allowed_pages' => array('pgp', 'ajax_public_key_import_string'),
     'allowed_output' => array(
         'pgp_msg_part' => array(FILTER_VALIDATE_BOOLEAN, false),
     ),

--- a/modules/smtp/hm-mime-message.php
+++ b/modules/smtp/hm-mime-message.php
@@ -50,6 +50,10 @@ class Hm_MIME_Msg {
         $this->body = $body;
     }
 
+    function set_autocrypt_header($public_key = NULL) {
+        $this->headers['Autocrypt'] = 'addr='.str_replace(['<', '>'], '', $this->headers['From']).'; prefer-encrypt=mutual; keydata='.base64_encode($public_key);
+    }
+
     /* return headers array */
     function get_headers() {
       return $this->headers;

--- a/modules/smtp/setup.php
+++ b/modules/smtp/setup.php
@@ -153,7 +153,9 @@ return array(
         'draft_in_reply_to' => FILTER_UNSAFE_RAW,
         'draft_notice' => FILTER_VALIDATE_BOOLEAN,
         'smtp_auto_bcc' => FILTER_VALIDATE_INT,
-        'profile_value' => FILTER_SANITIZE_STRING
+        'profile_value' => FILTER_SANITIZE_STRING,
+        'autocrypt_send_public_key' => FILTER_SANITIZE_STRING,
+        'autocrypt_pgp_key' => FILTER_SANITIZE_STRING
     )
 );
 

--- a/modules/smtp/site.css
+++ b/modules/smtp/site.css
@@ -25,3 +25,4 @@
 .editor-toolbar { z-index: 0; margin-left: 5px; margin-top: 10px; border: solid 1px #ccc; width: 100%; border-radius: 3px 3px 0px 0px; }
 .editor-statusbar { border-top: none !important; }
 .editor-toolbar:before, .editor-toolbar:after { background: none !important; }
+.send_public_key_check { margin-left: 15px;}


### PR DESCRIPTION
# Autocrypt

> This PR is a preview and it is not ready for merging.

This PR aims to implement the sending and receiving of public PGP keys through message headers using Autocrypt Level 1 standards.

When enabling the PGP module, the user can choose to include a public key in the message header on the compose page. When receiving a message with Autocrypt headers, the user can choose to import the received key on the message preview page.

Reference: https://autocrypt.org

![Screenshot_20210824_143717](https://user-images.githubusercontent.com/1107499/130663499-d1864b7a-b729-415d-b10c-f75d61ba678b.png)

![Screenshot_20210824_143813](https://user-images.githubusercontent.com/1107499/130663607-f5303181-d1eb-4750-b723-eaabe609f874.png)

# Currently mandatory items implemented according to specification

### Peer State Management

#### The Autocrypt Header

- The addr attribute is mandatory, and contains the single recipient address this header is valid for. If this address differs from the one in the From header, the entire Autocrypt header **MUST** be treated as invalid.
- The keydata attribute is mandatory, and contains the key data for the specified addr recipient address. The value of the keydata attribute is a Base64 representation of the binary OpenPGP “Transferable Public Key”. For ease of parsing, the keydata attribute **MUST** be the last attribute in this header.

#### OpenPGP Based key data

- The keydata sent by an Autocrypt-enabled Level 1 MUA **MUST** consist of an OpenPGP “Transferable Public Key”
- These packets **MUST** be assembled in binary format (not ASCII-armored), and then base64-encoded.
- A Level 1 MUA **MUST** be capable of processing and handling Ed25519 public keys for signatures, as well as Cv25519 for encryption. 

#### Header injection in outbound mail

- This header **MUST** contain the corresponding public key material (accounts[from-addr].public_key) as the keydata attribute, and from-addr as the addr attribute. The most minimal Level 1 compliant MUA will only include these two attributes. If accounts[from-addr].prefer_encrypt is set to mutual, then the header **MUST** have a prefer-encrypt attribute with the value mutual.
- If the From address changes during message composition (e.g., if the user selects a different outbound identity), then the MUA **MUST** change the Autocrypt header accordingly.
- The MUA **MUST NOT** include more than one valid Level 1 Autocrypt header (see Updating Autocrypt Peer State).

#### Message Encryption

- An Autocrypt MUA **MUST NOT** create an Autocrypt Setup Message without explicit user interaction

# Solves

- https://github.com/jasonmunro/cypht/issues/241
