### PR TITLE
fix smtp selected email when using unsubscribe and other list links

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1356,7 +1356,7 @@ function smtp_server_dropdown($data, $output_mod, $recip, $selected_id=false) {
             if (count($smtp_profiles) > 0) {
                 foreach ($smtp_profiles as $index => $profile) {
                     $res .= '<option ';
-                    if ((string) $selected === sprintf('%s.%s', $id, ($index + 1))) {
+                    if ((string) $selected === sprintf('%s.%s', $id, ($index + 1)) || (! strstr(strval($selected), '.') && strval($selected) === strval($id))) {
                         $res .= 'selected="selected" ';
                     }
                     $res .= 'value="'.$output_mod->html_safe($id.'.'.($index+1)).'">';


### PR DESCRIPTION
Fix smtp selected email when using unsubscribe and other list links leading to compose page with from address not part of a full profile. Selected profile/server from the dropdown list was just the smtp server ID in that case and needed better checking when building the list to preselect the right profile.