### PR TITLE
fix(frontend): insert pagination after message_table and not before

### DIFF
--- a/modules/core/js_modules/markup/pagination.js
+++ b/modules/core/js_modules/markup/pagination.js
@@ -27,7 +27,7 @@ function showPagination (totalPages) {
         $('.message_list .pagination').remove();
     }
     if (totalPages > 1) {
-        $(paginationMarkup(totalPages)).insertBefore('.message_table');
+        $(paginationMarkup(totalPages)).insertAfter('.message_table');
         handlePagination();
         refreshNextButton(getParam('list_page') || 1);
         refreshPreviousButton(getParam('list_page') || 1);


### PR DESCRIPTION
As requested in the previous Cypht meeting, the pagination should be placed at the end (after the message_table) rather than before. This makes it easier to paginate while scrolling, as users won’t need to scroll back up.