### PR TITLE
fix(other): Fix message content processing strip DNS prefetch tags before formatting

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -95,6 +95,7 @@ class Hm_Output_filter_message_body extends Hm_Output_Module {
     protected function output() {
         $txt = '<div class="msg_text_inner">';
         if ($this->get('msg_text')) {
+            $msg_text = strip_dns_prefetch_tags($this->get('msg_text'));
             $struct = $this->get('msg_struct_current', array());
             if (array_key_exists('envelope', $struct) && is_array($struct['envelope']) && count($struct['envelope']) > 0) {
                 $txt .= format_imap_envelope($struct['envelope'], $this);
@@ -102,7 +103,7 @@ class Hm_Output_filter_message_body extends Hm_Output_Module {
             if (isset($struct['subtype']) && strtolower($struct['subtype']) == 'html') {
                 $allowed = $this->get('header_allow_images');
                 $images = $this->get('imap_allow_images', false);
-                if ($allowed && stripos($this->get('msg_text'), 'img')) {
+                if ($allowed && stripos($msg_text, 'img')) {
                     if (!$images) {
                         $id = $this->get('imap_msg_part');
                         $txt .= '<div class="allow_image_link">'.
@@ -111,20 +112,19 @@ class Hm_Output_filter_message_body extends Hm_Output_Module {
                             $this->trans('Allow Images').'</a></div>';
                     }
                 }
-                $txt .= format_msg_html($this->get('msg_text'), $images);
+                $txt .= format_msg_html($msg_text, $images);
             }
             elseif (isset($struct['type']) && strtolower($struct['type']) == 'image') {
-                $txt .= format_msg_image($this->get('msg_text'), strtolower($struct['subtype']));
+                $txt .= format_msg_image($msg_text, strtolower($struct['subtype']));
             }
             else {
                 if ($this->get('imap_msg_part') === "0") {
-                    $txt .= format_msg_text($this->get('msg_text'), $this, false);
+                    $txt .= format_msg_text($msg_text, $this, false);
                 }
                 else {
-                    $txt .= format_msg_text($this->get('msg_text'), $this);
+                    $txt .= format_msg_text($msg_text, $this);
                 }
             }
-            $msg_text = strip_dns_prefetch_tags('msg_text');
         }
         $txt .= '</div>';
         $this->out('msg_text', $txt);


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

<!--
Validate your PR title - a quick Guide

A valid PR title contains a type (https://github.com/commitizen/conventional-commit-types/blob/master/index.json), a scope (https://github.com/cypht-org/cypht/blob/master/.github/workflows/test.lint.pr.yml#L31) and a title starting with a lower case letter.

Here are some valid examples:
- fix(frontend): my fix
- feat(backend): my feature
- docs(docker): my docs
- refactor(frontend/backend) : my refactor
- test(unit): my test
-->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- #1492

Thanks @Shadow243 to point this:
```
I’m not sure I fully understand the change here:
https://github.com/cypht-org/cypht/pull/1492/files#diff-cb64b326b00ace9230d591b354871b76ff18883f0770e1c2c7e28d9fb7d01026R127

It looks like the variable was declared but not actually used. Could you clarify the intention behind this?
```
- Correct DNS prefetch tag handling in message body output
- Process message text before formatting instead of after
