### PR TITLE
fix(other): prevent container startup failure by handling existing users in create script

### DIFF
--- a/scripts/create_account.php
+++ b/scripts/create_account.php
@@ -59,8 +59,14 @@ if ($dbh) {
 }
 
 if ($user && $pass) {
-    $res = $auth->create($user, $pass);
-    switch ($res) {
+    $res = Hm_DB::execute($dbh, 'select username from hm_user where username = ?', [$user]);
+    if (!empty($res)) {
+        fwrite(STDOUT, "User '{$user}' already exists. Skipping creation...\n");
+        exit(0);
+    }
+
+    $result = $auth->create($user, $pass);
+    switch ($result) {
         case 1:
             fwrite(STDERR, "Error: Unable to create user account.\n");
             exit(2);


### PR DESCRIPTION
Using user data persistence, when we restart Cypht Docker containers, the user creation scripts exits with status 2 if the user already exists, preventing the container from starting properly.

```
[+] Running 3/3
 ✔ cypht                      Built                                                                       0.0s 
 ✔ Container cypht10-db-1     Running                                                                     0.0s 
 ✔ Container cypht10-cypht-1  Recreated                                                                   0.2s 
Attaching to cypht-1, db-1
cypht-1  | Cannot load Xdebug - it was already loaded
cypht-1  | 
cypht-1  | Database connection successful ...
cypht-1  | Database detected. Running migrations...
cypht-1  | Running migrations...
cypht-1  | Migrations completed.
cypht-1  | 
cypht-1  | Db setup finished
cypht-1  | Creating directory for attachments /var/lib/hm3/attachments
cypht-1  | Cannot load Xdebug - it was already loaded
cypht-1  | user admin already exists
cypht-1  | Error: Unable to create user account.
cypht-1 exited with code 2
```