### PR TITLE
Fix bug in PHP 8.1 when require lib/request.php due to $GLOBALS modif…

### DIFF
--- a/lib/request.php
+++ b/lib/request.php
@@ -150,7 +150,10 @@ class Hm_Request {
         $_FILES = array();
         $_REQUEST = array();
         $_ENV = array();
-        $GLOBALS = array();
+        
+        foreach (array_keys($GLOBALS) as $key) {
+            unset($GLOBALS[$key]);
+        }
     }
 
     /**


### PR DESCRIPTION
…ication changes

## Pullrequest

This pull request fixes an issue in PHP 8.1 that was failing with **Fatal Error** when requiring the file `lib/request.php` due to `$GLOBALS` modification.

```
Fatal error: $GLOBALS can only be modified using the $GLOBALS[$name] = $value syntax in /var/www/html/vendor/jason-munro/cypht/lib/request.php on line 153
```

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] Run the following code with PHP8.1 to see the issue: `php -r "require 'lib/request.php';"`

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
