### PR TITLE
fix(other): improve user feedback for saved searches to include settings save reminder

### DIFF
--- a/modules/saved_searches/modules.php
+++ b/modules/saved_searches/modules.php
@@ -49,7 +49,12 @@ class Hm_Handler_update_search extends Hm_Handler_Module {
                 $this->user_config->set('saved_searches', $searches->dump());
                 $this->session->set('user_data', $this->user_config->dump());
                 $this->out('updated_search', true);
-                Hm_Msgs::add('Saved search updated', 'info');
+                if (isPageConfigured('save')) {
+                    Hm_Msgs::add("Saved search updated. To preserve your searches after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.", 'info');
+                }
+                else {
+                    Hm_Msgs::add('Saved search updated', 'info');
+                }
             }
             else {
                 Hm_Msgs::add('Unable to update the search parameters', 'danger');
@@ -111,7 +116,12 @@ class Hm_Handler_save_search extends Hm_Handler_Module {
                 $this->user_config->set('saved_searches', $searches->dump());
                 $this->session->set('user_data', $this->user_config->dump());
                 $this->out('saved_search', true);
-                Hm_Msgs::add('Search saved', 'success');
+                if (isPageConfigured('save')) {
+                    Hm_Msgs::add("Search saved. To preserve your searches after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.", 'success');
+                }
+                else {
+                    Hm_Msgs::add('Search saved', 'success');
+                }
             }
             else {
                 Hm_Msgs::add('You already have a search by that name', 'warning');
@@ -145,7 +155,12 @@ class Hm_Handler_save_advanced_search extends Hm_Handler_Module {
                 $this->user_config->set('saved_searches', $searches->dump());
                 $this->session->set('user_data', $this->user_config->dump());
                 $this->out('saved_advanced_search', true);
-                Hm_Msgs::add('Advanced search saved', 'success');
+                if (isPageConfigured('save')) {
+                    Hm_Msgs::add("Advanced search saved. To preserve your searches after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.", 'success');
+                }
+                else {
+                    Hm_Msgs::add('Advanced search saved', 'success');
+                }
             }
             else {
                 Hm_Msgs::add('Failed to save advanced search - name already exists', 'danger');
@@ -194,7 +209,12 @@ class Hm_Handler_update_advanced_search extends Hm_Handler_Module {
                 $this->user_config->set('saved_searches', $searches->dump());
                 $this->session->set('user_data', $this->user_config->dump());
                 $this->out('updated_advanced_search', true);
-                Hm_Msgs::add('Advanced search updated', 'info');
+                if (isPageConfigured('save')) {
+                    Hm_Msgs::add("Advanced search updated. To preserve your searches after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.", 'info');
+                }
+                else {
+                    Hm_Msgs::add('Advanced search updated', 'info');
+                }
             }
             else {
                 Hm_Msgs::add('Unable to update the advanced search parameters', 'danger');


### PR DESCRIPTION
When a user logout without saving his settings, the saved searches are lost, so we need a reminder