### PR TITLE
fix(other): fix PostgreSQL BYTEA resource handling in user config loading

### DIFF
--- a/lib/session_db.php
+++ b/lib/session_db.php
@@ -97,11 +97,7 @@ class Hm_DB_Session extends Hm_PHP_Session {
         if (is_array($results)) {
             if (array_key_exists('data', $results) && array_key_exists('hm_version', $results)) {
                 $this->version = $results['hm_version'];
-                $data = $results['data'];
-                if (is_resource($data)) {
-                    $data = stream_get_contents($data);
-                }
-                return $this->plaintext($data);
+                return $this->plaintext($results['data']);
             }
         }
         Hm_Debug::add('DB SESSION failed to read session data');


### PR DESCRIPTION
When using PostgreSQL with USER_CONFIG_TYPE=DB, the settings column
(BYTEA type) is returned by PDO as a resource stream rather than a
string. This caused a fatal error when the resource was passed to
base64_decode() in the decryption process.

Exact error
```
NOTICE: PHP message: PHP Fatal error:  Uncaught TypeError: base64_decode(): Argument #1 ($string) must be of type string, resource given in /usr/local/share/cypht/lib/crypt_sodium.php:28
127.0.0.1 -  12/Nov/2025:09:02:23 +0800 "POST /index.php" 500
Stack trace:
#0 /usr/local/share/cypht/lib/crypt_sodium.php(28): base64_decode()
#1 /usr/local/share/cypht/lib/config.php(362): Hm_Crypt::plaintext()
#2 /usr/local/share/cypht/lib/config.php(387): Hm_User_Config_DB->decrypt_settings()
#3 /usr/local/share/cypht/modules/core/handler_modules.php(719): Hm_User_Config_DB->load()
#4 /usr/local/share/cypht/lib/modules_exec.php(177): Hm_Handler_load_user_data->process()
#5 /usr/local/share/cypht/lib/modules_exec.php(155): Hm_Module_Exec->run_handler_module()
#6 /usr/local/share/cypht/lib/dispatch.php(218): Hm_Module_Exec->run_handler_modules()
#7 /usr/local/share/cypht/lib/dispatch.php(188): Hm_Dispatch->process_request()
#8 /usr/local/share/cypht/site/index.php(55): Hm_Dispatch->__construct()
#9 {main}
  thrown in /usr/local/share/cypht/lib/crypt_sodium.php on line 28
```

Related issue: https://github.com/cypht-org/cypht/issues/1544