### PR TITLE
Deactivate sieve from admin panel

### DIFF
--- a/hm3.sample.ini
+++ b/hm3.sample.ini
@@ -907,3 +907,7 @@ modules[]=keyboard_shortcuts
 ; Enable keyboard shortcuts
 ; Defaults to false
 ; default_setting_enable_keyboard_shortcuts=1
+
+; Enable sieve filter
+; Defaults to false
+; default_setting_enable_sieve_filter=true

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1567,7 +1567,7 @@ class Hm_Handler_imap_connect extends Hm_Handler_Module {
             list($success, $form) = $this->process_form(array('imap_user', 'imap_pass', 'imap_server_id'));
 
             $sieve_enabled = false;
-            if ($this->module_is_supported('sievefilters')) {
+            if ($this->module_is_supported('sievefilters') && $this->user_config->get('enable_sieve_filter_setting', true)) {
                 if (!isset($this->request->post['imap_sieve_host'])) {
                     foreach ($this->get('imap_servers', array()) as $index => $vals) {
                         if ($index == $form['imap_server_id']) {

--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -204,7 +204,7 @@ class Hm_Handler_process_folder_rename extends Hm_Handler_Module {
                 $old_folder = prep_folder_name($imap, $form['folder'], true);
                 $new_folder = prep_folder_name($imap, $form['new_folder'], false, $parent_str);
                 if ($new_folder && $old_folder && $imap->rename_mailbox($old_folder, $new_folder)) {
-                    if ($this->module_is_supported('sievefilters')) {
+                    if ($this->module_is_supported('sievefilters') && $this->user_config->get('enable_sieve_filter_setting', true)) {
                         $imap_servers = $this->user_config->get('imap_servers');
                         $imap_account = $imap_servers[$form['imap_server_id']];
                         $linked_mailboxes = get_sieve_linked_mailbox($imap_account, $this);
@@ -260,7 +260,7 @@ class Hm_Handler_process_folder_delete extends Hm_Handler_Module {
             $imap = Hm_IMAP_List::connect($form['imap_server_id'], $cache);
             if (is_object($imap) && $imap->get_state() == 'authenticated') {
                 $del_folder = prep_folder_name($imap, $form['folder'], true);
-                if ($this->module_is_supported('sievefilters')) {
+                if ($this->module_is_supported('sievefilters') && $this->user_config->get('enable_sieve_filter_setting', true)) {
                     if (is_mailbox_linked_with_filters($del_folder, $form['imap_server_id'], $this)) {
                         Hm_Msgs::add('ERRThis folder can\'t be deleted because it is used in a filter.');
                         return;
@@ -569,7 +569,7 @@ class Hm_Output_folders_page_link extends Hm_Output_Module {
 
 if (!hm_exists('get_sieve_linked_mailbox')) {
     function get_sieve_linked_mailbox ($imap_account, $module) {
-        if (!$module->module_is_supported('sievefilters')) {
+        if (!$module->module_is_supported('sievefilters') && $module->user_config->get('enable_sieve_filter_setting', true)) {
             return;
         }
         require_once VENDOR_PATH.'autoload.php';

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -177,7 +177,7 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                     'user' => $form['nux_email'],
                     'pass' => $form['nux_pass'],
                 );
-                if (in_array($form['nux_service'], ['gandi']) && $this->module_is_supported('sievefilters')) {
+                if (in_array($form['nux_service'], ['gandi']) && $this->module_is_supported('sievefilters') && $this->user_config->get('enable_sieve_filter_setting', true)) {
                     $imap_list['sieve_config_host'] = $details['sieve']['host'].':'.$details['sieve']['port'];
                 }
                 Hm_IMAP_List::add($imap_list);

--- a/modules/sievefilters/setup.php
+++ b/modules/sievefilters/setup.php
@@ -5,8 +5,9 @@ if (!defined('DEBUG_MODE')) { die(); }
 handler_source('sieve_filters');
 output_source('sievefilters');
 
-add_module_to_all_pages('handler', 'sieve_filters_enabled', true, 'imap', 'load_imap_servers_from_config', 'after');
+add_module_to_all_pages('handler', 'sieve_filters_enabled', true, 'sievefilters', 'load_imap_servers_from_config', 'after');
 add_handler('ajax_imap_message_content', 'sieve_filters_enabled_message_content', true, 'sievefilters', 'imap_message_content', 'after');
+add_handler('ajax_hm_folders', 'sieve_filters_enabled', true, 'core', 'load_user_data', 'after');
 
 setup_base_page('sieve_filters', 'core');
 setup_base_page('block_list', 'core');
@@ -22,7 +23,6 @@ add_output('block_list', 'blocklist_settings_start', true, 'sievefilters', 'cont
 add_output('block_list', 'blocklist_settings_accounts', true, 'sievefilters', 'blocklist_settings_start', 'after');
 add_handler('block_list', 'load_behaviour', true, 'sievefilters', 'load_user_data', 'after');
 add_handler('block_list', 'settings_load_imap', true, 'sievefilters', 'load_user_data', 'after');
-add_output('ajax_hm_folders', 'blocklist_settings_link', true, 'sievefilters', 'settings_menu_end', 'before');
 
 /* save filter */
 setup_base_ajax_page('ajax_sieve_save_filter', 'core');
@@ -96,6 +96,8 @@ add_handler('ajax_sieve_block_change_behaviour', 'settings_load_imap',  true);
 add_handler('ajax_sieve_block_change_behaviour', 'sieve_block_change_behaviour_script',  true);
 add_output('ajax_sieve_block_change_behaviour', 'sieve_block_change_behaviour_output',  true);
 
+add_handler('settings', 'process_enable_sieve_filter_setting', true, 'sievefilters', 'save_user_settings', 'before');
+add_output('settings', 'enable_sieve_filter_setting', true, 'sievefilters', 'start_general_settings', 'after');
 
 return array(
     'allowed_pages' => array(
@@ -139,6 +141,7 @@ return array(
         'imap_server_id' => FILTER_VALIDATE_INT,
         'folder' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
         'sender' => FILTER_UNSAFE_RAW,
-        'selected_behaviour' => FILTER_SANITIZE_FULL_SPECIAL_CHARS
+        'selected_behaviour' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'enable_sieve_filter' => FILTER_VALIDATE_INT,
     )
 );


### PR DESCRIPTION
This PR Permits to deactivate Sieve completely from admin panel. It also fixes **Enable Sieve Filters** checkbox when Adding an IMAP Server which was no longer there https://github.com/jasonmunro/cypht/issues/671

Relates: https://avan.tech/item84827