### PR TITLE
fix(frontend/backend): advanced search not displaying any messages

### DIFF
--- a/modules/advanced_search/modules.php
+++ b/modules/advanced_search/modules.php
@@ -370,7 +370,20 @@ class Hm_Output_filter_imap_advanced_search extends Hm_Output_Module {
      */
     protected function output() {
         if ($this->get('imap_search_results')) {
-            prepare_imap_message_list($this->get('imap_search_results'), $this, 'advanced_search');
+            $adv_search_result = format_imap_message_list(
+                $this->get('imap_search_results'), 
+                $this, 
+                'advanced_search',
+                'email'
+            );
+            
+            // Convert format (ID => [HTML, ID]) to format expected (HTML => ID)
+            $res = array();
+            foreach ($adv_search_result as $id => $row_data) {
+                $res[$row_data[0]] = $id;
+            }
+            
+            $this->out('formatted_message_list', $res);
         }
         elseif (!$this->get('formatted_message_list')) {
             $this->out('formatted_message_list', array());


### PR DESCRIPTION
This PR resolves a critical bug where the advanced search functionality failed to display messages in the UI, even though the server was returning valid data successfully. The issue was caused by an incorrect handling of the response data structure in the core message list update logic.