### PR TITLE
Add a way to customize the icons color with the fill attribute for svg icons

### DIFF
--- a/lib/output.php
+++ b/lib/output.php
@@ -70,6 +70,15 @@ class Hm_Output_HTTP extends Hm_Output {
  */
 class Hm_Image_Sources {
 
+    public static function __callStatic(string $method, array $parameters)
+    // This method adds a way to customize the svg icons according to your theme by adding the preferable icon color when calling Hm_Image_Sources
+    {
+        if (!property_exists('Hm_Image_Sources',$method)) {
+            return "";
+        }
+        return str_replace("width%3D%228%22%20height%3D%228%22%20",'fill%3D%22'.urlencode($parameters[0]).'%22%20width%3D%228%22%20height%3D%228%22%20',Hm_Image_Sources::${$method});
+    }
+
     public static $power = 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%228%22%20height%3D%228%22%20viewBox%3D%220%200%208%208%22%3E%0A%20%20%3Cpath%20d%3D%22M3%200v4h1v-4h-1zm-1.281%201.438l-.375.313c-.803.64-1.344%201.634-1.344%202.75%200%201.929%201.571%203.5%203.5%203.5s3.5-1.571%203.5-3.5c0-1.116-.529-2.11-1.344-2.75l-.375-.313-.625.781.375.313c.585.46.969%201.165.969%201.969%200%201.391-1.109%202.5-2.5%202.5s-2.5-1.109-2.5-2.5c0-.804.361-1.509.938-1.969l.406-.313-.625-.781z%22%0A%20%20%2F%3E%0A%3C%2Fsvg%3E';
     public static $home = 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%228%22%20height%3D%228%22%20viewBox%3D%220%200%208%208%22%3E%0A%20%20%3Cpath%20d%3D%22M4%200l-4%203h1v4h2v-2h2v2h2v-4.031l1%20.031-4-3z%22%20%2F%3E%0A%3C%2Fsvg%3E';
     public static $box = 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%228%22%20height%3D%228%22%20viewBox%3D%220%200%208%208%22%3E%0A%20%20%3Cpath%20d%3D%22M0%200v1h8v-1h-8zm0%202v5.906c0%20.06.034.094.094.094h7.813c.06%200%20.094-.034.094-.094v-5.906h-2.969v1.031h-2.031v-1.031h-3z%22%20%2F%3E%0A%3C%2Fsvg%3E';


### PR DESCRIPTION
## Pullrequest
When a user want to customize the icons color according to the theme change, instead of Hm_Image_Sources::$home bata we can now use Hm_Image_Sources::home("blue") or Hm_Image_Sources::home("#1a1a1a") or Hm_Image_Sources::home($icon_color_variable)  to determine the color.

### Issues
UI issue related to the icons when the user uses differents themes

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->

eg :
![image](https://user-images.githubusercontent.com/92297941/212768695-18a8d90a-a615-46e3-b5e2-44067ce49714.png)

![image](https://user-images.githubusercontent.com/92297941/212768605-f4331853-ad94-4e9c-a9d6-7c18843f3077.png)

- [X] None

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
