### PR TITLE
Fixed uncaught exception when htmlpurifier throws one

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -24,8 +24,12 @@ function format_msg_html($str, $images=false) {
     }
     $config->set('URI.AllowedSchemes', array('mailto' => true, 'data' => true, 'http' => true, 'https' => true));
     $config->set('Filter.ExtractStyleBlocks.TidyImpl', true);
-    $purifier = new HTMLPurifier($config);
-    return @$purifier->purify($str);
+    try {
+        $purifier = new HTMLPurifier($config);
+        return $purifier->purify($str);
+    } catch (Exception $e) {
+        return '';
+    }
 }}
 
 /**


### PR DESCRIPTION
With php >= 8 the @ error suppression operator does not silent fatal errors.