### PR TITLE
fix(backend): allow custom sources

### DIFF
--- a/modules/core/functions.php
+++ b/modules/core/functions.php
@@ -110,8 +110,15 @@ function format_data_sources($array, $output_mod) {
         $objects = array();
         foreach ($sources as $values) {
             $items = array();
+            $custom = array_key_exists('type', $values) && $values['type'] == 'custom';
             foreach ($values as $name => $value) {
-                $items[] = $output_mod->html_safe($name).':"'.$output_mod->html_safe($value).'"';
+                if ($custom && $name == 'params') {
+                    $value_output = json_encode($value);
+                } else {
+                    $value_output = '"'.$output_mod->html_safe($value).'"';
+                }
+
+                $items[] = $output_mod->html_safe($name).':'.$value_output;
             }
             $objects[] = '{'.implode(',', $items).'}';
         }

--- a/modules/core/js_modules/Hm_MessagesStore.js
+++ b/modules/core/js_modules/Hm_MessagesStore.js
@@ -324,6 +324,11 @@ class Hm_MessagesStore {
                     if (ds.type == 'feeds') {
                         cfg.push({ name: "hm_ajax_hook", value: 'ajax_feed_combined' });
                         cfg.push({ name: "feed_server_ids", value: ds.id });
+                    } else if (ds.type == 'custom') {
+                        cfg.push({ name: "hm_ajax_hook", value: ds.hook });
+                        for (const param in ds.params) {
+                            cfg.push({ name: param, value: ds.params[param] });
+                        }
                     } else {
                         cfg.push({ name: "hm_ajax_hook", value: this.path == 'search' ? 'ajax_imap_search' : 'ajax_imap_message_list' });
                         cfg.push({ name: "imap_server_ids", value: ds.id });


### PR DESCRIPTION
This PR reintroduce a way of adding custom sources from apps integrating Cypht. Recent refactoring removed the callback that where allowing apps to add sources to message list pages.