### PR TITLE
Fix draft attachment and remove legacy draft fallback

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -58,14 +58,14 @@ class Hm_Handler_load_smtp_is_imap_draft extends Hm_Handler_Module {
                 
                 $attached_files = [];
                 $this->session->set('uploaded_files', array());
-                if (array_key_exists('subs', $msg_struct[0])) {
+                if (array_key_exists(0, $msg_struct) && array_key_exists('subs', $msg_struct[0])) {
                     foreach ($msg_struct[0]['subs'] as $ind => $sub) {
                         if ($ind != '0.1') {
-                            $new_attachment['basename'] = $sub['attributes']['name'];
-                            $new_attachment['name'] = $sub['attributes']['name'];
+                            $new_attachment['basename'] = $sub['description'];
+                            $new_attachment['name'] = $sub['description'];
                             $new_attachment['size'] = $sub['size'];
                             $new_attachment['type'] = $sub['type'];
-                            $file_path = $this->config->get('attachment_dir').DIRECTORY_SEPARATOR.$sub['attributes']['name'];
+                            $file_path = $this->config->get('attachment_dir').DIRECTORY_SEPARATOR.$new_attachment['name'];
                             $content = Hm_Crypt::ciphertext($imap->get_message_content($this->request->get['uid'], $ind), Hm_Request_Key::generate());
                             file_put_contents($file_path, $content);
                             $new_attachment['tmp_name'] = $file_path;
@@ -881,6 +881,7 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
                 '<script type="text/javascript">var editor = new Editor(); editor.render();</script>';
         }
         $res .= '<table class="uploaded_files">';
+        
         foreach ($files as $file) {
             $res .= format_attachment_row($file, $this);
         }

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -56,6 +56,9 @@ class Hm_Handler_load_smtp_is_imap_draft extends Hm_Handler_Module {
                     return;
                 }
                 
+                # Attahcment Download
+                # Draft attachments must be redownloaded and added to the file cache to prevent 
+                # attachments from being deleted when editing a previously saved draft.
                 $attached_files = [];
                 $this->session->set('uploaded_files', array());
                 if (array_key_exists(0, $msg_struct) && array_key_exists('subs', $msg_struct[0])) {

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -278,11 +278,20 @@ class Hm_Handler_load_smtp_servers_from_config extends Hm_Handler_Module {
             $draft = get_draft($this->request->get['draft_id'], $this->session);
             $draft_id = $this->request->get['draft_id'];
         }
+        elseif (array_key_exists('draft_id', $this->request->post)) {
+            $draft = get_draft($this->request->post['draft_id'], $this->session);
+            $draft_id = $this->request->post['draft_id'];
+        }
         if ($reply_type) {
             $this->out('reply_type', $reply_type);
         }
+        if ($draft_id == 0 && array_key_exists('uid', $this->request->get)) {
+            $draft_id = $this->request->get['uid'];
+        }
+
         $this->out('compose_draft', $draft, false);
         $this->out('compose_draft_id', $draft_id);
+        
         $this->out('uploaded_files', get_uploaded_files($draft_id, $this->session));
         $compose_type = $this->user_config->get('smtp_compose_type_setting', 0);
         if ($this->get('is_mobile', false)) {
@@ -731,7 +740,7 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
         $msg_path = $this->get('list_path', '');
         $msg_uid = $this->get('uid', '');
         $from = $this->get('compose_from');
-
+        
         if (!$msg_path) {
             $msg_path = $this->get('compose_msg_path', '');
         }
@@ -796,7 +805,7 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
             }
             $draft_id = $msg_uid;
         }
-
+        
         $send_disabled = '';
         if (count($this->get('smtp_servers', array())) == 0) {
             $send_disabled = 'disabled="disabled" ';
@@ -1163,6 +1172,7 @@ function get_uploaded_files($id, $session) {
     if (array_key_exists($id, $files)) {
         return $files[$id];
     }
+
     return array();
 }}
 
@@ -1252,20 +1262,6 @@ function delete_draft($id, $session) {
 /**
  * @subpackage smtp/functions
  */
-if (!hm_exists('save_draft')) {
-function save_draft($atts, $id, $session) {
-    $drafts = $session->get('compose_drafts', array());
-    if ($id === false) {
-        $id = next_draft_key($session);
-    }
-    $drafts[$id] = $atts;
-    $session->set('compose_drafts', $drafts);
-    return $id;
-}}
-
-/**
- * @subpackage smtp/functions
- */
 if (!hm_exists('find_imap_by_smtp')) {
 function find_imap_by_smtp($imap_profiles, $smtp_profile) {
     $id = 0;
@@ -1321,6 +1317,7 @@ function save_imap_draft($atts, $id, $session, $mod, $mod_cache) {
     $specials = get_special_folders($mod, $imap_profile['id']);
 
     if (!array_key_exists('draft', $specials) || !$specials['draft']) {
+        Hm_Msgs::add('ERRThere is no draft directory configured for this account.');
         return -1;
     }
     $cache = Hm_IMAP_List::get_cache($mod_cache, $imap_profile['id']);
@@ -1339,6 +1336,7 @@ function save_imap_draft($atts, $id, $session, $mod, $mod_cache) {
         $name,
         $atts['draft_in_reply_to']
     );
+    
     $mime->add_attachments($uploaded_files);
     $mime->process_attachments();
 
@@ -1398,14 +1396,10 @@ function attach_file($content, $file, $filepath, $draft_id, $mod, $imap_draft=fa
         if (!get_draft($draft_id, $mod->session)) {
             if ($imap_draft) {
                 $new_draft_id = save_imap_draft($atts, $draft_id, $mod->session, $mod, $mod->cache);
+                save_uploaded_file($new_draft_id, $file, $mod->session);
                 if ($new_draft_id >= 0) {
                     $mod->out('draft_id', $new_draft_id);
                 }
-            }
-            else if (!$imap_draft) {
-                save_draft(array('draft_smtp' => '', 'draft_to' => '', 'draft_body' => '',
-                    'draft_subject' => '', 'draft_cc' => '', 'draft_bcc' => '',
-                    'draft_in_reply_to' => ''), $draft_id, $mod->session);
             }
         }
         $mod->out('upload_file_details', $file);

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -238,8 +238,16 @@ var upload_file = function(file) {
 
 var delete_attachment = function(file, link) {
     Hm_Ajax.request(
-        [{'name': 'hm_ajax_hook', 'value': 'ajax_smtp_delete_attachment'},
-        {'name': 'attachment_id', 'value': file}],
+    [{'name': 'hm_ajax_hook', 'value': 'ajax_smtp_delete_attachment'},
+     {'name': 'attachment_id', 'value': file}, 
+     {'name': 'draft_id', 'value': $('.compose_draft_id').val()},
+     {'name': 'draft_smtp', 'value': $('.compose_server').val()}, 
+     {'name': 'draft_subject', 'value': $('.compose_subject').val()}, 
+     {'name': 'draft_body', 'value': $('#compose_body').val()}, 
+     {'name': 'draft_to', 'value': $('.compose_to').val()}, 
+     {'name': 'draft_cc', 'value': $('.compose_cc').val()}, 
+     {'name': 'draft_bcc', 'value': $('.compose_bcc').val()}, 
+    ],
         function(res) { $(link).parent().parent().remove(); }
     );
     return false;


### PR DESCRIPTION
This PR removes the fallback of the legacy draft and fixes the ID issues that prevented the correct functioning of the IMAP drafts attachment.

**SOLUTION**
- Fixed the way the attachment cache IDs are updated when the draft ID is changed while editing
- When a previously saved draft with attachments is opened for editing, the attachments are downloaded to the attachments folder and added to the uploaded file cache. That way, when editing is complete, the new draft version will contain the files previously uploaded in the previous draft version.