### PR TITLE
Sieve: added more options to block/ban page

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1766,6 +1766,9 @@ class Hm_Handler_imap_message_content extends Hm_Handler_Module {
             $this->out('msg_server_id', $form['imap_server_id']);
             $this->out('msg_folder', $form['folder']);
             $this->out('msg_list_path', 'imap_'.$form['imap_server_id'].'_'.$form['folder']);
+            $this->out('site_config', $this->config);
+            $this->out('user_config', $this->user_config);
+            $this->out('imap_accounts', $this->user_config->get('imap_servers'), array());
             $this->out('show_pagination_links', $this->user_config->get('pagination_links_setting', true));
             $part = false;
             $prefetch = false;

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -284,9 +284,29 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
             $txt .= ' | <a class="archive_link hlink" id="archive_message" href="#">'.$this->trans('Archive').'</a>';
 
             if ($this->get('sieve_filters_enabled')) {
-                $imap_server = Hm_IMAP_List::get($this->get('msg_server_id'), false);
+                $server_id = $this->get('msg_server_id');
+                $imap_server = $this->get('imap_accounts')[$server_id];
                 if ($this->get('sieve_filters_client')) {
-                    $txt .= ' | <a class="block_sender_link hlink" id="block_sender" href="#"><img src="'.Hm_Image_Sources::$lock.'" width="10px"></img> <span id="filter_block_txt">'.$this->trans('Block Sender').'</span></a>';
+                    $sender = addr_parse($headers['From'])['email'];
+                    $domain = '*@'.get_domain($sender);
+                    $blocked_senders = get_blocked_senders_array($imap_server, $this->get('site_config'), $this->get('user_config'));
+                    $sender_blocked = in_array($sender, $blocked_senders);
+                    $domain_blocked = in_array($domain, $blocked_senders);
+                    $txt .= ' | <div style="display: inline-block;"><a class="block_sender_link hlink'.($domain_blocked || $sender_blocked ? '" id="unblock_sender" data-target="'.($domain_blocked? 'domain':'sender').'"' : ' dropdown-toggle"').' href="#"><img src="'.Hm_Image_Sources::$lock.'" width="10px"></img> <span id="filter_block_txt">'.$this->trans($domain_blocked ? 'Unblock Domain' : ($sender_blocked ? 'Unblock Sender' : 'Block Sender')).'</span></a>
+                    <div class="dropdown">'
+                    .'<form id="block_sender_form"><div><label>'.$this->trans('Who Is Blocked').'</label>'
+                    .'<select name="scope">'
+                    .'<option value="sender">'.$this->trans('This Sender').'</option>'
+                    .'<option value="domain">'.$this->trans('Whole domain').'</option></select></div>'
+                    .'<div><label>'.$this->trans('Action').'</label>'
+                    .'<select name="block_action" id="block_action">'
+                    .'<option value="default">'.$this->trans('Default action').'</option>'
+                    .'<option value="discard">'.$this->trans('Discard').'</option>'
+                    .'<option value="blocked">'.$this->trans('Move To Blocked').'</option>'
+                    .'<option value="reject_default">'.$this->trans('Reject With Default Message').'</option>'
+                    .'<option value="reject_with_message">'.$this->trans('Reject With Specific Message').'</option>'
+                    .'</select></div><div><button type="submit" id="block_sender">'.$this->trans('Block').'</button></div></form>'
+                    .'</div></div>';
                 } else {
                     $txt .= ' | <span title="This functionality requires the email server support &quot;Sieve&quot; technology which is not provided. Contact your email provider to fix it or enable it if supported."><img src="'.Hm_Image_Sources::$lock.'" width="10px"></img> <span id="filter_block_txt">'.$this->trans('Block Sender').'</span></span>';
                 }

--- a/modules/imap/site.css
+++ b/modules/imap/site.css
@@ -89,3 +89,10 @@
 .attached_image { margin-right: 20px; margin-bottom: 20px; height: 200px; }
 .attached_image_box { display: flex; flex-wrap: wrap; border-top: solid 1px #ddd; padding-top: 20px; padding-left: 20px; width: 100%; padding-bottom: 40px; }
 .list_meta { float: none; margin-left: 37%; }
+.dropdown { display: none; position: absolute; margin-top: 15px; background-color: #fff; border: 1px solid #ddd; box-shadow: 3px 3px 3px #ddd; font-variant: none;     min-width: 250px; }
+.dropdown a { padding: 8px; padding-left: 15px !important; padding-right: 15px !important; white-space: nowrap; font-size: 1rem; display: block !important; margin-right: 0; border: 0; cursor: pointer; }
+.dropdown a:hover { background-color: #eee; }
+#block_sender_form { padding: 15px; display: block; }
+#block_sender_form label, #block_sender_form select, #block_sender_form textarea, #block_sender_form button { display: block; margin: 3px 0; width: 100%; }
+#block_sender_form button { color: #fff; background-color: brown; cursor: pointer; }
+#block_sender_form label { text-transform: capitalize; }

--- a/modules/sievefilters/setup.php
+++ b/modules/sievefilters/setup.php
@@ -143,5 +143,8 @@ return array(
         'sender' => FILTER_UNSAFE_RAW,
         'selected_behaviour' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
         'enable_sieve_filter' => FILTER_VALIDATE_INT,
+        'scope' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'action' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'reject_message' => FILTER_SANITIZE_FULL_SPECIAL_CHARS
     )
 );

--- a/modules/sievefilters/site.css
+++ b/modules/sievefilters/site.css
@@ -416,3 +416,15 @@ table.filter_actions_modal_table th {
 .mobile table.filter_actions_modal_table td:last-child {
     border-bottom: 0;
 }
+
+.submit_default_behavior {
+    background-color: teal;
+    color: #fff;
+    margin-left: 5px;
+    padding-inline: 10px;
+    cursor: pointer;
+}
+
+.select_default_reject_message {
+    margin-left: 5px;
+}

--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -171,13 +171,37 @@ $(function () {
 
     if (hm_page_name() === 'block_list') {
         $(document).on('change', '.select_default_behaviour', function(e) {
-            let elem = $(this);
+            if ($(this).val() == 'Discard') {
+                // $(this).closest('.filter_subblock')
+                //     .find('.submit_default_behavior')
+                //     .toggle('click');
+                $(this).closest('.filter_subblock')
+                    .find('.select_default_reject_message')
+                    .remove();
+            } else {
+                $('<input type="text" class="select_default_reject_message" placeholder="Reject message" />').insertAfter($(this));
+            }
+        });
+        $(document).on('click', '.submit_default_behavior', function(e) {
+            let parent = $(this).closest('.filter_subblock');
+            let elem = parent.find('.select_default_behaviour');
+            let submit = $(this);
+
+            const payload = [
+                {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_block_change_behaviour'},
+                {'name': 'selected_behaviour', 'value': elem.val()},
+                {'name': 'imap_server_id', 'value': elem.attr('imap_account')}
+            ];
+            if (elem.val() == 'Reject') {
+                const reject = parent.find('.select_default_reject_message');
+                payload.push({'name': 'reject_message', 'value': reject.val()});
+            }
+
+            submit.css('opacity', '0.3');
             Hm_Ajax.request(
-                [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_block_change_behaviour'},
-                    {'name': 'selected_behaviour', 'value': elem.val()},
-                    {'name': 'imap_server_id', 'value': elem.attr('imap_account')}
-                ],
+                payload,
                 function(res) {
+                    submit.css('opacity', '1');
                     console.log(res);
                 }
             );


### PR DESCRIPTION
This merge request adds more options to block/ban page

It helps users to know who is blocked offering the possibility to block
- The whole domain
- Specific email

Also it helps choose the action to be executed
- Default action: This is specified in the block_list page where users choose the default action (Discard/Reject with a default message)
- Discard
- Move to Banned folder
- Reject with default message
- Reject with specific message

Relates: https://avan.tech/item92586
 