### PR TITLE
[FIX] Add a handler for invalid imap email date

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -190,8 +190,10 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
                             $txt .= $this->html_safe($value).'</th></tr>';
                         }
                         elseif ($fld == 'date') {
-                            $dt = new DateTime($value);
-                            $value = sprintf('%s (%s)', $dt->format('c Z'), human_readable_interval($value));
+                            try {
+                                $dt = new DateTime($value);
+                                $value = sprintf('%s (%s)', $dt->format('c Z'), human_readable_interval($value));
+                            } catch (Exception $e) {}
                             $txt .= '<tr class="header_'.$fld.'"><th>'.$this->trans($name).'</th><td>'.$this->html_safe($value).'</td></tr>';
                         }
                         else {


### PR DESCRIPTION
## Pullrequest

Some messages come with invalid dates which can be parsed by DateTime object and throw error that break the email message to be displayed.

Related: https://avan.tech/item79430

### Issues
- [X] None