### PR TITLE
fix(backend): handle undefined array keys username and password

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -559,7 +559,7 @@ class Hm_Handler_imap_message_list_type extends Hm_Handler_Module {
                     } else {
                         $folder = hex2bin($parts[2]);
                     }
-                    
+
                     $mailbox = Hm_IMAP_List::get_mailbox_without_connection($details);
                     $label = $mailbox->get_folder_name($folder);
                     if(!$label) {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

<!--
Validate your PR title - a quick Guide

A valid PR title contains a type (https://github.com/commitizen/conventional-commit-types/blob/master/index.json), a scope (https://github.com/cypht-org/cypht/blob/master/.github/workflows/test.lint.pr.yml#L31) and a title starting with a lower case letter.

Here are some valid examples:
- fix(frontend): my fix
- feat(backend): my feature
- docs(docker): my docs
- refactor(frontend/backend) : my refactor
- test(unit): my test
-->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Two issues:
```
[26-Nov-2025 12:31:03 UTC] PHP Warning:  Undefined array key "username" in /var/www/html/cypht/modules/imap/hm-ews.php on line 45
[26-Nov-2025 12:31:03 UTC] PHP Warning:  Undefined array key "password" in /var/www/html/cypht/modules/imap/hm-ews.php on line 45
```

### Todo
<!-- In case some parts are still missing, list them here. -->
- Lgn in into your Cypht
- Click your EWS account Inbx(should request _ajax_imap_folder_display_ request)
- Check your logs according to your configuration.