### PR TITLE
Added sieve configuration in nux for gandi

### DIFF
--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -169,14 +169,18 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
             if (Nux_Quick_Services::exists($form['nux_service'])) {
                 $details = Nux_Quick_Services::details($form['nux_service']);
                 $details['name'] = $form['nux_name'];
-                Hm_IMAP_List::add(array(
+                $imap_list = array(
                     'name' => $details['name'],
                     'server' => $details['server'],
                     'port' => $details['port'],
                     'tls' => $details['tls'],
                     'user' => $form['nux_email'],
                     'pass' => $form['nux_pass'],
-                ));
+                );
+                if (in_array($form['nux_service'], ['gandi']) && $this->module_is_supported('sievefilters')) {
+                    $imap_list['sieve_config_host'] = $details['sieve']['host'].':'.$details['sieve']['port'];
+                }
+                Hm_IMAP_List::add($imap_list);
                 $servers = Hm_IMAP_List::dump(false, true);
                 $ids = array_keys($servers);
                 $new_id = array_pop($ids);

--- a/modules/nux/services.php
+++ b/modules/nux/services.php
@@ -191,5 +191,9 @@ Nux_Quick_Services::add('gandi', array(
         'server' => 'mail.gandi.net',
         'port' => 465,
         'tls' => true
+    ),
+    'sieve' => array(
+        'port' => 4190,
+        'host' => 'mail.gandi.net'
     )
 ));


### PR DESCRIPTION
## Pullrequest
When adding a gandi server using nux, automatically enable sieve filters on it

### Issues
- relates https://avan.tech/item81897