### PR TITLE
fix(backend): exclude_auto_bcc causes some unrelated messages to disappear from the inbox

### DIFF
--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -2314,7 +2314,7 @@ if (!class_exists('Hm_IMAP')) {
          * @param string $filter can be one of ALL, SEEN, UNSEEN, ANSWERED, UNANSWERED, DELETED, UNDELETED, FLAGGED, or UNFLAGGED
          * @return array list of IMAP message UIDs
          */
-        public function get_message_sort_order($sort='ARRIVAL', $reverse=true, $filter='ALL', $terms=array(), $exclude_deleted=true, $exclude_auto_bcc=true, $only_auto_bcc=false) {
+        public function get_message_sort_order($sort='ARRIVAL', $reverse=true, $filter='ALL', $terms=array(), $exclude_deleted=true, $exclude_auto_bcc=false, $only_auto_bcc=false) {
             if (!$this->is_clean($sort, 'keyword') || !$this->is_clean($filter, 'keyword') || !$this->is_supported('SORT')) {
                 return [];
             }


### PR DESCRIPTION
Some emails were being excluded from the mailbox due to the `NOT HEADER X-Auto-Bcc cypht` filter. After debugging, it was found that this filter matches messages containing the keywords `header`, `auto`, `cypht`, etc., anywhere in the message, including the subject or body. This caused some emails in my inbox not to appear, even though they were visible in earlier versions.

This [thread](https://github.com/cypht-org/cypht/issues/1540#issuecomment-3226086175) is a perfect example: all related emails in it are not shown.