### PR TITLE
fix(docker): issue #1780 about docker images platform

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM php:8.1-fpm-bookworm
+FROM php:8.1-fpm-bookworm
 
 WORKDIR /usr/local/share/cypht
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,8 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     COMPOSER_HOME=/tmp/composer_home
 
 # Install system packages and PHP extensions
-RUN --mount=type=cache,target=/var/cache/apt \
-    set -eux \
+RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         supervisor \


### PR DESCRIPTION
All non-amd64 images on Docker Hub were built with the wrong architecture, which affects version 2.5.0 and later images.

Related issues: https://github.com/cypht-org/cypht/issues/1818 https://github.com/cypht-org/cypht/issues/1780