### PR TITLE
fix(backend): handle undefined special_imap_folders in user_settings

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -616,7 +616,7 @@ class Hm_Output_js_data extends Hm_Output_Module {
         $settings = $this->get('user_settings', array());
         $enable_snooze = $settings['enable_snooze'] ?? DEFAULT_ENABLE_SNOOZE;
         $enable_collect_address_on_send = $settings['enable_collect_address_on_send_setting'] ?? DEFAULT_ENABLE_COLLECT_ADDRESS_ON_SEND;
-        $specialFolders = $settings['special_imap_folders'];
+        $specialFolders = $settings['special_imap_folders'] ?? array();
         $formattedSpecialFolders = [];
         foreach ($specialFolders as $serverId => $folders) {
             $formattedSpecialFolders[$serverId] = [];


### PR DESCRIPTION
This PR fixes undefined array key error for `special_imap_folders` in `Hm_Output_js_data` output module that causes disconnections in Docker deployments.

When running Cypht in Docker containers (using daily tag: cypht/cypht:daily), new users or users with uninitialized configurations encounter PHP warnings and get disconnected after around 30 seconds. From the logs we see these errors: 
```
PHP Warning: Undefined array key "special_imap_folders" in /usr/local/share/cypht/modules/core/output_modules.php on line 619
PHP Warning: foreach() argument must be of type array|object, null given in /usr/local/share/cypht/modules/core/output_modules.php on line 621
```
