### PR TITLE
Allow addition of non-sieve IMAP account

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1259,7 +1259,7 @@ class Hm_Handler_process_add_imap_server extends Hm_Handler_Module {
                         'port' => $form['new_imap_port'],
                         'tls' => $tls);
 
-                    if (isset($this->request->post['sieve_config_host'])) {
+                    if (isset($this->request->post['sieve_config_host']) && $this->request->post['sieve_config_host']) {
                         $imap_list['sieve_config_host'] = $this->request->post['sieve_config_host'];
                     }
                     Hm_IMAP_List::add($imap_list);

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -351,9 +351,10 @@ class Hm_Output_display_configured_imap_servers extends Hm_Output_Module {
                 $default_value = '';
                 if (isset($vals['sieve_config_host'])) {
                     $default_value = $vals['sieve_config_host'];
+                
+                    $res .=  '<span><label class="screen_reader" for="imap_sieve_host_'.$index.'">'.$this->trans('Sieve Host').'</label>'.
+                            '<input '.$disabled.' id="imap_sieve_host_'.$index.'" class="credentials imap_sieve_host_input" placeholder="Sieve Host" type="text" name="imap_sieve_host" value="'.$default_value.'"></span>';
                 }
-                $res .=  '<span><label class="screen_reader" for="imap_sieve_host_'.$index.'">'.$this->trans('Sieve Host').'</label>'.
-                         '<input '.$disabled.' id="imap_sieve_host_'.$index.'" class="credentials imap_sieve_host_input" placeholder="Sieve Host" type="text" name="imap_sieve_host" value="'.$default_value.'"></span>';
             }
 
             if (!isset($vals['user']) || !$vals['user']) {

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -1008,7 +1008,15 @@ $(function() {
     });
 
     $(document).on('keyup', '#new_imap_address', function () {
-        $('#sieve_config_host').val($(this).val() + ':4190')
+        if ($('#enable_sieve_filter').is(':checked') && $(this).val()) {
+            $('#sieve_config_host').val($(this).val() + ':4190');
+        } else {
+            $('#sieve_config_host').val('');
+        }
+    });
+
+    $(document).on('change', '#enable_sieve_filter', function () {
+        $('#new_imap_address').trigger('keyup');
     });
 
     $(document).on('click', '.checkbox_label', function(e) {


### PR DESCRIPTION
## Pullrequest
Non sieve IMAP account are not added in all cases (when sieve filters is checked or not). This merge request fixes that

### Issues
- relates https://avan.tech/item82261
