### PR TITLE
fix(workflow): allow underscores and digits in module scope pattern

### DIFF
--- a/.github/workflows/test.lint.pr.yml
+++ b/.github/workflows/test.lint.pr.yml
@@ -36,7 +36,7 @@ jobs:
             frontend
             backend
             frontend/backend
-            module/[a-z-]+
+            module/[a-z0-9_-]+
             unit
             e2e
             other


### PR DESCRIPTION
### Issue

The module scope regex `module/[a-z-]+` excluded  a few modules whose names contain underscores (e.g. advanced_search, imap_folders) or start with a digit (e.g. 2fa). Updated to `module/[a-z0-9_-]+` to match all existing module directory names.