### PR TITLE
fix(other): local contacts not being tracked as unsaved changes on save page

### DIFF
--- a/modules/local_contacts/modules.php
+++ b/modules/local_contacts/modules.php
@@ -25,6 +25,7 @@ class Hm_Handler_process_add_contact_from_message extends Hm_Handler_Module {
                 foreach ($addresses as $vals) {
                     $contacts->add_contact(array('source' => 'local', 'email_address' => $vals['email'], 'display_name' => $vals['name'], 'group' => isset($vals['contact_group']) ? $vals['contact_group'] : 'Personal Addresses'));
                 }
+                $this->session->record_unsaved('Contact Added');
                 Hm_Msgs::add('Contact Added');
             }
         }
@@ -40,6 +41,7 @@ class Hm_Handler_process_delete_contact extends Hm_Handler_Module {
         list($success, $form) = $this->process_form(array('contact_type', 'contact_source', 'contact_id'));
         if ($success && $form['contact_type'] == 'local' && $form['contact_source'] == 'local') {
             if ($contacts->delete($form['contact_id'])) {
+                $this->session->record_unsaved('Contact Deleted');
                 $this->out('contact_deleted', 1);
                 Hm_Msgs::add('Contact Deleted');
             }
@@ -66,6 +68,7 @@ class Hm_Handler_process_add_contact extends Hm_Handler_Module {
                 $details['group'] = 'Personal Addresses';
             }
             $contacts->add_contact($details);
+            $this->session->record_unsaved('Contact Added');
             Hm_Msgs::add('Contact Added');
         }
     }
@@ -177,6 +180,7 @@ class Hm_Handler_process_edit_contact extends Hm_Handler_Module {
                 $details['group'] = 'Personal Addresses';
             }
             if ($contacts->update_contact($form['contact_id'], $details)) {
+                $this->session->record_unsaved('Contact Updated');
                 Hm_Msgs::add('Contact Updated');
             }
         }


### PR DESCRIPTION
## Issue
When adding, updating, or deleting local contacts, the changes were not being tracked as unsaved. This meant:
- The save page showed "No changes need to be saved" even after adding contacts
- Users could lose contact data if they logged out without explicitly saving