### PR TITLE
Fixed warning when user clicked on compose

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1021,12 +1021,15 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
             $draft_id = $msg_uid;
         }
         
-        $imap_server_id = explode('_', $msg_path)[1];
-        $imap_server = Hm_IMAP_List::get($imap_server_id, false);
-        $reply_from = process_address_fld($reply['msg_headers']['From']);
-      
-        if ($reply_type == 'reply_all' && $reply_from[0]['email'] != $imap_server['user'] && strpos($to, $reply_from[0]['email']) === false) {
-            $to .= ', '.$reply_from[0]['label'].' '.$reply_from[0]['email'];
+        // User clicked on compose
+        if ($reply_type) {
+            $imap_server_id = explode('_', $msg_path)[1];
+            $imap_server = Hm_IMAP_List::get($imap_server_id, false);
+            $reply_from = process_address_fld($reply['msg_headers']['From']);
+    
+            if ($reply_type == 'reply_all' && $reply_from[0]['email'] != $imap_server['user'] && strpos($to, $reply_from[0]['email']) === false) {
+                $to .= ', '.$reply_from[0]['label'].' '.$reply_from[0]['email'];
+            }
         }
 
         $send_disabled = '';


### PR DESCRIPTION
When user clicks on compose, there is no reply_from nor message headers defined. This MR fixes warning that where thrown in such case.

Relates: https://app.glitchtip.com/evoludata/issues/1792897