### PR TITLE
fix(backend): ews display attachment filenames for received messages

### DIFF
--- a/modules/imap/hm-ews.php
+++ b/modules/imap/hm-ews.php
@@ -267,8 +267,6 @@ class Hm_EWS {
             $msg = new Type\MessageType();
             $msg->setFrom($from);
             $msg->setToRecipients($recipients);
-
-            $message = $this->use_iso_if_safe($message);
             $mimeContent = Type\MimeContentType::buildFromArray([
                 'CharacterSet' => 'UTF-8',
                 '_' => base64_encode($message)
@@ -285,44 +283,6 @@ class Hm_EWS {
         } catch (\Exception $e) {
             return $e->getMessage();
         }
-    }
-
-    /**
-     * Convert UTF-8 to ISO-8859-1 if the content is safe to do so.
-     * This prevents Exchange from converting quoted-printable to base64 encoding.
-     * 
-     * @param string $message The MIME message from Hm_MIME_Msg
-     * @return string Modified message with ISO-8859-1 where safe
-     */
-    private function use_iso_if_safe($message) {
-        // Use regex to find and replace each text part's charset + body
-        return preg_replace_callback(
-            '/Content-Type:\s*text\/[^;]+;\s*charset="?UTF-8"?[^\r\n]*\r\n' .
-            'Content-Transfer-Encoding:\s*quoted-printable\r\n\r\n' .
-            '(.*?)(?=\r\n--|\r\n\r\n--|\z)/s',
-            function($match) {
-                // Decode quoted-printable body
-                $decoded = quoted_printable_decode($match[1]);
-
-                // This will fail for characters not in ISO-8859-1 (e.g., €, emojis, Cyrillic).
-                $converted = @iconv('UTF-8', 'ISO-8859-1', $decoded);
-                if ($converted === false) {
-                    return $match[0]; // Keep UTF-8 (contains €, emojis, Cyrillic, etc.)
-                }
-
-                $backToUtf8 = @iconv('ISO-8859-1', 'UTF-8', $converted);
-                if ($backToUtf8 === false || $decoded !== $backToUtf8) {
-                    return $match[0]; // Not exact match, keep UTF-8
-                }
-
-                // Safe to convert: replace charset and re-encode
-                $newHeader = preg_replace('/charset="?UTF-8"?/i', 'charset="iso-8859-1"', $match[0]);
-                $newBody = quoted_printable_encode($converted);
-
-                return str_replace($match[1], $newBody, $newHeader);
-            },
-            $message
-        );
     }
 
     public function store_message($folder, $message, $seen = true, $draft = false) {


### PR DESCRIPTION
1. Properly extract attachment filenames from received messages.
2. Uncaught Error: Call to undefined method Hm_EWS::supports_dsn() in /cypht/modules/smtp/modules.php:584