### PR TITLE
Implode process list field if array is passed

### DIFF
--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1022,6 +1022,7 @@ function get_list_headers($headers) {
 if (!hm_exists('process_list_fld')) {
 function process_list_fld($fld) {
     $res = array('links' => array(), 'email' => array(), 'values' => array());
+    $fld = is_array($fld) ? implode(" ", $fld) : $fld;
     foreach (explode(',', $fld) as $val) {
         $val = trim(str_replace(array('<', '>'), '', $val));
         if (preg_match("/^http/", $val)) {


### PR DESCRIPTION
Somehow an array is getting passed to the process_list_fld() function with some emails I am receiving, this implodes the array if one is passed.

There is probably a better way to fix this but I wasn't able to trace it down that far.

Closes #544 