### PR TITLE
fix(frontend): saved search navigating with null value

### DIFF
--- a/modules/core/navigation/navigation.js
+++ b/modules/core/navigation/navigation.js
@@ -64,7 +64,10 @@ function autoAppendParamsForNavigation(href)
                 }
             } else {
                 for (let field of ['list_page', 'search_terms', 'search_fld', 'search_since', 'sort']) {
-                    target.set(field, currentUrl.searchParams.get(field));
+                    const val = currentUrl.searchParams.get(field);
+                    if (val !== null && !target.has(field)) {
+                        target.set(field, val);
+                    }
                 }
             }
             return href.split('?')[0] + '?' + target.toString();

--- a/modules/saved_searches/modules.php
+++ b/modules/saved_searches/modules.php
@@ -111,6 +111,7 @@ class Hm_Handler_save_search extends Hm_Handler_Module {
                 $this->user_config->set('saved_searches', $searches->dump());
                 $this->session->set('user_data', $this->user_config->dump());
                 $this->out('saved_search', true);
+                Hm_Msgs::add('Search saved', 'success');
             }
             else {
                 Hm_Msgs::add('You already have a search by that name', 'warning');

--- a/modules/saved_searches/setup.php
+++ b/modules/saved_searches/setup.php
@@ -58,7 +58,10 @@ return array(
         'ajax_update_save_search_label',
     ),
     'allowed_get' => array(
-        'search_name' => FILTER_SANITIZE_FULL_SPECIAL_CHARS
+        'search_name' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'search_terms' => FILTER_UNSAFE_RAW,
+        'search_fld' => FILTER_UNSAFE_RAW,
+        'search_since' => FILTER_UNSAFE_RAW,
     ),
     'allowed_post' => array(
         'search_name' => FILTER_UNSAFE_RAW,


### PR DESCRIPTION
### Description

This PR improves the logic in `autoAppendParamsForNavigation()` to prevent valid query parameters from being overwritten with `null`.

Normally, the `else` block could be removed entirely, since `target` already contains all necessary data from the clicked link. However, it's unclear if `currentUrl.searchParams.get(field)` might be needed in edge cases elsewhere.

As a compromise, the logic is kept, but now guarded: parameters are only set if they **do not already exist** in `target` and are **not null**. This prevents overwriting valid values (e.g., `search_terms=steven`) with `null` when navigating from pages like `?page=save`.

### Changes

- Added conditional check before setting fallback params from `currentUrl`
- Prevented `target.set()` when the param already exists or is null

### Why

To fix a bug where `search_terms`, `search_fld`, etc., were being reset to `null` when navigating between pages, even though they were present in the original link.

Reported at https://avan.tech/item136195#threadId91683
