### PR TITLE
fix(backend): xdebug ini file location and remove COPY

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN set -e \
 RUN printf "[xdebug] \n\
 zend_extension=xdebug.so \n\
 xdebug.mode=debug \n\
-xdebug.client_host=host.docker.internal" > /tmp/xdebug.ini
+xdebug.client_host=host.docker.internal" > /usr/local/etc/php/conf.d/xdebug.ini
 
 RUN printf "post_max_size = 60M \n\
 upload_max_filesize = 50M \n\
@@ -64,7 +64,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 
 COPY docker/nginx.conf /etc/nginx/nginx.conf
 COPY docker/supervisord.conf /etc/supervisord.conf
-COPY docker/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
 # Application and config files
 COPY composer.* ./


### PR DESCRIPTION
fix COPY issue with docker
It was: `COPY docker/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini`

<img width="713" height="205" alt="Screenshot 2025-08-13 at 02 02 00" src="https://github.com/user-attachments/assets/d257499b-94d0-4e74-a20d-3c8cc8bdabf2" />
