### PR TITLE
fix(module/config): read postgres byte streams before decryption

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -357,7 +357,15 @@ class Hm_User_Config_DB extends Hm_Config {
      */
     private function decrypt_settings($data, $key) {
         if (!$this->crypt) {
-            $data = $this->decode($data['settings']);
+            $settings = $data['settings'];
+            if (is_resource($settings)) {
+                $settings = stream_get_contents($settings);
+            }
+            if ($settings === false) {
+                $this->decrypt_failed = true;
+                return false;
+            }
+            $data = $this->decode($settings);
         } else {
             $data = $this->decode(Hm_Crypt::plaintext($data['settings'], $key));
         }

--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -111,13 +111,33 @@ class Hm_SMTP {
         else {
             $this->port = 25;
         }
-        if (isset($conf['tls']) && $conf['tls']) {
-            $this->tls = true;
+        $this->tls = false;
+        $this->starttls = false;
+        if (isset($conf['tls'])) {
+            $tls_val = $conf['tls'];
+            if (is_string($tls_val)) {
+                $normalized = mb_strtolower(trim($tls_val));
+                if ($normalized === 'starttls') {
+                    $this->starttls = true;
+                }
+                elseif ($normalized === 'tls' || $normalized === 'ssl' || $normalized === 'true' || $normalized === '1') {
+                    $this->tls = true;
+                }
+                elseif ($normalized === 'false' || $normalized === '0' || $normalized === '') {
+                    // leave both false
+                }
+                elseif ($tls_val) {
+                    $this->tls = true;
+                }
+            }
+            elseif ($tls_val === true || $tls_val === 1) {
+                $this->tls = true;
+            }
+            elseif ($tls_val) {
+                $this->tls = true;
+            }
         }
-        else {
-            $this->tls = false;
-        }
-        if (!$this->tls) {
+        if (!$this->tls && !$this->starttls) {
             $this->starttls = true;
         }
         $this->request_auths = array(


### PR DESCRIPTION
PostgreSQL can hand `hm_user_settings.settings` back as a stream resource when PDO is built with libpq support. Passing that resource straight into `base64_decode()` causes a PHP 8 fatal error before libsodium gets a chance to decrypt the payload. Normalizing the value with `stream_get_contents()` ensures the stored settings are always a string before decode/decrypt, which allows users to log in again.
