### PR TITLE
fix(other): only init KindEditor for signature in HTML compose mode

### DIFF
--- a/modules/core/js_modules/route_handlers.js
+++ b/modules/core/js_modules/route_handlers.js
@@ -12,8 +12,8 @@ function applyServersPageHandlers() {
         }
     });
 
-    // Init KindEditor for stepper signature field in HTML compose mode
-    hm_init_sig_editor('#srv_setup_stepper_profile_signature', 'stepperSigEditor');
+    // Init KindEditor for stepper signature field in HTML compose mode only
+    hm_init_sig_editor('#srv_setup_stepper_profile_signature.html_sig_editor', 'stepperSigEditor');
 
     // Optional modules
     if (window.feedServersPageHandler) feedServersPageHandler();

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -112,7 +112,7 @@ var ews_edit_action = function(event) {
 };
 
 var ews_init_sig_editor = function() {
-    hm_init_sig_editor('#ews_profile_signature', 'ewsSigEditor');
+    hm_init_sig_editor('#ews_profile_signature.html_sig_editor', 'ewsSigEditor');
 };
 
 var ews_sync_sig = function() {


### PR DESCRIPTION
### Issue

The stepper (add server) and EWS (add Exchange server) forms were unconditionally initializing KindEditor on the signature textarea by targeting the element by ID alone. This caused the rich-text editor to appear even when **Outbound mail format** was set to **Plain Text**.