### PR TITLE
fix(other): decompression-bomb safeguards bypassed when following HTT redirects (streaming API)

### DIFF
--- a/tests/selenium/requirements.txt
+++ b/tests/selenium/requirements.txt
@@ -9,5 +9,5 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 trio==0.22.2
 trio-websocket==0.11.1
-urllib3==2.6.0
+urllib3==2.6.3
 wsproto==1.2.0


### PR DESCRIPTION
https://github.com/cypht-org/cypht/security/dependabot/12