### PR TITLE
Added sieve configuration in hm3 ini

### DIFF
--- a/hm3.sample.ini
+++ b/hm3.sample.ini
@@ -94,6 +94,9 @@ imap_auth_port=143
 ; enable this. This is only for TLS enabled sockets (typically on port 993).
 imap_auth_tls=
 
+; The hostname and IP address and port sieve is listening on. Example: mail.abc.net:4190
+imap_auth_sieve_conf=
+
 
 ; POP3 Authentication
 ; -------------------

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -190,7 +190,7 @@ class Hm_Auth_IMAP extends Hm_Auth {
      */
     public function check_credentials($user, $pass) {
         $imap = new Hm_IMAP();
-        list($server, $port, $tls) = get_auth_config($this->site_config, 'imap');
+        list($server, $port, $tls, $sieve_config) = get_auth_config($this->site_config, 'imap');
         if (!$user || !$pass || !$server || !$port) {
             Hm_Debug::add($imap->show_debug(true));
             Hm_Debug::add('Invalid IMAP auth configuration settings');
@@ -198,7 +198,8 @@ class Hm_Auth_IMAP extends Hm_Auth {
         }
         $this->imap_settings = array('server' => $server, 'port' => $port,
             'tls' => $tls, 'username' => $user, 'password' => $pass,
-            'no_caps' => false, 'blacklisted_extensions' => array('enable')
+            'no_caps' => false, 'blacklisted_extensions' => array('enable'),
+            'sieve_config_host' => $sieve_config
         );
         return $this->check_connection($imap);
     }
@@ -390,5 +391,9 @@ function get_auth_config($config, $prefix) {
     $server = $config->get($prefix.'_auth_server', false);
     $port = $config->get($prefix.'_auth_port', false);
     $tls = $config->get($prefix.'_auth_tls', false);
-    return array($server, $port, $tls);
+    $ret = array($server, $port, $tls);
+    if ($prefix == 'imap') {
+        $ret[] = $config->get($prefix.'_auth_sieve_conf_host', false);
+    }
+    return $ret;
 }

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1442,15 +1442,19 @@ class Hm_Handler_load_imap_servers_from_config extends Hm_Handler_Module {
                 else {
                     $name = $this->config->get('imap_auth_name', 'Default');
                 }
-                Hm_IMAP_List::add(array( 
+                $imap_details = array( 
                     'name' => $name,
                     'default' => true,
                     'server' => $auth_server['server'],
                     'port' => $auth_server['port'],
                     'tls' => $auth_server['tls'],
                     'user' => $auth_server['username'],
-                    'pass' => $auth_server['password']),
-                $max);
+                    'pass' => $auth_server['password']
+                );
+                if (! empty($auth_server['sieve_config_host']) && count(explode(':', $auth_server['sieve_config_host'])) == 2) {
+                    $imap_details['sieve_config_host'] = $auth_server['sieve_config_host'];
+                }
+                Hm_IMAP_List::add($imap_details, $max);
             }
         }
     }

--- a/scripts/create_config.php
+++ b/scripts/create_config.php
@@ -99,6 +99,10 @@ function imap_auth_port_setting($current) {
     return '<tr><td>IMAP authentication server port</td><td><input type="number" value="'.$current.'" name="imap_auth_port" /></td></tr>';
 }
 
+function imap_auth_sieve_conf_host_setting($current) {
+    return '<tr><td>Sieve configuration</td><td><input type="number" value="'.$current.'" name="imap_auth_sieve_conf_host" /></td></tr>';
+}
+
 function imap_auth_server_setting($current) {
     return '<tr><td>IMAP authentication server hostname</td><td><input type="text" value="'.$current.'" name="imap_auth_server" /></td></tr>';
 }
@@ -249,6 +253,7 @@ function setting_defaults() {
             'imap_auth_server' => 'localhost',
             'imap_auth_port' => '143',
             'imap_auth_tls' => '',
+            'imap_auth_sieve_conf_host' => ''
         ),
         'POP3' => array(
             'pop3_auth_name' => 'localhost',


### PR DESCRIPTION
Fixes: https://github.com/jasonmunro/cypht/issues/671#issuecomment-1440362471

This PR helps enable sieve configuration when IMAP connection is added via the hm3.ini file