### PR TITLE
Cypht: Indicate which server when this error is shown: "Could not authenticate to the selected IMAP server"

### DIFF
--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -968,6 +968,23 @@ function imap_authed($imap) {
 
 /**
  * @subpackage imap/functions
+ * @param $debug_msg
+ * @return string
+ */
+if (!hm_exists('get_failed_email')) {
+function get_failed_email($debug_msg) {
+    $email = '';
+    preg_match_all("/[\._a-zA-Z0-9-]+@[\._a-zA-Z0-9-]+/i", $debug_msg, $matches);
+    if(count($matches[0]) < 1){
+        $email = '';
+    }else{
+        $email = $matches[0][0];
+    }
+    return $email;
+}}
+
+/**
+ * @subpackage imap/functions
  */
 if (!hm_exists('process_sort_arg')) {
 function process_sort_arg($sort, $default = 'arrival') {

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -617,7 +617,7 @@ class Hm_Handler_imap_folder_expand extends Hm_Handler_Module {
                 $this->out('imap_expanded_folder_path', $path);
             }
             else {
-                Hm_Msgs::add(sprintf('ERRCould not authenticate to the selected %s server ()', $imap->server_type));
+                Hm_Msgs::add(sprintf('ERRCould not authenticate to the selected %s server (%s)', $imap->server_type, get_failed_email($imap->show_debug())));
             }
         }
     }


### PR DESCRIPTION
Indicate which server when this error is shown: "Could not authenticate to the selected IMAP server"

## Pullrequest
<!-- Describe the Pullrequest. -->


### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How to Test
<!-- Give a detailed description of how to test your PR and confirm it is working as expected. -->
- [ ] Add a few IMAP and SMTP accounts
- [ ] Enable google Less secure apps of one account 
- [ ] Then try to create a folder
- [ ] You will get a warning message

For more details : [Click](https://avan.tech/item57989-Cypht-Indicate-which-server-when-this-error-is-shown-Could-not-authenticate-to-the-selected-IMAP-server#threadId=52711)
### Todo
- [X] None
