### PR TITLE
fix(frontend): enter key validation issue after autocomplete in compose form

### DIFF
--- a/modules/contacts/site.js
+++ b/modules/contacts/site.js
@@ -163,10 +163,13 @@ var autocomplete_keyboard_nav = function(event, list_div, class_name, fld_val) {
         return false;
     }
     else if (event.keyCode == 13) {
-        $(class_name).focus();
-        $(list_div).hide();
-        add_autocomplete(event, class_name, list_div);
-        return false;
+        if ($(event.target).hasClass('contact_suggestion')) {
+            $(class_name).focus();
+            $(list_div).hide();
+            add_autocomplete(event, class_name, list_div);
+            return false;
+        }
+        return true;
     }
     else if (event.keyCode == 27) {
         $(list_div).html('');


### PR DESCRIPTION
This PR fixes the following issue:

In the compose message form, after using **contact autocomplete** (To, Cc, Bcc), pressing Enter to validate recipients stopped working. The text would disappear instead of being converted to bubbles.