### PR TITLE
fix(backend): skip servers with failed connections in IMAP message list handler

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1394,6 +1394,13 @@ class Hm_Handler_imap_message_list extends Hm_Handler_Module {
         foreach ($ids as $key => $id) {
             $details = Hm_IMAP_List::dump($id);
             $mailbox = Hm_IMAP_List::get_connected_mailbox($id, $this->cache);
+
+            if (!$mailbox || !$mailbox->authed()) {
+                $server_name = isset($details['name']) && $details['name'] ? $details['name'] : $id;
+                Hm_Msgs::add(sprintf('Unable to connect to IMAP server "%s".', $server_name), 'warning');
+                continue;
+            }
+
             if($this->get('list_path') == 'snoozed' && !$mailbox->folder_exists('Snoozed')) {
                 continue;
             }

--- a/tests/selenium/base.py
+++ b/tests/selenium/base.py
@@ -158,6 +158,34 @@ class WebTest:
         print(" - finding element by class {0}".format(class_name))
         return self.driver.find_element(By.CLASS_NAME, class_name)
 
+    def visible_by_class(self, class_name):
+        print(" - finding visible element by class {0}".format(class_name))
+        elements = self.driver.find_elements(By.CLASS_NAME, class_name)
+        for element in elements:
+            try:
+                if element.is_displayed():
+                    return element
+            except exceptions.StaleElementReferenceException:
+                continue
+        raise exceptions.NoSuchElementException(
+            f"No visible element found with class name '{class_name}'"
+        )
+
+    def wait_for_class_text_contains(self, class_name, expected_text, timeout=60):
+        print(f" - waiting for class {class_name} to contain '{expected_text}'")
+        def _condition(driver):
+            elements = driver.find_elements(By.CLASS_NAME, class_name)
+            for element in elements:
+                try:
+                    if element.is_displayed():
+                        text = element.text.strip()
+                        if expected_text in text:
+                            return element
+                except exceptions.StaleElementReferenceException:
+                    continue
+            return False
+        return WebDriverWait(self.driver, timeout).until(_condition)
+
     def wait_for_element_by_class(self, class_name, timeout=60):
         """Wait for an element to be present and visible by class name"""
         print(" - waiting for element by class {0}".format(class_name))

--- a/tests/selenium/pages.py
+++ b/tests/selenium/pages.py
@@ -21,8 +21,7 @@ class PageTests(WebTest):
         self.safari_workaround()
         self.wait_for_navigation_to_complete()
         # More flexible text matching for search page
-        self.wait_on_class('content_title')
-        content_title = self.by_class('content_title')
+        content_title = self.wait_for_class_text_contains('content_title', 'Search')
         title_text = content_title.text.strip()
         print(f"MESSAGES FOUND: '{title_text}'")
         assert 'Search' in title_text or 'search' in title_text.lower(), f"Expected 'Search' in title, got: '{title_text}'"
@@ -36,12 +35,12 @@ class PageTests(WebTest):
         self.wait_for_navigation_to_complete()
         # Look for mailbox_list_title inside content_title
         try:
-            mailbox_title = self.by_class('mailbox_list_title')
+            mailbox_title = self.wait_for_class_text_contains('mailbox_list_title', 'Sent')
             title_text = mailbox_title.text.strip()
             assert 'Sent' in title_text, f"Expected 'Sent' in mailbox title, got: '{title_text}'"
         except:
             # Fallback: check content_title for sent-related text
-            content_title = self.by_class('content_title')
+            content_title = self.wait_for_class_text_contains('content_title', 'Sent')
             title_text = content_title.text.strip()
             assert 'Sent' in title_text, f"Expected 'Sent' in content title, got: '{title_text}'"
 
@@ -54,12 +53,12 @@ class PageTests(WebTest):
         self.wait_for_navigation_to_complete()
         # Look for mailbox_list_title inside content_title
         try:
-            mailbox_title = self.by_class('mailbox_list_title')
+            mailbox_title = self.wait_for_class_text_contains('mailbox_list_title', 'Unread')
             title_text = mailbox_title.text.strip()
             assert 'Unread' in title_text, f"Expected 'Unread' in mailbox title, got: '{title_text}'"
         except:
             # Fallback: check content_title for unread-related text
-            content_title = self.by_class('content_title')
+            content_title = self.wait_for_class_text_contains('content_title', 'Unread')
             title_text = content_title.text.strip()
             assert 'Unread' in title_text, f"Expected 'Unread' in content title, got: '{title_text}'"
 
@@ -74,12 +73,12 @@ class PageTests(WebTest):
         self.wait_for_navigation_to_complete()
         # Look for mailbox_list_title inside content_title
         try:
-            mailbox_title = self.by_class('mailbox_list_title')
+            mailbox_title = self.wait_for_class_text_contains('mailbox_list_title', 'Everything')
             title_text = mailbox_title.text.strip()
             assert 'Everything' in title_text, f"Expected 'Everything' in mailbox title, got: '{title_text}'"
         except:
             # Fallback: check content_title for everything-related text
-            content_title = self.by_class('content_title')
+            content_title = self.wait_for_class_text_contains('content_title', 'Everything')
             title_text = content_title.text.strip()
             assert 'Everything' in title_text, f"Expected 'Everything' in content title, got: '{title_text}'"
 
@@ -90,7 +89,7 @@ class PageTests(WebTest):
         self.wait_with_folder_list()
         self.safari_workaround()
         self.wait_for_navigation_to_complete()
-        mailbox_title = self.by_class('mailbox_list_title')
+        mailbox_title = self.wait_for_class_text_contains('mailbox_list_title', 'Flagged')
         title_text = mailbox_title.text.strip()
         assert 'Flagged' in title_text, f"Expected 'Flagged' in mailbox title, got: '{title_text}'"
 
@@ -104,7 +103,7 @@ class PageTests(WebTest):
         self.safari_workaround()
         self.wait_for_navigation_to_complete()
         # More flexible text matching for contacts page
-        content_title = self.by_class('content_title')
+        content_title = self.wait_for_class_text_contains('content_title', 'Contacts')
         title_text = content_title.text.strip()
         assert 'Contacts' in title_text, f"Expected 'Contacts' in title, got: '{title_text}'"
 
@@ -118,7 +117,7 @@ class PageTests(WebTest):
         self.safari_workaround()
         self.wait_for_navigation_to_complete()
         # More flexible text matching for compose page
-        content_title = self.by_class('content_title')
+        content_title = self.wait_for_class_text_contains('content_title', 'Compose')
         title_text = content_title.text.strip()
         assert 'Compose' in title_text, f"Expected 'Compose' in title, got: '{title_text}'"
 
@@ -131,7 +130,8 @@ class PageTests(WebTest):
         self.wait_with_folder_list()
         self.safari_workaround()
         self.wait_for_navigation_to_complete()
-        assert self.by_class('calendar_content_title').text == 'Calendar'
+        title = self.wait_for_class_text_contains('calendar_content_title', 'Calendar')
+        assert title.text == 'Calendar'
 
     def history(self):
         if not self.mod_active('history'):
@@ -142,7 +142,8 @@ class PageTests(WebTest):
         self.wait_with_folder_list()
         self.safari_workaround()
         self.wait_for_navigation_to_complete()
-        assert 'Message history' in self.by_class('content_title').text
+        content_title = self.wait_for_class_text_contains('content_title', 'Message history')
+        assert 'Message history' in content_title.text
 
     def home(self):
         list_item = self.by_class('menu_home')


### PR DESCRIPTION
[Related task](https://avan.tech/item140149)

**Problem:** PHP Fatal error: Call to a member function search() on bool when visiting message list pages with no IMAP servers configured.
**Solution:** Added error checking to skip failed mailbox connections before calling ->search() method.
