### PR TITLE
Added drag and drop functionnality to cc, bcc and to fields

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -170,7 +170,7 @@ function format_reply_address($fld, $excluded) {
     if ($res) {
         return array($addr, implode(', ', array_map(function($v) {
             if (trim($v['label'])) {
-                return $v['label'].' '.$v['email'];
+                return str_replace([',', ';'], '', $v['label']).' '.$v['email'];
             }
             else {
                 return $v['email'];

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1062,14 +1062,14 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
             '<input type="hidden" name="compose_msg_uid" value="'.$this->html_safe($msg_uid).'" />'.
             '<input type="hidden" class="compose_draft_id" name="draft_id" value="'.$this->html_safe($draft_id).'" />'.
             '<input type="hidden" class="compose_in_reply_to" name="compose_in_reply_to" value="'.$this->html_safe($in_reply_to).'" />'.
-            '<div class="to_outer"><input autocomplete="off" value="'.$this->html_safe($to).
-            '" required name="compose_to" class="compose_to" type="text" placeholder="'.$this->trans('To').'" />'.
+            '<div class="to_outer"><div class="compose_container"><div class="bubbles"></div><input autocomplete="off" value="'.$this->html_safe($to).
+            '" required name="compose_to" class="compose_to" type="text" placeholder="'.$this->trans('To').'" /></div>'.
             '<a href="#" tabindex="-1" class="toggle_recipients">+</a></div><div id="to_contacts"></div>'.
-            '<div class="recipient_fields"><input autocomplete="off" value="'.$this->html_safe($cc).
+            '<div class="recipient_fields"><div class="compose_container"><div class="bubbles"></div><input autocomplete="off" value="'.$this->html_safe($cc).
             '" name="compose_cc" class="compose_cc" type="text" placeholder="'.$this->trans('Cc').
-            '" /><div id="cc_contacts"></div><input autocomplete="off" value="'.$this->html_safe($bcc).
+            '" /><div id="cc_contacts"></div></div><div class="compose_container" ><div class="bubbles"></div><input autocomplete="off" value="'.$this->html_safe($bcc).
             '" name="compose_bcc" class="compose_bcc" type="text" placeholder="'.$this->trans('Bcc').'" />'.
-            '</div><div id="bcc_contacts"></div><input value="'.$this->html_safe($subject).
+            '<div id="bcc_contacts"></div></div></div><input value="'.$this->html_safe($subject).
             '" required name="compose_subject" class="compose_subject" type="text" placeholder="'.
             $this->trans('Subject').'" /><textarea id="compose_body" name="compose_body" class="compose_body">'.
             $this->html_safe($body).'</textarea>';

--- a/modules/smtp/site.css
+++ b/modules/smtp/site.css
@@ -1,8 +1,9 @@
 .compose_page { width: 100%; height: 100%; min-height: 400px; background-color: #fff; width: 100%; }
 .compose_form { position: relative; display: block; padding: 20px; width: 80%; padding-left: 30px; padding-bottom: 0px; }
-.compose_bcc, .compose_cc, .compose_subject, .compose_to { padding: 5px; margin: 5px; width: 100%; }
-/*.compose_to { width: calc(100% - 25px); }*/
+.compose_bcc, .compose_cc, .compose_subject, .compose_to { padding: 5px; margin: 5px; width: 95%; }
+.compose_to, .compose_bcc, .compose_cc { border: unset; outline: none; white-space: nowrap; }
 .toggle_recipients { background-color: #fff; position: absolute; padding-left: 5px; right: 9px; top: 28px; font-size: 120%; }
+.compose_subject { width: 98%; padding: 11px 15px; }
 .compose_body { width: 100%; min-height: 300px; padding: 5px; margin: 5px; }
 .smtp_send { cursor: pointer; color: #666; font-size: 125%; padding: 10px; margin-top: 10px; }
 .smtp_send_archive { cursor: pointer; color: #666; font-size: 125%; padding: 10px; margin-top: 10px; margin-left: 10px; }
@@ -29,3 +30,9 @@
 .meter span {display: block; height: 100%; }
 .progress {background-color: #4323f5; animation: progressBar 1s ease-in-out; animation-fill-mode:both; }
 @keyframes progressBar { 0% { width: 0; } 100% { width: 100%; }}
+.compose_container { padding: 0 10px 0 0; border: 1px solid #ddd; margin-left: 5px; width: 100%; border-radius: 5px; margin-bottom: 10px; }
+.bubbles { display: inline-block; margin-left: 5px; background-color: #fff; cursor: pointer; padding: 5px 0; }
+.bubble { font-size: .9rem; border: 1px solid #ddd; border-radius: 4px; padding: 7px 14px; display: inline-block; }
+.bubble:hover { background-color: #eee; }
+.bubble:not(:first-child) { margin-left: 5px; }
+.bubble_close { font-size: 1.7em; float: right; margin-top: 9px; line-height: 0; margin-left: 7px; }


### PR DESCRIPTION
This pull request fixes https://github.com/jasonmunro/cypht/issues/577. 

It adds the drag and drop reordering functionality into the mail composer, with the ability to remove a recipient with a little X button next to them.

Relates: https://avan.tech/item81038