### PR TITLE
[FIX] Cypht: When we reply to an email we have sent, it proposes our address

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -122,6 +122,9 @@ function reply_to_address($headers, $type) {
             }
         }
     }
+    if (!array_key_exists('delivered-to', $headers) && array_key_exists('to', $headers)) {
+        list($parsed, $msg_to) = format_reply_address($headers['to'], $parsed); 
+    }
     if ($type == 'reply_all') {
         if ($delivered_address) {
             $parsed[] = $delivered_address;


### PR DESCRIPTION
Correct this to propose the right address when we reply to an email we have sent.
More details about the fixed issue (https://github.com/jasonmunro/cypht/issues/384)