### PR TITLE
fix(other): fix PHP 8.2+ deprecation mb_convert_encoding HTML-ENTITIES

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -462,7 +462,16 @@ class HTMLToText {
 
     function __construct($html) {
         $doc = new DOMDocument();
-        $doc->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        libxml_use_internal_errors(true);
+
+        // Check if already valid UTF-8, if not convert it
+        if (!mb_check_encoding($html, 'UTF-8')) {
+            // Try to detect and convert the encoding
+            $html = mb_convert_encoding($html, 'UTF-8', mb_detect_encoding($html, mb_list_encodings(), true));
+        }
+        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+        libxml_clear_errors();
+
         if (trim($html) && $doc->hasChildNodes()) {
             $this->parse_nodes($doc->childNodes);
         }


### PR DESCRIPTION
```
1) /var/www/html/cypht485/modules/core/message_functions.php:465
mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead

Triggered by:

* Hm_Test_Core_Message_Functions::test_convert_html_to_text
  /var/www/html/cypht485/tests/phpunit/modules/core/message_functions.php:22

* Hm_Test_Core_Message_Functions::test_format_reply_as_text
  /var/www/html/cypht485/tests/phpunit/modules/core/message_functions.php:110
```