### PR TITLE
fix(other): point docker compose to latest Cypht release 2.6.0

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       retries: 5
 
   cypht:
-    image: cypht/cypht:2.5.1
+    image: cypht/cypht:2.6.0
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Related to : https://github.com/cypht-org/cypht/releases/tag/v2.6.0