### PR TITLE
fix: Change AOL SMTP port from 587 to 465

### DIFF
--- a/modules/nux/services.php
+++ b/modules/nux/services.php
@@ -105,7 +105,7 @@ Nux_Quick_Services::add('aol', array(
     'auth' => 'login',
     'smtp' => array(
         'server' => 'smtp.aol.com',
-        'port' => 587,
+        'port' => 465,
         'tls' => true
     )
 ));


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

<!--
Validate your PR title - a quick Guide

A valid PR title contains a type (https://github.com/commitizen/conventional-commit-types/blob/master/index.json), a scope (https://github.com/cypht-org/cypht/blob/master/.github/workflows/test.lint.pr.yml#L31) and a title starting with a lower case letter.

Here are some valid examples:
- fix(frontend): my fix
- feat(backend): my feature
- docs(docker): my docs
- refactor(frontend/backend) : my refactor
- test(unit): my test
-->

## 🍰 Pullrequest

AOL uses port 465 for SMTP, as specified here: https://help.aol.com/articles/how-do-i-use-other-email-applications-to-send-and-receive-my-aol-mail

Authentication will fail unless the correct port is used.

<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
