### PR TITLE
fix(other): use user email as IMAP account name instead of static config

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1804,7 +1804,8 @@ class Hm_Handler_load_imap_servers_from_config extends Hm_Handler_Module {
                 $name = $auth_server['name'];
             }
             else {
-                $name = $this->config->get('imap_auth_name', 'Default');
+                // Use the username (email address) as the account name instead of static config
+                $name = $auth_server['username'];
             }
             $imap_details = array(
                 'name' => $name,


### PR DESCRIPTION
In this PR we replace hardcoded IMAP_AUTH_NAME with the authenticated user's email
address to provide personalized account names in the folder list.

Related issue: https://github.com/cypht-org/cypht/issues/1873