### PR TITLE
fix(other): resolve MySQL access denied in container networking with init script

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
       - "3306:3306"
     volumes:
       - ./data/mysql:/var/lib/mysql
+      # Mount the initialization script to create user with Docker network permissions
+      - ./init-db.sh:/docker-entrypoint-initdb.d/01-init-user.sh:ro
     environment:
       - MYSQL_ROOT_PASSWORD=root_password
       - MYSQL_DATABASE=cypht

--- a/docker/init-db.sh
+++ b/docker/init-db.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# MariaDB/MySQL initialization script for Cypht
+# This script runs in /docker-entrypoint-initdb.d/ and ensures the database user
+# has proper permissions for Docker networking.
+#
+# It is intended to be used **only** with MariaDB/MySQL.
+# - It creates the application user with '@%' host for Docker network connections
+# - It also ensures a '@localhost' user exists for local access / healthchecks
+#
+# Note: PostgreSQL and SQLite do not use this script and do **not** have the same
+# Docker networking permission problem:
+# - SQLite is file-based, has no users, and is accessed directly by the app
+# - PostgreSQL's official image already creates the user/database from POSTGRES_*
+#   env vars and its default pg_hba.conf allows password auth from other containers
+
+set -e
+
+# MySQL/MariaDB initialization
+MYSQL_USER="${MYSQL_USER:-cypht}"
+MYSQL_PASSWORD="${MYSQL_PASSWORD:-cypht_password}"
+MYSQL_DATABASE="${MYSQL_DATABASE:-cypht}"
+
+# Get root password - MariaDB init scripts can access this via environment or file
+if [ -n "$MYSQL_ROOT_PASSWORD_FILE" ] && [ -f "$MYSQL_ROOT_PASSWORD_FILE" ]; then
+    MYSQL_ROOT_PASSWORD=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
+elif [ -n "$MYSQL_ROOT_PASSWORD" ]; then
+    MYSQL_ROOT_PASSWORD="$MYSQL_ROOT_PASSWORD"
+else
+    echo "Error: MYSQL_ROOT_PASSWORD not set" >&2
+    exit 1
+fi
+
+# Create user with wildcard host (%) to allow connections from any Docker container
+# This is necessary because Docker containers connect via service names, not localhost.
+# Note: MYSQL_USER environment variable creates 'user'@'localhost', but we also need 'user'@'%'.
+mysql -u root -p"${MYSQL_ROOT_PASSWORD}" <<EOF_SQL
+-- Create user with wildcard host for Docker network connections
+-- This allows connections from any container in the Docker network
+CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
+GRANT ALL PRIVILEGES ON ${MYSQL_DATABASE}.* TO '${MYSQL_USER}'@'%';
+
+-- Ensure localhost user exists (may already exist from MYSQL_USER env var)
+CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PASSWORD}';
+GRANT ALL PRIVILEGES ON ${MYSQL_DATABASE}.* TO '${MYSQL_USER}'@'localhost';
+
+-- Flush privileges to ensure changes take effect
+FLUSH PRIVILEGES;
+EOF_SQL
+
+echo "✓ Created MySQL/MariaDB user '${MYSQL_USER}' with Docker network permissions (@'%' and @'localhost')"
+


### PR DESCRIPTION
## 🍰 Pullrequest
This PR fixes `Access denied for user 'cypht'@'<ip>'` errors when running Cypht with MySQL/MariaDB in Docker by ensuring the application DB user is created with the correct host permissions for container networking.

### Issue
Related to https://github.com/cypht-org/cypht/issues/1020

