### PR TITLE
refactor(backend): improve block page performance by reusing Sieve connections

### DIFF
--- a/modules/sievefilters/functions.php
+++ b/modules/sievefilters/functions.php
@@ -627,7 +627,6 @@ if (!hm_exists('get_sieve_linked_mailbox')) {
                     $folders[$s] = $obj->value;
                 }
             }
-            $client->close();
             return $folders;
         } catch (Exception $e) {
             Hm_Msgs::add("Sieve: {$e->getMessage()}", "danger");

--- a/modules/sievefilters/hm-sieve.php
+++ b/modules/sievefilters/hm-sieve.php
@@ -4,9 +4,16 @@
 require_once APP_PATH.'modules/sievefilters/functions.php';
 
 class Hm_Sieve_Client_Factory {
+    private static $instances = [];
+
     public function init($user_config = null, $imap_account = null, $is_nux_supported = false)
     {
         if ($imap_account && ! empty($imap_account['sieve_config_host'])) {
+            $cache_key = md5($imap_account['sieve_config_host'].'|'.$imap_account['user']);
+            if (isset(self::$instances[$cache_key])) {
+                return self::$instances[$cache_key];
+            }
+
             // Check if module nux is enabled and if it is, get the sieve host from the services
             if($is_nux_supported && $sieve_config = get_sieve_host_from_services($imap_account['server'])) {
                 $sieve_host = $sieve_config['host'];
@@ -17,6 +24,7 @@ class Hm_Sieve_Client_Factory {
             }
             $client = new PhpSieveManager\ManageSieve\Client($sieve_host, $sieve_port);
             $client->connect($imap_account['user'], $imap_account['pass'], $sieve_tls, "", "PLAIN");
+            self::$instances[$cache_key] = $client;
             return $client;
         } else {
             $errorMsg = 'Invalid config host';

--- a/modules/sievefilters/modules.php
+++ b/modules/sievefilters/modules.php
@@ -41,7 +41,6 @@ class Hm_Handler_sieve_edit_filter extends Hm_Handler_Module {
             } else {
                 $this->out('test_type', 'ANYOF');
             }
-            $client->close();
         } catch (Exception $e) {
             Hm_Msgs::add("Sieve: {$e->getMessage()}", "danger");
             return;
@@ -109,7 +108,6 @@ class Hm_Handler_sieve_edit_script extends Hm_Handler_Module {
         try {
             $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
             $script = $client->getScript($this->request->post['sieve_script_name']);
-            $client->close();
             $this->out('script', $script);
         } catch (Exception $e) {
             Hm_Msgs::add("Sieve: {$e->getMessage()}", "danger");
@@ -158,7 +156,6 @@ class Hm_Handler_sieve_delete_filter extends Hm_Handler_Module {
             $main_script = generate_main_script($scripts);
             save_main_script($client, $main_script, $scripts);
             $client->activateScript('main_script');
-            $client->close();
             Hm_Msgs::add('Script removed');
         } catch (Exception $e) {
             Hm_Msgs::add("Sieve: {$e->getMessage()}", "danger");
@@ -198,7 +195,6 @@ class Hm_Handler_sieve_delete_script extends Hm_Handler_Module {
 
             save_main_script($client, $main_script, $scripts);
             $client->activateScript('main_script');
-            $client->close();
             Hm_Msgs::add('Script removed');
         } catch (Exception $e) {
             Hm_Msgs::add("Sieve: {$e->getMessage()}", "danger");
@@ -277,7 +273,6 @@ class Hm_Handler_sieve_block_domain_script extends Hm_Handler_Module {
             );
             save_main_script($client, $main_script, $scripts);
             $client->activateScript('main_script');
-            $client->close();
             $this->out('reload_page', true);
         } catch (Exception $e) {
             Hm_Msgs::add("Sieve: {$e->getMessage()}", "danger");
@@ -439,7 +434,6 @@ class Hm_Handler_sieve_unblock_sender extends Hm_Handler_Module {
             );
             save_main_script($client, $main_script, $scripts);
             $client->activateScript('main_script');
-            $client->close();
 
             if ($unblock_sender) {
                 Hm_Msgs::add('Sender Unblocked');
@@ -610,7 +604,6 @@ class Hm_Handler_sieve_block_unblock_script extends Hm_Handler_Module {
             );
             save_main_script($client, $main_script, $scripts);
             $client->activateScript('main_script');
-            $client->close();
 
             if (isset($this->request->post['change_behavior'])) {
                 Hm_Msgs::add($scope_title . ' Behavior Changed');
@@ -1032,7 +1025,6 @@ class Hm_Handler_sieve_save_filter extends Hm_Handler_Module {
 
             save_main_script($client, $main_script, $scripts);
             $client->activateScript('main_script');
-            $client->close();
             Hm_Msgs::add('Filter saved');
         } catch (Exception $e) {
             Hm_Msgs::add("Sieve: {$e->getMessage()}", "danger");
@@ -1071,7 +1063,6 @@ class Hm_Handler_sieve_save_script extends Hm_Handler_Module {
                 $script_name,
                 $this->request->post['script']
             );
-            $client->close();
             Hm_Msgs::add('Script saved');
         } catch (Exception $e) {
             Hm_Msgs::add("Sieve: {$e->getMessage()}", "danger");
@@ -1535,7 +1526,6 @@ class Hm_Handler_sieve_toggle_script_state extends Hm_Handler_Module {
             $main_script = generate_main_script($scripts);
             save_main_script($client, $main_script, $scripts);
             $client->activateScript('main_script');
-            $client->close();
 
             Hm_Msgs::add("Script $state");
         } catch (Exception $e) {
@@ -1732,7 +1722,6 @@ class Hm_Handler_load_custom_actions extends Hm_Handler_Module
                     ];
                 }
             }
-            $client->close();
         } catch (Exception $e) {
             Hm_Msgs::add("Sieve: {$e->getMessage()}", "danger");
         }
@@ -1827,7 +1816,6 @@ class Hm_Handler_sieve_remame_folder extends Hm_Handler_Module
                             $script_parsed
                         );
                     }
-                    $client->close();
                     Hm_Msgs::add('Sieve filters using the folder were also updated to use the new folder name.', 'info');
                 } catch (Exception $e) {
                     Hm_Msgs::add("Failed to rename folder in sieve scripts", "warning");

--- a/tests/phpunit/modules/sievefilters/functions.php
+++ b/tests/phpunit/modules/sievefilters/functions.php
@@ -362,4 +362,51 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
         $this->assertStringContainsString('project archive', $result['list']);
         $this->assertStringNotContainsString('external-script', $result['list']);
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_client_factory_returns_cached_client_for_same_account() {
+        require_once APP_PATH.'modules/sievefilters/hm-sieve.php';
+
+        $imap_account = array(
+            'sieve_config_host' => 'tls://sieve.example.com:4190',
+            'user' => 'alice@example.com',
+        );
+        $cache_key = md5($imap_account['sieve_config_host'].'|'.$imap_account['user']);
+        $cached_client = $this->createMock(PhpSieveManager\ManageSieve\Client::class);
+
+        $instances = (new ReflectionClass(Hm_Sieve_Client_Factory::class))->getProperty('instances');
+        $instances->setAccessible(true);
+        $instances->setValue(null, array($cache_key => $cached_client));
+
+        $client = (new Hm_Sieve_Client_Factory())->init(null, $imap_account, false);
+
+        $this->assertSame($cached_client, $client);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_client_factory_cache_is_keyed_per_account() {
+        require_once APP_PATH.'modules/sievefilters/hm-sieve.php';
+
+        $alice_account = array('sieve_config_host' => 'tls://sieve.example.com:4190', 'user' => 'alice@example.com');
+        $bob_account = array('sieve_config_host' => 'tls://sieve.example.com:4190', 'user' => 'bob@example.com');
+        $alice_key = md5($alice_account['sieve_config_host'].'|'.$alice_account['user']);
+        $bob_key = md5($bob_account['sieve_config_host'].'|'.$bob_account['user']);
+        $alice_client = $this->createMock(PhpSieveManager\ManageSieve\Client::class);
+        $bob_client = $this->createMock(PhpSieveManager\ManageSieve\Client::class);
+
+        $instances = (new ReflectionClass(Hm_Sieve_Client_Factory::class))->getProperty('instances');
+        $instances->setAccessible(true);
+        $instances->setValue(null, array($alice_key => $alice_client, $bob_key => $bob_client));
+
+        $factory = new Hm_Sieve_Client_Factory();
+
+        $this->assertSame($alice_client, $factory->init(null, $alice_account, false));
+        $this->assertSame($bob_client, $factory->init(null, $bob_account, false));
+    }
 }


### PR DESCRIPTION
As discussed with @kroky via telegram, we aim to minimize the number of Sieve server reconnections to improve the block page performance.