### PR TITLE
Added nice message when no accounts support sieve

### DIFF
--- a/modules/sievefilters/modules.php
+++ b/modules/sievefilters/modules.php
@@ -1246,9 +1246,11 @@ class Hm_Output_sievefilters_settings_accounts extends Hm_Output_Module {
         $mailboxes = $this->get('imap_accounts', array());
         $res = get_classic_filter_modal_content();
         $res .= get_script_modal_content();
+        $sieve_supported = 0;
         foreach($mailboxes as $mailbox) {
             $factory = get_sieve_client_factory($this->get('site_config'));
             $client = $factory->init($this->get('user_config'), $mailbox);
+            $sieve_supported += (int) $client;
             if ($client) {
                 $num_filters = sizeof(get_mailbox_filters($mailbox, false, $this->get('site_config'), $this->get('user_config')));
                 $res .= '<div class="sievefilters_accounts_item">';
@@ -1284,6 +1286,9 @@ class Hm_Output_sievefilters_settings_accounts extends Hm_Output_Module {
                             </div>';
                 $res .= '</div></div></div>';
             }
+        }
+        if ($sieve_supported == 0) {
+            $res .= '<div class="empty_list">None of the configured IMAP servers support Sieve</div>';
         }
         return $res;
     }


### PR DESCRIPTION
Relates:  - https://avan.tech/item81898

When none of the accounts permit Sieve, this PR adds a nicer error message  **None of the configured IMAP servers support Sieve**