### PR TITLE
Fixed blank page for imap server added from hm3.ini

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1457,6 +1457,8 @@ class Hm_Handler_load_imap_servers_from_config extends Hm_Handler_Module {
                     $imap_details['sieve_config_host'] = $auth_server['sieve_config_host'];
                 }
                 Hm_IMAP_List::add($imap_details, $max);
+                $servers = Hm_IMAP_List::dump(false, true);
+                $this->user_config->set('imap_servers', $servers);
             }
         }
     }

--- a/modules/sievefilters/modules.php
+++ b/modules/sievefilters/modules.php
@@ -1261,8 +1261,8 @@ class Hm_Output_sievefilters_settings_accounts extends Hm_Output_Module {
         foreach($mailboxes as $mailbox) {
             $factory = get_sieve_client_factory($this->get('site_config'));
             $client = $factory->init($this->get('user_config'), $mailbox);
-            $sieve_supported += (int) $client;
             if ($client) {
+                $sieve_supported++;
                 $num_filters = sizeof(get_mailbox_filters($mailbox, false, $this->get('site_config'), $this->get('user_config')));
                 $res .= '<div class="sievefilters_accounts_item">';
                 $res .= '<div class="sievefilters_accounts_title settings_subtitle">' . $mailbox['name'];


### PR DESCRIPTION
When configuring imap server from hm3 config file, it was not added in imap servers user settings that was leading to a blank page unless ?/page=servers url was accessed.

Fixes https://github.com/jasonmunro/cypht/issues/671