### PR TITLE
Fix issue#516 (the requested PHP extension gd is missing from your system)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,12 +39,18 @@
         "ext-redis": "To use Redis for caching, this needs to be installed",
         "ext-gd": "To use 2fa, this needs to be installed for the QR code display",
         "ext-memcached": "To use Memcached for caching, this needs to be installed",
-        "ext-gnupg": "To use the PGP module set, this needs to be installed"
+        "ext-gnupg": "To use the PGP module set, this needs to be installed",
+        "ext-imagick":"To use 2fa, this needs to be installed for the QR code display"
     },
     "config": {
     	"optimize-autoloader": true,
         "allow-plugins": {
             "endroid/installer": false
         }
+    },
+    "scripts": {
+        "post-update-cmd": "composer suggest",
+        "post-package-install":"composer suggest",
+        "post-install-cmd": "composer suggest"
     }
 }

--- a/modules/2fa/modules.php
+++ b/modules/2fa/modules.php
@@ -54,6 +54,11 @@ class Hm_Handler_2fa_check extends Hm_Handler_Module {
             return;
         }
 
+        if(!extension_loaded('imagick')){
+            Hm_Msgs::add('ERR2FA The imagick extension is required to use 2fa feature, please contact your administrator for fixing this');
+            return;
+        }
+
         list($secret, $simple) = get_2fa_key($this->config);
         if (!$secret) {
             Hm_Debug::add('2FA module set enabled, but no shared secret configured');


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->

### Issues

- fixes #516 
- relates #562 

### Checklist

- [ ] Update composer dependency by running `composer update`


### How2Test

- [ ] Try to use the 2FA while the **Imagick** extension is not enabled
- [ ] Start A fresh composer install and see whether it passes when the **Imagick** extension is not enabled


### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
