### PR TITLE
fix(other): fix Bootstrap Icons not visible in production mode (DEBUG=false)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /site.js
 /site.css
 /site/
+/fonts/
 /todo
 /tests/selenium/creds.py
 /tests/selenium/local_creds.py

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -318,14 +318,24 @@ function write_config_file($settings, $filters) {
  * @return void
  */
 function append_bootstrap_icons_files() {
+    // Ensure target font directories exist for both deployment modes:
+    // - Running from site/: fonts are expected under site/fonts relative to site/site.css
+    // - Running from the main directory: fonts are expected under fonts relative to site.css
     if (!is_dir("site/fonts")) {
         mkdir('site/fonts', 0755);
+    }
+    if (!is_dir("fonts")) {
+        mkdir('fonts', 0755);
     }
     $source_folder = VENDOR_PATH.'twbs/bootstrap-icons/font/fonts/';
     $files = glob("$source_folder*.*");
     foreach($files as $file){
-        $dest_forlder = str_replace($source_folder, "site/fonts/", $file);
-        copy($file, $dest_forlder);
+        // Copy for site/ deployments (CSS loaded from site/site.css → ./fonts resolves to site/fonts)
+        $dest_folder_site = str_replace($source_folder, "site/fonts/", $file);
+        copy($file, $dest_folder_site);
+        // Copy for main-directory deployments (CSS loaded from site.css → ./fonts resolves to fonts)
+        $dest_folder_root = str_replace($source_folder, "fonts/", $file);
+        copy($file, $dest_folder_root);
     }
 }
 


### PR DESCRIPTION
## Issue
Bootstrap Icons are not displaying when running Cypht in production mode (`DEBUG=false`). Icons worked correctly in debug mode but were missing in production.

When combining CSS files for production, the Bootstrap Icons CSS was included in `site.css`, but the font file paths remained as relative paths (`./fonts/`) that were correct for the original vendor location but incorrect for the combined production CSS file location. The fonts are copied to `site/fonts/` during the build process, but the CSS was still referencing `./fonts/`, causing 404 errors for the font files.
