### PR TITLE
Fixed module re-assignment in sieve module

### DIFF
--- a/modules/sievefilters/setup.php
+++ b/modules/sievefilters/setup.php
@@ -64,8 +64,6 @@ add_output('ajax_sieve_delete_script', 'sieve_delete_output',  true);
 setup_base_ajax_page('ajax_sieve_block_unblock', 'core');
 add_handler('ajax_sieve_block_unblock', 'load_imap_servers_from_config', true, 'imap', 'load_user_data', 'after');
 add_handler('ajax_sieve_block_unblock', 'load_smtp_servers_from_config', true, 'imap', 'load_user_data', 'after');
-add_handler('ajax_sieve_block_unblock', 'login', false, 'core');
-add_handler('ajax_sieve_block_unblock', 'load_user_data',  true, 'core');
 add_handler('ajax_sieve_block_unblock', 'sieve_block_unblock_script',  true);
 add_output('ajax_sieve_block_unblock', 'sieve_block_unblock_output',  true);
 
@@ -73,15 +71,12 @@ add_output('ajax_sieve_block_unblock', 'sieve_block_unblock_output',  true);
 setup_base_ajax_page('ajax_sieve_unblock_sender', 'core');
 add_handler('ajax_sieve_unblock_sender', 'load_imap_servers_from_config', true, 'imap', 'load_user_data', 'after');
 add_handler('ajax_sieve_unblock_sender', 'load_smtp_servers_from_config', true, 'imap', 'load_user_data', 'after');
-add_handler('ajax_sieve_unblock_sender', 'login', false, 'core');
-add_handler('ajax_sieve_unblock_sender', 'load_user_data',  true, 'core');
 add_handler('ajax_sieve_unblock_sender', 'sieve_unblock_sender',  true);
 add_output('ajax_sieve_unblock_sender', 'sieve_block_unblock_output',  true);
 
 /* get mailboxes script */
 setup_base_ajax_page('ajax_sieve_get_mailboxes', 'core');
 add_handler('ajax_sieve_get_mailboxes', 'load_imap_servers_from_config', true, 'imap', 'load_user_data', 'after');
-add_handler('ajax_sieve_get_mailboxes', 'login', false, 'core');
 add_handler('ajax_sieve_get_mailboxes', 'settings_load_imap',  true);
 add_handler('ajax_sieve_get_mailboxes', 'sieve_get_mailboxes_script',  true);
 add_output('ajax_sieve_get_mailboxes', 'sieve_get_mailboxes_output',  true);
@@ -89,7 +84,6 @@ add_output('ajax_sieve_get_mailboxes', 'sieve_get_mailboxes_output',  true);
 /* get mailboxes script */
 setup_base_ajax_page('ajax_sieve_block_domain', 'core');
 add_handler('ajax_sieve_block_domain', 'load_imap_servers_from_config', true, 'imap', 'load_user_data', 'after');
-add_handler('ajax_sieve_block_domain', 'login', false, 'core');
 add_handler('ajax_sieve_block_domain', 'settings_load_imap',  true);
 add_handler('ajax_sieve_block_domain', 'sieve_block_domain_script',  true);
 add_output('ajax_sieve_block_domain', 'sieve_block_domain_output',  true);
@@ -98,7 +92,6 @@ add_output('ajax_sieve_block_domain', 'sieve_block_domain_output',  true);
 /* change blocking default behaviour */
 setup_base_ajax_page('ajax_sieve_block_change_behaviour', 'core');
 add_handler('ajax_sieve_block_change_behaviour', 'load_imap_servers_from_config', true, 'imap', 'load_user_data', 'after');
-add_handler('ajax_sieve_block_change_behaviour', 'login', false, 'core');
 add_handler('ajax_sieve_block_change_behaviour', 'settings_load_imap',  true);
 add_handler('ajax_sieve_block_change_behaviour', 'sieve_block_change_behaviour_script',  true);
 add_output('ajax_sieve_block_change_behaviour', 'sieve_block_change_behaviour_output',  true);


### PR DESCRIPTION
Removed "Already registered module"  warnings in sieve module.

- relates https://avan.tech/item84342
