### PR TITLE
Added to and cc fields when forwarding and email

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -232,7 +232,7 @@ function reply_lead_in($headers, $type, $to, $output_mod) {
     }
     elseif ($type == 'forward') {
         $flds = array();
-        foreach( array('From', 'Date', 'Subject') as $fld) {
+        foreach( array('From', 'Date', 'Subject', 'To', 'Cc') as $fld) {
             if (array_key_exists($fld, $headers)) {
                 $flds[$fld] = $headers[$fld];
             }


### PR DESCRIPTION
Fixes https://github.com/jasonmunro/cypht/issues/706

Forwarding email was missing the to and cc fields. This merge request adds them.