### PR TITLE
Fixed wrong config name in hm3 file

### DIFF
--- a/hm3.sample.ini
+++ b/hm3.sample.ini
@@ -94,8 +94,8 @@ imap_auth_port=143
 ; enable this. This is only for TLS enabled sockets (typically on port 993).
 imap_auth_tls=
 
-; The hostname and IP address and port sieve is listening on. Example: mail.abc.net:4190
-imap_auth_sieve_conf=
+; The hostname/IP address and port sieve is listening on. Example: example.org:4190
+imap_auth_sieve_conf_host=
 
 
 ; POP3 Authentication


### PR DESCRIPTION
Config is imap_auth_sieve_conf_host instead of imap_auth_sieve_conf