### PR TITLE
fix(frontend): fix incorrect unsaved changes count when adding multip…

### DIFF
--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -216,7 +216,6 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                     }
                     Hm_IMAP_List::clean_up();
                     $this->session->record_unsaved('IMAP server added');
-                    $this->session->record_unsaved('SMTP server added');
                     $this->session->secure_cookie($this->request, 'hm_reload_folders', '1');
                     if (isPageConfigured('save')) {
                         Hm_Msgs::add("E-mail account successfully added, To preserve these settings after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.");


### PR DESCRIPTION
When adding servers through cypht/?page=servers, the "Unsaved Changes" list on the save page displayed incorrect counts:

- SMTP server added: (2X) instead of (1X)

- IMAP server added: (1X) 

- Special folders assigned: (1X) 
