### PR TITLE
fix(frontend): collapsed sidebar layout appears slightly broken

### DIFF
--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -1,5 +1,5 @@
 :root {
-  --nav-collapsed-size: 140px;
+  --nav-collapsed-size: 130px;
   --nav-expanded-size: 320px;
   --nav-size: var(--nav-expanded-size);
 }


### PR DESCRIPTION
The sidebar spacing got adjusted in https://github.com/cypht-org/cypht/pull/1653, though it seems the collapsed state was missed.