### PR TITLE
load profiles when attaching a file, so smtp drafts are correctly saved

### DIFF
--- a/modules/profiles/setup.php
+++ b/modules/profiles/setup.php
@@ -21,6 +21,7 @@ add_output('compose', 'compose_signature_values', true, 'profiles', 'compose_for
 add_handler('compose', 'compose_profile_data', true, 'profiles', 'load_smtp_servers_from_config', 'after');
 
 add_handler('ajax_smtp_save_draft', 'compose_profile_data', true, 'profiles', 'load_smtp_servers_from_config', 'after');
+add_handler('ajax_smtp_attach_file', 'compose_profile_data', true, 'profiles', 'load_smtp_servers_from_config', 'after');
 
 return array(
     'allowed_pages' => array(

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -559,6 +559,9 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
 
         /* add attachments */
         $mime->add_attachments(get_uploaded_files($form['draft_id'], $this->session));
+        if ($form['draft_id'] > 0) {
+            $mime->add_attachments(get_uploaded_files(0, $this->session));
+        }
 
         /* get smtp recipients */
         $recipients = $mime->get_recipient_addresses();
@@ -613,6 +616,9 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
         Hm_Msgs::add("Message Sent");
         delete_draft($form['draft_id'], $this->session);
         delete_uploaded_files($this->session, $form['draft_id']);
+        if ($form['draft_id'] > 0) {
+            delete_uploaded_files($this->session, 0);
+        }
     }
 }
 

--- a/modules/smtp/setup.php
+++ b/modules/smtp/setup.php
@@ -62,6 +62,7 @@ add_handler('ajax_smtp_save_draft', 'http_headers', true, 'core');
 
 /* attach file */
 add_handler('ajax_smtp_attach_file', 'load_imap_servers_from_config', true, 'imap', 'load_user_data', 'after');
+add_handler('ajax_smtp_attach_file', 'load_smtp_servers_from_config', true, 'imap', 'load_user_data', 'after');
 add_handler('ajax_smtp_attach_file', 'login', false, 'core');
 add_handler('ajax_smtp_attach_file', 'load_user_data',  true, 'core');
 add_handler('ajax_smtp_attach_file', 'smtp_attach_file',  true);


### PR DESCRIPTION
... into a linked imap profile drafts folder; additionally send local attachments saved to first draft as part of imap draft sending procedure - otherwise, attachments stay on the server and are never sent out

@henrique-borba I think saving imap drafts when smtp/imap profile is setup is your work, can you check out these fixes? The main problem I was hunting is missing files in the sent email after attaching them to a message. However, I found another bug as well. In short:

1. Profiles were not loaded upon auto-saving an imap draft when attaching a file. This made the actual draft miss the attachments.
2. Even with the above fix, attachments still were not sent out when compose form was submitted. This was because the attachments are saved locally with Cypht draft ids (0, 1, 2, etc.) while imap drafts have IDs equal to the message UID from the remote imap folder. So, when sending out the email, attachments were not related properly due to mismatch of IDs. I added a temporary fix here - whenever a draft with ID > 0 is sent we also add the default attachments saved to draft ID 0. This fixed the immediate issue we have but is not perfect as it might interfere with Cypht drafts when no profiles are used - in that case, if you save draft 0 (upload 1 file), save draft 1 with another file and send draft 1, file from draft 0 will be sent as well. I think a proper fix here implies properly parsing the saved imap draft (when this feature is used) and reattaching the files to the sent email. This means:
a) delete local attachments when imap draft is saved as those are saved as part of the imap message
b) show attachments to the imap draft in the compose form when editing an imap draft
c) send those attachments even if they are not locally uploaded when submitting the compose form

If you have a different/easier to implement idea, I am also fine but I think this imap draft feature needs some updates in order to work fine with attachments.
