### PR TITLE
Prevent reloading page each time after hm_reload_folders has executed

### DIFF
--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -1145,6 +1145,7 @@ var Hm_Folders = {
             sessionStorage.clear();
             Hm_Utils.restore_local_settings(ui_state);
             Hm_Utils.expand_core_settings();
+            document.cookie = "hm_reload_folders=1; max-age=0";
             return true;
         }
         return false;


### PR DESCRIPTION
## Pullrequest
Some actions such as adding new server using nux modules, process github authorization force reloading folders. After that actions Hm_Utils.get_from_local_storage is always returning false because session storage is deleted on each page reload. This make previous/next email links impossible to see. This PR aims to delete the cookie after is has reloaded folders.

### Issues
- relates https://avan.tech/item60586
