### PR TITLE
fix(module/smtp): honor starttls mode instead of implicit tls

### DIFF
--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -111,13 +111,33 @@ class Hm_SMTP {
         else {
             $this->port = 25;
         }
-        if (isset($conf['tls']) && $conf['tls']) {
-            $this->tls = true;
+        $this->tls = false;
+        $this->starttls = false;
+        if (isset($conf['tls'])) {
+            $tls_val = $conf['tls'];
+            if (is_string($tls_val)) {
+                $normalized = mb_strtolower(trim($tls_val));
+                if ($normalized === 'starttls') {
+                    $this->starttls = true;
+                }
+                elseif ($normalized === 'tls' || $normalized === 'ssl' || $normalized === 'true' || $normalized === '1') {
+                    $this->tls = true;
+                }
+                elseif ($normalized === 'false' || $normalized === '0' || $normalized === '') {
+                    // leave both false
+                }
+                elseif ($tls_val) {
+                    $this->tls = true;
+                }
+            }
+            elseif ($tls_val === true || $tls_val === 1) {
+                $this->tls = true;
+            }
+            elseif ($tls_val) {
+                $this->tls = true;
+            }
         }
-        else {
-            $this->tls = false;
-        }
-        if (!$this->tls) {
+        if (!$this->tls && !$this->starttls) {
             $this->starttls = true;
         }
         $this->request_auths = array(


### PR DESCRIPTION
Cypht currently treats any truthy `default_smtp_tls` value as a request for an implicit TLS socket. When the configuration sets `starttls`, the client still opens a TLS session immediately, so submission servers on 587 see a ClientHello before STARTTLS is negotiated. This patch normalizes the string value and keeps implicit TLS limited to `tls` / `ssl` / `true`, allowing `starttls` to follow the upgrade flow as intended.
