### PR TITLE
fix(frontend): enhance focus management for compose page based on email scenario

### DIFF
--- a/modules/smtp/js_modules/route_handlers.js
+++ b/modules/smtp/js_modules/route_handlers.js
@@ -195,13 +195,23 @@ function applySmtpComposePageHandlers() {
     if ($('.compose_cc').val() || $('.compose_bcc').val()) {
         toggle_recip_flds();
     }
+    // Handle focus management for different compose scenarios
     if (window.location.href.search('&reply=1') !== -1 || window.location.href.search('&reply_all=1') !== -1) {
         replace_cursor_positon ($('textarea[name="compose_body"]'));
     }
-    if (window.location.href.search('&forward=1') !== -1) {
+    else if (window.location.href.search('&forward=1') !== -1) {
+        replace_cursor_positon ($('textarea[name="compose_body"]'));
         setTimeout(function() {
             save_compose_state();
         }, 100);
+    }
+    else {
+        var toField = $('.compose_to');
+        if (toField.val().trim() === '') {
+            toField.focus();
+        } else {
+            $('textarea[name="compose_body"]').focus();
+        }
     }
     if ($('.sys_messages').text() != 'Message Sent') {
         get_smtp_profile($('.compose_server').val());


### PR DESCRIPTION
[Related task](https://avan.tech/item45559)

****Issue:** Cursor not placed correctly when replying/forwarding emails.
Fix:** Enhanced focus management to place cursor in the appropriate field:

- Reply/Forward → message body
- New compose (empty To) → "To" field
- New compose (pre-filled To) → message body