### PR TITLE
fix(other): fix asset download links when Cypht is installed outside web root

### DIFF
--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -372,8 +372,15 @@ function create_production_site($assets, $settings, $hashes) {
     copy('site.js', 'site/site.js');
     append_bootstrap_icons_files();
 
+    // Copy main assets directory
+    if (is_readable('assets/')) {
+        printf("copying assets directory...\n");
+        copy_recursive('assets');
+    }
+
     $index_file = file_get_contents('index.php');
     $index_file = preg_replace("/APP_PATH', ''/", "APP_PATH', '".APP_PATH."'", $index_file);
+    $index_file = preg_replace("/ASSETS_PATH', APP_PATH\.'assets\/'/", "ASSETS_PATH', WEB_ROOT.'assets/'", $index_file);
     $index_file = preg_replace("/CACHE_ID', ''/", "CACHE_ID', '".urlencode(Hm_Crypt::unique_id(32))."'", $index_file);
     $index_file = preg_replace("/SITE_ID', ''/", "SITE_ID', '".urlencode(Hm_Crypt::unique_id(64))."'", $index_file);
     $index_file = preg_replace("/DEBUG_MODE', true/", "DEBUG_MODE', false", $index_file);


### PR DESCRIPTION
When Cypht is installed in a non-web-accessible directory (e.g., `/usr/local/share/cypht`) for security purposes, asset download links (such as server account sample files) fail with 404 errors. 

The issue occurs because `ASSETS_PATH` is defined using the absolute filesystem path (`APP_PATH.'assets/'`), which results in invalid URLs like:

`http://localhost/usr/local/share/cypht/assets/data/server_accounts_sample.yaml`

This works fine when Cypht is installed in the document root.

Related issue: https://github.com/cypht-org/cypht/issues/1532