### PR TITLE
Added callback handler to close inline message when archiving it

### DIFF
--- a/modules/inline_message/site.js
+++ b/modules/inline_message/site.js
@@ -177,7 +177,10 @@ $(function() {
             Hm_Ajax.add_callback_hook('*', capture_subject_click);
             Hm_Ajax.add_callback_hook('ajax_imap_delete_message', msg_inline_close);
             Hm_Ajax.add_callback_hook('ajax_imap_move_copy_action', msg_inline_close);
-            Hm_Ajax.add_callback_hook('ajax_imap_unread',msg_inline_close);
+            Hm_Ajax.add_callback_hook('ajax_imap_archive_message', msg_inline_close);
+            if (hm_list_path().substr(0, 4) !== 'imap') {
+                Hm_Ajax.add_callback_hook('ajax_imap_unread', msg_inline_close);
+            }
             if (hm_list_path().substr(0, 4) === 'imap') {
                 Hm_Ajax.add_callback_hook('ajax_imap_folder_display', capture_subject_click);
             }


### PR DESCRIPTION
## Pullrequest
We have the **show inline message** which allow us to view message side by side with message list. It works good in combined view. But elsewhere inline message closes on the next ajax call. 

Another issue is that Archive does close the inline message even if the message is deleted. And the message list isn't updated. This merge request solves these two issues.