### PR TITLE
Cypht "reply to all": Should be available if there are more than one email in from, to and cc

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -236,7 +236,12 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
                 '<a class="hlink small_headers" style="display: none;" href="#">'.$this->trans('Small headers').'</a>';
             if (!isset($headers['Flags']) || !stristr($headers['Flags'], 'draft')) {
                 $txt .= ' | <a class="reply_link hlink" href="?page=compose&amp;reply=1'.$reply_args.'">'.$this->trans('Reply').'</a>';
-                $txt .= ' | <a class="reply_all_link hlink" href="?page=compose&amp;reply_all=1'.$reply_args.'">'.$this->trans('Reply-all').'</a>';
+                if ($reply_all || $size > 1) {
+                    $txt .= ' | <a class="reply_all_link hlink" href="?page=compose&amp;reply_all=1'.$reply_args.'">'.$this->trans('Reply-all').'</a>';
+                }
+                else {
+                    $txt .= ' | <a class="reply_all_link hlink disabled_link">'.$this->trans('Reply-all').'</a>';
+                }
                 $txt .= ' | <a class="forward_link hlink" href="?page=compose&amp;forward=1'.$reply_args.'">'.$this->trans('Forward').'</a>';
             }
             if ($msg_part === '0') {


### PR DESCRIPTION
Cypht "reply to all": Should be available if there are more than one email in from, to and cc

## Pullrequest
Sending message to multiple emails, the reply all button will appear if there is only one email, the button is hidden.
link to the task: https://avan.tech/item72360-Cypht-reply-to-all-Should-be-available-if-there-are-more-than-one-email-in-from-to-and-cc 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] None

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
