### PR TITLE
Cypht: Copy and Move buttons don't appear OK in mobile portrait mode

### DIFF
--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -114,7 +114,7 @@ textarea, select, input { border: solid 1px #ddd; background-color: #fff; color:
 .wait { }
 .msg_controls { position: relative; display: none; padding-left: 0px; margin-right: 20px; }
 .msg_controls_visible { display: inline; }
-.msg_controls a, .toggle_link { font-size: .6em; letter-spacing: 0px; color: #666; background-color: #fff; border: solid 1px #ede8e6; padding: 3px; width: 30px; border-radius: 3px; vertical-align: 3px; }
+.msg_controls a, .toggle_link { font-size: .6em; letter-spacing: 0px; color: #666; background-color: #fff; border: solid 1px #ede8e6; padding: 3px; width: auto; border-radius: 3px; vertical-align: 3px; display: inline-block !important; }
 .msg_controls a { margin-right: 3px; }
 .toggle_link { padding-left: 4px !important; padding-right: 4px !important; padding-top: 4px !important;}
 .refresh_list, .list_settings_link { opacity: .4; padding: 5px; padding-bottom: 0px; cursor: pointer; padding-right: 0px; vertical-align: -13px; }
@@ -225,12 +225,18 @@ div.unseen, .unseen .subject { font-weight: 700; }
 .mobile .folder_toggle { display: block; top: 0px; left: -3px; }
 .mobile .folder_toggle img { width: 24px; height: 32px; margin-top: -7px; }
 .mobile .folder_toggle { position: fixed; z-index: 101; }
-.mobile .message_table { padding-left: 5px !important; }
+.mobile .message_table { padding-left: 5px !important; margin-top: 30px !important; }
 .mobile .list_settings_link, .mobile .refresh_list { width: 24px; height: 24px; vertical-align: -13px; }
 .mobile .refresh_list { margin-right: 5px; }
 .mobile .update_message_list { margin-right: 20px; }
 .mobile .msg_text { width: 100%; max-width: 480px !important; word-break: break-all; word-wrap: break-word; font-size: 100%; }
-.mobile .msg_controls { background: linear-gradient(180deg, #fff, #fff, #f7f2ef) !important; z-index: 100; position: fixed; right: -20px; height: 29px; font-size: 115%; padding-left: 10px; padding-top: 9px; top: 10px; left: 70px !important; }
+.mobile .msg_controls { background: linear-gradient(180deg, #fff, #fff, #f7f2ef) !important; z-index: 100; position: fixed; right: -10px; height: 54px; font-size: 115%; padding-left: 5px; padding-top: 5px; top: 1px; left: 65px !important; }
+@media (orientation: landscape) { 
+    .mobile .msg_controls { top: 12px; height: 26px; }
+    .mobile .toggle_link { height: 17px !important; }
+    .mobile .search_form { margin-left: -18px !important; }
+}
+/* .mobile .msg_controls::-webkit-scrollbar { display: none !important; } */
 .mobile .offline { height: 23px; padding-left: 38px; padding-right: 38px; }
 .mobile .header_subject th { white-space: normal !important; word-break: break-all !important; word-wrap: break-word !important; }
 .mobile .msg_headers th { padding-left: 10px !important; }
@@ -239,6 +245,7 @@ div.unseen, .unseen .subject { font-weight: 700; }
 .mobile .list_meta { display: none; }
 .mobile .user_settings table { white-space: normal; word-break: normal !important; table-layout: auto; }
 .mobile .header_links, .mobile .nlink { white-space: normal !important; word-break: break-all; word-wrap: break-word; }
+.mobile .search_form { margin-top: 20px !important; }
 .mobile .search_form select, .mobile .search_form button, .mobile .search_form input { margin-left: 0px !important; margin: 0px; margin-top: 5px; }
 .mobile .search_form label { display: none; }
 .mobile .search_update { clear: both; }
@@ -257,8 +264,8 @@ div.unseen, .unseen .subject { font-weight: 700; }
 .mobile .list_controls { color: #777; background: linear-gradient(180deg, #fff, #fff, #f7f2ef); border-bottom: solid 1px #ede8e6; height: 48px; padding-left: 5px; padding-right: 5px; }
 .mobile .page_links { font-size: 150%; }
 .mobile .page_links a img { width: 24px; height: 24px; }
-.mobile .toggle_link { padding: 5px !important; line-height: normal !important; margin-left: 5px !important; }
-.mobile .toggle_link img { vertical-align: -3px !important; width: 16px; height: 16px; }
+.mobile .toggle_link { padding: 4px 6px !important; line-height: normal !important; margin-left: -3px !important; margin-top: -4px; position: relative; }
+.mobile .toggle_link img { vertical-align: -3px !important; width: 16px; height: 16px; margin-left: -3px !important}
 .mobile .compose_form { padding: 0px !important; padding-left: 5px !important; width: 92% !important; }
 .mobile .toggle_recipients { top: 8px !important; right: 0px !important; }
 .mobile .prevnext, .mobile .news_cell .subject div img { width: 20px; height: 20px; }


### PR DESCRIPTION
Fix the look of  Copy and Move buttons in mobile portrait mode