### PR TITLE
Fixed bugs related to smtp compose form

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -122,9 +122,6 @@ function reply_to_address($headers, $type) {
             }
         }
     }
-    if (!array_key_exists('delivered-to', $headers) && array_key_exists('to', $headers)) {
-        list($parsed, $msg_to) = format_reply_address($headers['to'], $parsed); 
-    }
     if ($type == 'reply_all') {
         if ($delivered_address) {
             $parsed[] = $delivered_address;

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1037,8 +1037,8 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
         $imap_server_id = explode('_', $msg_path)[1];
         $imap_server = Hm_IMAP_List::get($imap_server_id, false);
         $reply_from = process_address_fld($reply['msg_headers']['From']);
-        
-        if ($reply_from[0]['email'] != $imap_server['user'] && strpos($to, $reply_from[0]['email']) === false) {
+       
+        if ($reply_type == 'reply_all' && $reply_from[0]['email'] != $imap_server['user'] && strpos($to, $reply_from[0]['email']) === false) {
             $to .= ', '.$reply_from[0]['label'].' '.$reply_from[0]['email'];
         }
         

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1041,6 +1041,14 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
         if ($reply_type == 'reply_all' && $reply_from[0]['email'] != $imap_server['user'] && strpos($to, $reply_from[0]['email']) === false) {
             $to .= ', '.$reply_from[0]['label'].' '.$reply_from[0]['email'];
         }
+
+        // Prevent sending message to oneself
+        if (strpos($reply_from[0]['email'], $to) !== false) {
+            $excluded = [$to];
+            $to = format_reply_address($reply['msg_headers']['To'], $excluded)[1]; 
+            $cc = format_reply_address($reply['msg_headers']['Cc'], $excluded)[1]; 
+            $bcc = format_reply_address($reply['msg_headers']['Bcc'], $excluded)[1];
+        }
         
         $send_disabled = '';
         if (count($this->get('smtp_servers', array())) == 0) {


### PR DESCRIPTION
Prevented reply to react like reply to all and also when an email is in cc instead of replying to who sent the mail we were responding to the recipient of the mail in from field.
Also prevented user to respond to the email he sent.

- relates https://avan.tech/item81605
