### PR TITLE
fix(backend): bulk import file links

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,6 +73,7 @@ RUN if [ "$WITH_DEBUG" = "true" ]; then \
 
 RUN composer install
 
+COPY assets/ assets/
 COPY config/ config/
 COPY language/ language/
 COPY lib/ lib/


### PR DESCRIPTION
Related issue: https://github.com/cypht-org/cypht/issues/1532

In development mode, everything works as expected. However, in the Docker image, some functionality is broken — likely due to a missing COPY directive in the Dockerfile.

This PR adds the missing COPY assets/ assets/ line to ensure all required resources (including bulk import samples) are included in the image.

<img width="1424" alt="Screenshot 2025-06-19 at 15 35 52" src="https://github.com/user-attachments/assets/9094fef3-95c5-4698-8023-9148fdf20d82" />
