### PR TITLE
Fixed sieve bug when deliver/stop filtering is the last or in middle of actions

### DIFF
--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -357,7 +357,7 @@ $(function () {
             let actions_value = $('[name^=sieve_selected_action_value]').map(function(idx, elem) {
                 return $(elem).val();
             }).get();
-            let actions_field_type = $('input[name^=sieve_selected_action_value]').map(function(idx, elem) {
+            let actions_field_type = $('[name^=sieve_selected_action_value]').map(function(idx, elem) {
                 return $(elem).attr('type');
             }).get();
             let actions_extra_value = $('input[name^=sieve_selected_extra_action_value]').map(function(idx, elem) {


### PR DESCRIPTION
Relates: https://github.com/jasonmunro/cypht/issues/679

When Deliver (Keep) / Stop filtering / Discard is in middle or last in actions list error **All fields of actions and conditions must be provided** is triggered when saving filter.

