### PR TITLE
ability to specify sieve client externally, so integrating apps can use a different factory

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1404,7 +1404,6 @@ class Hm_Handler_load_imap_servers_from_config extends Hm_Handler_Module {
      * This list is cached in the session between page loads by Hm_Handler_save_imap_servers
      */
     public function process() {
-        $this->out('sieve_filters_enabled', $this->module_is_supported('sievefilters'));
         $servers = $this->user_config->get('imap_servers', array());
         $added = false;
         $updated = false;
@@ -1803,12 +1802,6 @@ class Hm_Handler_imap_message_content extends Hm_Handler_Module {
                     $this->out('msg_text', $msg_text);
                     $this->out('msg_download_args', sprintf("page=message&amp;uid=%s&amp;list_path=imap_%s_%s&amp;imap_download_message=1", $form['imap_msg_uid'], $form['imap_server_id'], $form['folder']));
                     $this->out('msg_show_args', sprintf("page=message&amp;uid=%s&amp;list_path=imap_%s_%s&amp;imap_show_message=1", $form['imap_msg_uid'], $form['imap_server_id'], $form['folder']));
-
-                    $server = $this->user_config->get('imap_servers')[$this->request->post['imap_server_id']];
-
-                    if (array_key_exists('sieve_config_host', $server)) {
-                        $this->out('sieve_filters_enabled', $this->module_is_supported('sievefilters'));
-                    }
 
                     if (!$prefetch) {
                         clear_existing_reply_details($this->session);

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -282,10 +282,10 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
             $txt .= ' | <a class="hlink" id="copy_message" href="#">'.$this->trans('Copy').'</a>';
             $txt .= ' | <a class="hlink" id="move_message" href="#">'.$this->trans('Move').'</a>';
             $txt .= ' | <a class="archive_link hlink" id="archive_message" href="#">'.$this->trans('Archive').'</a>';
-            
+
             if ($this->get('sieve_filters_enabled')) {
                 $imap_server = Hm_IMAP_List::get($this->get('msg_server_id'), false);
-                if (isset($imap_server['sieve_config_host'])) {
+                if ($this->get('sieve_filters_client')) {
                     $txt .= ' | <a class="block_sender_link hlink" id="block_sender" href="#"><img src="'.Hm_Image_Sources::$lock.'" width="10px"></img> <span id="filter_block_txt">'.$this->trans('Block Sender').'</span></a>';
                 } else {
                     $txt .= ' | <span title="This functionality requires the email server support &quot;Sieve&quot; technology which is not provided. Contact your email provider to fix it or enable it if supported."><img src="'.Hm_Image_Sources::$lock.'" width="10px"></img> <span id="filter_block_txt">'.$this->trans('Block Sender').'</span></span>';

--- a/modules/sievefilters/setup.php
+++ b/modules/sievefilters/setup.php
@@ -5,6 +5,9 @@ if (!defined('DEBUG_MODE')) { die(); }
 handler_source('sieve_filters');
 output_source('sievefilters');
 
+add_module_to_all_pages('handler', 'sieve_filters_enabled', true, 'imap', 'load_imap_servers_from_config', 'after');
+add_handler('ajax_imap_message_content', 'sieve_filters_enabled_message_content', true, 'sievefilters', 'imap_message_content', 'after');
+
 setup_base_page('sieve_filters', 'core');
 setup_base_page('block_list', 'core');
 


### PR DESCRIPTION
Abstract the way sieve client is constructed, so we can use a different client in Tiki-Cypht integration - we need an internal custom one that saves filters in Tiki, so we can process them later in Tiki - this is in the case when IMAP server doesn't support sieve or we need extra functionality not supported in sieve.
Context: https://gitlab.com/tikiwiki/tiki/-/merge_requests/1837