### PR TITLE
Fix : create empty setting entry for carddav server

### DIFF
--- a/modules/carddav_contacts/modules.php
+++ b/modules/carddav_contacts/modules.php
@@ -225,6 +225,10 @@ class Hm_Handler_process_carddav_auth_settings extends Hm_Handler_Module {
         if (array_key_exists('carddav_passwords', $this->request->post)) {
             $passwords = $this->request->post['carddav_passwords'];
         }
+                
+        if(empty($settings)){
+            $settings = array_fill_keys(array_keys($users),[]);
+        }
         foreach ($settings as $name => $vals) {
             if (array_key_exists($name, $users)) {
                 $results[$name]['user'] = $users[$name];


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->
The CardDav module doesn't allow users to save contacts in a given address book

### Issues

- [X] fixes #640

### Checklist
<!-- Anything important to be thought of when deploying? -->
- [X] Config Update

### How2Test
<!-- Give a detailed description of how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests -->
- [X] Activate the carddav module in the `hm3.ini` file by adding modules[]=carddav_contacts
- [X] Move the carddav.ini file from `modules/carddav_contacts/carddav.ini` to your `app_data_dir` defined in your `hm3.ini`
- [X] Generate the production site
