### PR TITLE
feat(other): persist Bcc header in sent and draft messages

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -183,7 +183,7 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
       protected function output() {
         if ($this->get('msg_headers')) {
             $txt = '';
-            $small_headers = array('subject', 'x-snoozed', 'date', 'from', 'to', 'reply-to', 'cc', 'flags');
+            $small_headers = array('subject', 'x-snoozed', 'date', 'from', 'to', 'reply-to', 'cc', 'x-original-bcc', 'flags');
             $reply_args = sprintf('&amp;list_path=%s&amp;uid=%s',
                 $this->html_safe($this->get('msg_list_path')),
                 $this->html_safe($this->get('msg_text_uid'))
@@ -297,6 +297,9 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
                                     $new_value[] = $this->trans(trim($v));
                                 }
                                 $value = implode(', ', $new_value);
+                            }
+                            if (mb_strtolower($name) == 'x-original-bcc') {
+                                $name = 'Bcc';
                             }
                             $txt .= '<div class="row g-0 py-0 py-sm-1 small_header d-flex">';
                             $txt .= '<div class="col-md-2"><span class="text-muted">'.$this->trans($name).'</span></div>';

--- a/modules/smtp/hm-mime-message.php
+++ b/modules/smtp/hm-mime-message.php
@@ -129,6 +129,16 @@ class Hm_MIME_Msg {
         $this->headers['X-Auto-Bcc'] = 'cypht';
     }
 
+    function set_original_bcc_header() {
+        if ($this->bcc) {
+            $this->headers['X-Original-Bcc'] = $this->bcc;
+        }
+    }
+
+    function get_bcc() {
+        return $this->bcc;
+    }
+
     function quote_fld($val) {
         if (!trim($val)) {
             return '';

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -101,6 +101,10 @@ class Hm_Handler_load_smtp_is_imap_draft extends Hm_Handler_Module {
                     $imap_draft['Cc'] = $this->unangle($msg_header['Cc']);
                 }
 
+                if (array_key_exists('X-Original-Bcc', $msg_header)) {
+                    $imap_draft['Bcc'] = $this->unangle($msg_header['X-Original-Bcc']);
+                }
+
                 if ($imap_draft) {
                     recip_count_check($imap_draft, $this);
                     $this->out('draft_id', $this->request->get['uid']);
@@ -769,6 +773,7 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
 
         /* check for associated IMAP server to save a copy */
         if ($imap_server !== false) {
+            $mime->set_original_bcc_header();
             $this->out('save_sent_server', $imap_server, false);
             $this->out('save_sent_msg', $mime);
         }
@@ -1147,6 +1152,9 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
             }
             if (array_key_exists('Cc', $imap_draft)) {
                 $cc = $imap_draft['Cc'];
+            }
+            if (array_key_exists('Bcc', $imap_draft)) {
+                $bcc = $imap_draft['Bcc'];
             }
             if (array_key_exists('From', $imap_draft)) {
                 $from = $imap_draft['From'];
@@ -2034,6 +2042,8 @@ function prepare_draft_mime($atts, $uploaded_files, $from = false, $name = '', $
         $atts['schedule'],
         $profile_id
     );
+
+    $mime->set_original_bcc_header();
 
     $mime->add_attachments($uploaded_files);
 


### PR DESCRIPTION
This PR fixes the issue where Bcc recipients were missing from saved email headers.