### PR TITLE
Permit to turn off JMAP

### DIFF
--- a/hm3.sample.ini
+++ b/hm3.sample.ini
@@ -581,6 +581,11 @@ modules[]=feeds
 ; POP3 email account support
 modules[]=pop3
 
+; JMAP
+; ----
+; JSON Meta Application Protocol for emails
+modules[]=jmap
+
 ; IMAP
 ; ----
 ; IMAP email account support. If you want to use OAuth2 over IMAP (currently

--- a/hm3.sample.ini
+++ b/hm3.sample.ini
@@ -584,7 +584,7 @@ modules[]=pop3
 ; JMAP
 ; ----
 ; JSON Meta Application Protocol for emails
-modules[]=jmap
+;modules[]=jmap
 
 ; IMAP
 ; ----

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1282,7 +1282,7 @@ class Hm_Handler_process_add_imap_server extends Hm_Handler_Module {
                 }
             }
         }
-        $this->out('is_module_supported', $this->module_is_supported('jmap'));
+        $this->out('is_jmap_supported', $this->module_is_supported('jmap'));
     }
 }
 

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1282,6 +1282,7 @@ class Hm_Handler_process_add_imap_server extends Hm_Handler_Module {
                 }
             }
         }
+        $this->out('is_module_supported', $this->module_is_supported('jmap'));
     }
 }
 
@@ -1340,6 +1341,7 @@ class Hm_Handler_load_imap_servers_for_search extends Hm_Handler_Module {
         }
     }
 }
+
 
 /**
  * Load IMAP servers for message list pages

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -463,7 +463,7 @@ class Hm_Output_add_jmap_server_dialog extends Hm_Output_Module {
             return '';
         }
 
-        if(!$this->get('is_module_supported')){
+        if(!$this->get('is_jmap_supported')){
             return '<div class="jmap_server_setup"><div class="jmap_section" style="display: none;">';
          }
 

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -462,6 +462,11 @@ class Hm_Output_add_jmap_server_dialog extends Hm_Output_Module {
         if ($this->get('single_server_mode')) {
             return '';
         }
+
+        if(!$this->get('is_module_supported')){
+            return '<div class="jmap_server_setup"><div class="jmap_section" style="display: none;">';
+         }
+
         $count = count(array_filter($this->get('imap_servers', array()), function($v) { return array_key_exists('type', $v) && $v['type'] == 'jmap';}));
         $count = sprintf($this->trans('%d configured'), $count);
         return '<div class="jmap_server_setup"><div data-target=".jmap_section" class="server_section">'.


### PR DESCRIPTION
## Pullrequest

### Issues

- [X] The file `hm3.sample.ini` permits to turn off pop3, but not JMAP

### Checklist

- [X] Add the JMAP module entry in the hm3.sample.ini and turn it off by default
- [X] Hide the JMAP config entry on the servers page (?page=servers) when the JMAP module is not configured

### Related

[Make JMAP optional (default off)](https://avan.tech/item81902-Cypht-Make-JMAP-optional-default-off)
