### PR TITLE
fix(other): fix Save Settings links for subdirectory installations

### DIFF
--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -1180,7 +1180,7 @@ class Hm_Handler_quick_servers_setup extends Hm_Handler_Module {
                 }
                 $this->out('just_saved_credentials', true);
                 if (isPageConfigured('save')) {
-                    Hm_Msgs::add("Server saved. To preserve these settings after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.");
+                    Hm_Msgs::add("Server saved. To preserve these settings after logout, please go to <a class='alert-link' href='?page=save'>Save Settings</a>.");
                 } else {
                     Hm_Msgs::add("Server saved.");
                 }

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1505,7 +1505,7 @@ class Hm_Handler_process_add_jmap_server extends Hm_Handler_Module {
                     'port' => false,
                     'tls' => false));
                 if (isPageConfigured('save')) {
-                    Hm_Msgs::add("Added server!. To preserve these settings after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.");
+                    Hm_Msgs::add("Added server!. To preserve these settings after logout, please go to <a class='alert-link' href='?page=save'>Save Settings</a>.");
                     $this->session->record_unsaved('JMAP server added');
                 } else {
                     Hm_Msgs::add('Added server!');
@@ -1666,7 +1666,7 @@ class Hm_Handler_save_ews_server extends Hm_Handler_Module {
                 $this->user_config->set('special_imap_folders', $specials);
             }
             if (isPageConfigured('save')) {
-                Hm_Msgs::add("EWS server saved. To preserve these settings after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.");
+                Hm_Msgs::add("EWS server saved. To preserve these settings after logout, please go to <a class='alert-link' href='?page=save'>Save Settings</a>.");
                 $this->session->record_unsaved('EWS server added');
             } else {
                 Hm_Msgs::add('EWS server saved.');

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -141,7 +141,7 @@ class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module {
                         $this->session->record_unsaved('SMTP server added');
                     }
                     if (isPageConfigured('save')) {
-                        Hm_Msgs::add("E-mail account successfully added, To preserve these settings after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.");
+                        Hm_Msgs::add("E-mail account successfully added, To preserve these settings after logout, please go to <a class='alert-link' href='?page=save'>Save Settings</a>.");
                     } else {
                         Hm_Msgs::add("E-mail account successfully added.");
                     }
@@ -218,7 +218,7 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                     $this->session->record_unsaved('IMAP server added');
                     $this->session->secure_cookie($this->request, 'hm_reload_folders', '1');
                     if (isPageConfigured('save')) {
-                        Hm_Msgs::add("E-mail account successfully added, To preserve these settings after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.");
+                        Hm_Msgs::add("E-mail account successfully added, To preserve these settings after logout, please go to <a class='alert-link' href='?page=save'>Save Settings</a>.");
                     } else {
                         Hm_Msgs::add("E-mail account successfully added.");
                     }

--- a/modules/saved_searches/modules.php
+++ b/modules/saved_searches/modules.php
@@ -117,7 +117,7 @@ class Hm_Handler_save_search extends Hm_Handler_Module {
                 $this->session->set('user_data', $this->user_config->dump());
                 $this->out('saved_search', true);
                 if (isPageConfigured('save')) {
-                    Hm_Msgs::add("Search saved. To preserve your searches after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.", 'success');
+                    Hm_Msgs::add("Saved search updated. To preserve your searches after logout, please go to <a class='alert-link' href='?page=save'>Save Settings</a>.", 'info');
                 }
                 else {
                     Hm_Msgs::add('Search saved', 'success');
@@ -156,7 +156,7 @@ class Hm_Handler_save_advanced_search extends Hm_Handler_Module {
                 $this->session->set('user_data', $this->user_config->dump());
                 $this->out('saved_advanced_search', true);
                 if (isPageConfigured('save')) {
-                    Hm_Msgs::add("Advanced search saved. To preserve your searches after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.", 'success');
+                    Hm_Msgs::add("Advanced search saved. To preserve your searches after logout, please go to <a class='alert-link' href='?page=save'>Save Settings</a>.", 'success');
                 }
                 else {
                     Hm_Msgs::add('Advanced search saved', 'success');
@@ -210,7 +210,7 @@ class Hm_Handler_update_advanced_search extends Hm_Handler_Module {
                 $this->session->set('user_data', $this->user_config->dump());
                 $this->out('updated_advanced_search', true);
                 if (isPageConfigured('save')) {
-                    Hm_Msgs::add("Advanced search updated. To preserve your searches after logout, please go to <a class='alert-link' href='/?page=save'>Save Settings</a>.", 'info');
+                    Hm_Msgs::add("Advanced search updated. To preserve your searches after logout, please go to <a class='alert-link' href='?page=save'>Save Settings</a>.", 'info');
                 }
                 else {
                     Hm_Msgs::add('Advanced search updated', 'info');


### PR DESCRIPTION
## Issue

When Cypht is installed in a subdirectory (e.g., `http://localhost/cypht/`), the "Save Settings" links in various success messages were redirecting users to the wrong URL (`http://localhost/?page=save` instead of `http://localhost/cypht/?page=save`).