### PR TITLE
fix(module/sievefilters): avoid duplicate modal bindings and invalid main_sc…

### DIFF
--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -1681,7 +1681,7 @@ pre.msg_source {
 .menu_search.selected_menu { background-color: transparent; }
 #dropdownMenuForward + ul .forward_link span,
 #contact_info + #contact_popup span { white-space: nowrap; }
-#extra-header-buttons { display: inline-block; margin-top: 0.5rem; }
+#extra-header-buttons { display: inline-block; margin-top: 0; }
 
 /* some theming changes */
 .allow_image_link .btn-light, .definitive_actions .btn-light,

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -355,6 +355,16 @@ Hm_Modal.prototype = {
     init: function() {
         this.destroy();
 
+        // Remove any orphaned modal element with the same ID
+        var orphan = document.getElementById(this.opts.modalId);
+        if (orphan) {
+            var orphanBsModal = bootstrap.Modal.getInstance(orphan);
+            if (orphanBsModal) {
+                orphanBsModal.dispose();
+            }
+            orphan.remove();
+        }
+
         const modal = `
             <div id="${this.opts.modalId}" class="modal fade modal-${this.opts.size}" data-bs-backdrop="static" tabindex="-1" aria-hidden="true">
                 <div class="modal-dialog">

--- a/modules/sievefilters/functions.php
+++ b/modules/sievefilters/functions.php
@@ -177,9 +177,14 @@ if (!hm_exists('generate_main_script')) {
     function generate_main_script($script_list)
     {
         $sorted_list = [];
+        $has_blocked_senders = false;
         foreach ($script_list as $script_name) {
             if ($script_name == 'main_script') {
                 continue;
+            }
+
+            if ($script_name == 'blocked_senders') {
+                $has_blocked_senders = true;
             }
 
             if (mb_strstr($script_name, 'cypht')) {
@@ -191,8 +196,10 @@ if (!hm_exists('generate_main_script')) {
         $include_header = 'require ["include"];'."\n\n";
         $include_body = '';
 
-        // Block List MUST be the first script executed
-        $include_body .= 'include :personal "blocked_senders";'."\n";
+        // Block List MUST be the first script executed when it exists.
+        if ($has_blocked_senders) {
+            $include_body .= 'include :personal "blocked_senders";' ."\n";
+        }
 
         foreach ($sorted_list as $script_name => $include_script) {
             $include_body .= 'include :personal "'.$script_name.'";'."\n";
@@ -256,7 +263,10 @@ if (!hm_exists('format_main_script')) {
             return '"' . $req . '"';
         }, $reqs);
 
-        $script = 'require [' . implode(',', $reqs) . '];' . "\n";
+        $script = '';
+        if (!empty($reqs)) {
+            $script .= 'require [' . implode(',', $reqs) . '];' . "\n";
+        }
         $script .= implode("\n", $lines);
         
         return $script;

--- a/modules/sievefilters/modules.php
+++ b/modules/sievefilters/modules.php
@@ -1209,6 +1209,9 @@ class Hm_Output_sievefilters_modal_content_start extends Hm_Output_Module
  */
 class Hm_Output_new_sieve_filter_for_message_like_this extends Hm_Output_Module {
     public function output() {
+        if (!$this->get('sieve_filters_enabled')) {
+            return '';
+        }
         $mailbox_name = $this->get('mailbox_name') ?? '';
         $headers = $this->get('filter_headers', []);
         
@@ -1742,6 +1745,9 @@ class Hm_Output_message_list_custom_actions extends Hm_Output_Module
 {
     protected function output()
     {
+        if (!$this->get('sieve_filters_enabled')) {
+            return '';
+        }
         $custom_actions = $this->get('custom_actions', []);
         $mailbox_name = $this->get('mailbox_name', '');
 

--- a/modules/sievefilters/setup.php
+++ b/modules/sievefilters/setup.php
@@ -20,7 +20,7 @@ add_handler('ajax_imap_debug', 'sieve_connect', true, 'imap', 'imap_connect', 'a
 // sieve filter
 add_handler('message_list', 'load_mailbox_name', true, 'sievefilters', 'load_user_data', 'after');
 add_handler('message_list', 'load_custom_actions', true, 'sievefilters', 'load_mailbox_name', 'after');
-add_output('sieve_filters', 'sievefilters_settings_start', true, 'sievefilters', 'version_upgrade_checker', 'after');
+add_output('sieve_filters', 'sievefilters_modal_content_start', true, 'sievefilters', 'version_upgrade_checker', 'after');
 add_output('message_list', 'sievefilters_modal_content_start', true, 'sievefilters', 'message_list_end', 'after');
 add_output('message_list', 'message_list_custom_actions', true, 'sievefilters', 'imap_custom_controls', 'after');
 add_output('sieve_filters', 'sievefilters_title_start', true, 'sievefilters', 'content_section_start', 'after');

--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -988,6 +988,7 @@ const registerSievePageEvents = (edit_filter_modal, edit_script_modal) => {
                         }
                     }
                 });
+                add_filter_match_mode();
                 edit_filter_modal.setTitle(current_editing_filter_name);
                 edit_filter_modal.open();
             }
@@ -1822,6 +1823,7 @@ $(function () {
                     }
                 });
 
+                add_filter_match_mode();
                 edit_filter_modal.setTitle(
                     hm_trans('Edit Filter') + ': ' + filterName,
                 );

--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -624,33 +624,39 @@ const hm_sieve_button_events = (edit_filter_modal, edit_script_modal) => {
         $(this).parent().find('.sievefilters_accounts').toggleClass('d-none');
     });
 
-    $(document).off('click', '.add_filter').on('click', '.add_filter', function() {
-        edit_filter_modal.setTitle('Add Filter');
-        $('.modal_sieve_filter_priority').val('');
-        $('.modal_sieve_filter_test').val('ALLOF');
-        $('#stop_filtering').prop('checked', false);
-        current_account = $(this).attr('account');
-        current_account_element = $(this);
-        edit_filter_modal.open();
+    $(document).off('click', '.add_filter');
+    if (edit_filter_modal) {
+        $(document).on('click', '.add_filter', function() {
+            edit_filter_modal.setTitle('Add Filter');
+            $('.modal_sieve_filter_priority').val('');
+            $('.modal_sieve_filter_test').val('ALLOF');
+            $('#stop_filtering').prop('checked', false);
+            current_account = $(this).attr('account');
+            current_account_element = $(this);
+            edit_filter_modal.open();
 
-        // Reset the form fields when opening the modal
-        $(".modal_sieve_filter_name").val('');
-        $(".modal_sieve_script_priority").val('');
-        $(".sieve_list_conditions_modal").empty();
-        $(".filter_actions_modal_table").empty();
-    });
+            // Reset the form fields when opening the modal
+            $(".modal_sieve_filter_name").val('');
+            $(".modal_sieve_script_priority").val('');
+            $(".sieve_list_conditions_modal").empty();
+            $(".filter_actions_modal_table").empty();
+        });
+    }
 
-    $(document).off('click', '.add_script').on('click', '.add_script', function() {
-        edit_script_modal.setTitle('Add Script');
-        $('.modal_sieve_script_textarea').val('');
-        $('.modal_sieve_script_name').val('');
-        $('.modal_sieve_script_priority').val('');
-        is_editing_script = false;
-        current_editing_script_name = '';
-        current_account = $(this).attr('account');
-        current_account_element = $(this);
-        edit_script_modal.open();
-    });
+    $(document).off('click', '.add_script');
+    if (edit_script_modal) {
+        $(document).on('click', '.add_script', function() {
+            edit_script_modal.setTitle('Add Script');
+            $('.modal_sieve_script_textarea').val('');
+            $('.modal_sieve_script_name').val('');
+            $('.modal_sieve_script_priority').val('');
+            is_editing_script = false;
+            current_editing_script_name = '';
+            current_account = $(this).attr('account');
+            current_account_element = $(this);
+            edit_script_modal.open();
+        });
+    }
 
     /**
      * Delete action Button
@@ -901,84 +907,90 @@ const hm_sieve_button_events = (edit_filter_modal, edit_script_modal) => {
     /**
      * Edit script event
      */
-    $(document).off('click', '.edit_script').on('click', '.edit_script', function (e) {
-        e.preventDefault();
-        let obj = $(this);
-        edit_script_modal.setTitle('Edit Script');
-        is_editing_script = true;
-        current_editing_script_name = $(this).attr('script_name');
-        current_account = $(this).attr('imap_account');
-        current_account_element = $(this);
-        $('.modal_sieve_script_name').val($(this).attr('script_name_parsed'));
-        $('.modal_sieve_script_priority').val($(this).attr('priority'));
-        Hm_Ajax.request(
-            [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_edit_script'},
-                {'name': 'imap_account', 'value': $(this).attr('imap_account')},
-                {'name': 'sieve_script_name', 'value': $(this).attr('script_name')}],
-            function(res) {
-                $('.modal_sieve_script_textarea').html(res.script);
-                edit_script_modal.open();
-            }
-        );
-    });
+    $(document).off('click', '.edit_script');
+    if (edit_script_modal) {
+        $(document).on('click', '.edit_script', function (e) {
+            e.preventDefault();
+            let obj = $(this);
+            edit_script_modal.setTitle('Edit Script');
+            is_editing_script = true;
+            current_editing_script_name = $(this).attr('script_name');
+            current_account = $(this).attr('imap_account');
+            current_account_element = $(this);
+            $('.modal_sieve_script_name').val($(this).attr('script_name_parsed'));
+            $('.modal_sieve_script_priority').val($(this).attr('priority'));
+            Hm_Ajax.request(
+                [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_edit_script'},
+                    {'name': 'imap_account', 'value': $(this).attr('imap_account')},
+                    {'name': 'sieve_script_name', 'value': $(this).attr('script_name')}],
+                function(res) {
+                    $('.modal_sieve_script_textarea').html(res.script);
+                    edit_script_modal.open();
+                }
+            );
+        });
+    }
 
     /**
      * Edit filter event
      */
-    $(document).off('click', '.edit_filter').on('click', '.edit_filter', function (e) {
-        e.preventDefault();
-        let obj = $(this);
-        current_account = $(this).attr('account');
-        current_account_element = $(this);
-        is_editing_filter = true;
-        current_editing_filter_name = $(this).attr('script_name');
-        current_account = $(this).attr('imap_account');
-        current_account_element = $(this);
-        // $('#stop_filtering').prop('checked', false);
-        $('.modal_sieve_filter_name').val($(this).attr('script_name_parsed'));
-        $('.modal_sieve_filter_priority').val($(this).attr('priority'));
-        $('.sieve_list_conditions_modal').html('');
-        $('.filter_actions_modal_table').html('');
-        Hm_Ajax.request(
-            [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_edit_filter'},
-                {'name': 'imap_account', 'value': $(this).attr('imap_account')},
-                {'name': 'sieve_script_name', 'value': $(this).attr('script_name')}],
-            function(res) {
-                conditions = JSON.parse(JSON.parse(res.conditions));
-                actions = JSON.parse(JSON.parse(res.actions));
-                test_type = res.test_type;
-                $(".modal_sieve_filter_test").val(test_type);
-                conditions.forEach(function (condition) {
-                    add_filter_condition();
-                    $(".add_condition_sieve_filters").last().val(condition.condition);
-                    $(".add_condition_sieve_filters").last().trigger('change');
-                    $(".condition_options").last().val(condition.type);
-                    $("[name^=sieve_selected_extra_option_value]").last().val(condition.extra_option_value);
-                    if ($("[name^=sieve_selected_option_value]").last().is('input')) {
-                        $("[name^=sieve_selected_option_value]").last().val(condition.value);
-                    }
-                });
-
-                actions.forEach(function (action) {
-                    if (action.action === "stop") {
-                        $('#stop_filtering').prop('checked', true);
-                    } else {
-                        add_filter_action(action.value);
-                        $(".sieve_actions_select").last().val(action.action);
-                        $(".sieve_actions_select").last().trigger('change');
-                        $("[name^=sieve_selected_extra_action_value]").last().val(action.extra_option_value);
-                        if ($("[name^=sieve_selected_action_value]").last().is('input')) {
-                            $("[name^=sieve_selected_action_value]").last().val(action.value);
-                        } else if ($("[name^=sieve_selected_action_value]").last().is('textarea')) {
-                            $("[name^=sieve_selected_action_value]").last().text(action.value);
+    $(document).off('click', '.edit_filter');
+    if (edit_filter_modal) {
+        $(document).on('click', '.edit_filter', function (e) {
+            e.preventDefault();
+            let obj = $(this);
+            current_account = $(this).attr('account');
+            current_account_element = $(this);
+            is_editing_filter = true;
+            current_editing_filter_name = $(this).attr('script_name');
+            current_account = $(this).attr('imap_account');
+            current_account_element = $(this);
+            // $('#stop_filtering').prop('checked', false);
+            $('.modal_sieve_filter_name').val($(this).attr('script_name_parsed'));
+            $('.modal_sieve_filter_priority').val($(this).attr('priority'));
+            $('.sieve_list_conditions_modal').html('');
+            $('.filter_actions_modal_table').html('');
+            Hm_Ajax.request(
+                [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_edit_filter'},
+                    {'name': 'imap_account', 'value': $(this).attr('imap_account')},
+                    {'name': 'sieve_script_name', 'value': $(this).attr('script_name')}],
+                function(res) {
+                    conditions = JSON.parse(JSON.parse(res.conditions));
+                    actions = JSON.parse(JSON.parse(res.actions));
+                    test_type = res.test_type;
+                    $(".modal_sieve_filter_test").val(test_type);
+                    conditions.forEach(function (condition) {
+                        add_filter_condition();
+                        $(".add_condition_sieve_filters").last().val(condition.condition);
+                        $(".add_condition_sieve_filters").last().trigger('change');
+                        $(".condition_options").last().val(condition.type);
+                        $("[name^=sieve_selected_extra_option_value]").last().val(condition.extra_option_value);
+                        if ($("[name^=sieve_selected_option_value]").last().is('input')) {
+                            $("[name^=sieve_selected_option_value]").last().val(condition.value);
                         }
-                    }
-                });
-                edit_filter_modal.setTitle(current_editing_filter_name);
-                edit_filter_modal.open();
-            }
-        );
-    });
+                    });
+
+                    actions.forEach(function (action) {
+                        if (action.action === "stop") {
+                            $('#stop_filtering').prop('checked', true);
+                        } else {
+                            add_filter_action(action.value);
+                            $(".sieve_actions_select").last().val(action.action);
+                            $(".sieve_actions_select").last().trigger('change');
+                            $("[name^=sieve_selected_extra_action_value]").last().val(action.extra_option_value);
+                            if ($("[name^=sieve_selected_action_value]").last().is('input')) {
+                                $("[name^=sieve_selected_action_value]").last().val(action.value);
+                            } else if ($("[name^=sieve_selected_action_value]").last().is('textarea')) {
+                                $("[name^=sieve_selected_action_value]").last().text(action.value);
+                            }
+                        }
+                    });
+                    edit_filter_modal.setTitle(current_editing_filter_name);
+                    edit_filter_modal.open();
+                }
+            );
+        });
+    }
 
     /**
      * Actions Drag and Drop
@@ -1604,6 +1616,8 @@ function escapeHtml(text) {
 }
 
 $(function () {
+    hm_sieve_button_events();
+
     $(document).on('change', '#block_action', function(e) {
         if ($(this).val() == 'reject_with_message') {
             $('<div id="reject_message"><label>'+hm_trans('Message')+'</label><textarea id="reject_message_textarea"></textarea></div>').insertAfter($(this));
@@ -1817,8 +1831,6 @@ $(function () {
             },
         );
     });
-
-    hm_sieve_button_events();
 
     $(document).on('click', '.remove-chip', function () {
         $(this).parent().remove();

--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -619,45 +619,14 @@ const add_filter_action = Hm_Filters.add_filter_action;
 /**************************************************************************************
 *                                      MODAL EVENTS
 **************************************************************************************/
-const hm_sieve_button_events = (edit_filter_modal, edit_script_modal) => {
-    $(document).off('click', '.sievefilters_accounts_title').on('click', '.sievefilters_accounts_title', function() {
-        $(this).parent().find('.sievefilters_accounts').toggleClass('d-none');
-    });
 
-    $(document).off('click', '.add_filter');
-    if (edit_filter_modal) {
-        $(document).on('click', '.add_filter', function() {
-            edit_filter_modal.setTitle('Add Filter');
-            $('.modal_sieve_filter_priority').val('');
-            $('.modal_sieve_filter_test').val('ALLOF');
-            $('#stop_filtering').prop('checked', false);
-            current_account = $(this).attr('account');
-            current_account_element = $(this);
-            edit_filter_modal.open();
-
-            // Reset the form fields when opening the modal
-            $(".modal_sieve_filter_name").val('');
-            $(".modal_sieve_script_priority").val('');
-            $(".sieve_list_conditions_modal").empty();
-            $(".filter_actions_modal_table").empty();
-        });
-    }
-
-    $(document).off('click', '.add_script');
-    if (edit_script_modal) {
-        $(document).on('click', '.add_script', function() {
-            edit_script_modal.setTitle('Add Script');
-            $('.modal_sieve_script_textarea').val('');
-            $('.modal_sieve_script_name').val('');
-            $('.modal_sieve_script_priority').val('');
-            is_editing_script = false;
-            current_editing_script_name = '';
-            current_account = $(this).attr('account');
-            current_account_element = $(this);
-            edit_script_modal.open();
-        });
-    }
-
+/**
+ * Shared modal-internal event handlers.
+ * Registers delegated handlers for interactions inside any sieve filter/script
+ * modal (add/delete conditions, add/delete actions, select changes).
+ * Called globally on document ready so they work on every page.
+ */
+const registerSieveModalEvents = () => {
     /**
      * Delete action Button
      */
@@ -843,6 +812,45 @@ const hm_sieve_button_events = (edit_filter_modal, edit_script_modal) => {
             }
         }
     });
+};
+
+/**
+ * Page-specific event handlers for the sieve filters page.
+ * These require modal instances or operate on elements that only exist
+ * on the sieve filters settings page.
+ */
+const registerSievePageEvents = (edit_filter_modal, edit_script_modal) => {
+    $(document).off('click', '.sievefilters_accounts_title').on('click', '.sievefilters_accounts_title', function() {
+        $(this).parent().find('.sievefilters_accounts').toggleClass('d-none');
+    });
+
+    $(document).off('click', '.add_filter').on('click', '.add_filter', function() {
+        edit_filter_modal.setTitle('Add Filter');
+        $('.modal_sieve_filter_priority').val('');
+        $('.modal_sieve_filter_test').val('ALLOF');
+        $('#stop_filtering').prop('checked', false);
+        current_account = $(this).attr('account');
+        current_account_element = $(this);
+        edit_filter_modal.open();
+
+        // Reset the form fields when opening the modal
+        $(".modal_sieve_filter_name").val('');
+        $(".modal_sieve_script_priority").val('');
+        $(".sieve_list_conditions_modal").empty();
+        $(".filter_actions_modal_table").empty();
+    });
+
+    $(document).off('click', '.add_script').on('click', '.add_script', function() {
+        edit_script_modal.setTitle('Add Script');
+        $('.modal_sieve_script_textarea').val('');
+        $('.modal_sieve_script_name').val('');
+        $('.modal_sieve_script_priority').val('');
+        is_editing_script = false;
+        current_editing_script_name = '';
+        current_account = $(this).attr('account');
+        current_account_element = $(this);
+        edit_script_modal.open();
+    });
 
     /**
      * Delete filter event
@@ -907,90 +915,84 @@ const hm_sieve_button_events = (edit_filter_modal, edit_script_modal) => {
     /**
      * Edit script event
      */
-    $(document).off('click', '.edit_script');
-    if (edit_script_modal) {
-        $(document).on('click', '.edit_script', function (e) {
-            e.preventDefault();
-            let obj = $(this);
-            edit_script_modal.setTitle('Edit Script');
-            is_editing_script = true;
-            current_editing_script_name = $(this).attr('script_name');
-            current_account = $(this).attr('imap_account');
-            current_account_element = $(this);
-            $('.modal_sieve_script_name').val($(this).attr('script_name_parsed'));
-            $('.modal_sieve_script_priority').val($(this).attr('priority'));
-            Hm_Ajax.request(
-                [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_edit_script'},
-                    {'name': 'imap_account', 'value': $(this).attr('imap_account')},
-                    {'name': 'sieve_script_name', 'value': $(this).attr('script_name')}],
-                function(res) {
-                    $('.modal_sieve_script_textarea').html(res.script);
-                    edit_script_modal.open();
-                }
-            );
-        });
-    }
+    $(document).off('click', '.edit_script').on('click', '.edit_script', function (e) {
+        e.preventDefault();
+        let obj = $(this);
+        edit_script_modal.setTitle('Edit Script');
+        is_editing_script = true;
+        current_editing_script_name = $(this).attr('script_name');
+        current_account = $(this).attr('imap_account');
+        current_account_element = $(this);
+        $('.modal_sieve_script_name').val($(this).attr('script_name_parsed'));
+        $('.modal_sieve_script_priority').val($(this).attr('priority'));
+        Hm_Ajax.request(
+            [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_edit_script'},
+                {'name': 'imap_account', 'value': $(this).attr('imap_account')},
+                {'name': 'sieve_script_name', 'value': $(this).attr('script_name')}],
+            function(res) {
+                $('.modal_sieve_script_textarea').html(res.script);
+                edit_script_modal.open();
+            }
+        );
+    });
 
     /**
      * Edit filter event
      */
-    $(document).off('click', '.edit_filter');
-    if (edit_filter_modal) {
-        $(document).on('click', '.edit_filter', function (e) {
-            e.preventDefault();
-            let obj = $(this);
-            current_account = $(this).attr('account');
-            current_account_element = $(this);
-            is_editing_filter = true;
-            current_editing_filter_name = $(this).attr('script_name');
-            current_account = $(this).attr('imap_account');
-            current_account_element = $(this);
-            // $('#stop_filtering').prop('checked', false);
-            $('.modal_sieve_filter_name').val($(this).attr('script_name_parsed'));
-            $('.modal_sieve_filter_priority').val($(this).attr('priority'));
-            $('.sieve_list_conditions_modal').html('');
-            $('.filter_actions_modal_table').html('');
-            Hm_Ajax.request(
-                [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_edit_filter'},
-                    {'name': 'imap_account', 'value': $(this).attr('imap_account')},
-                    {'name': 'sieve_script_name', 'value': $(this).attr('script_name')}],
-                function(res) {
-                    conditions = JSON.parse(JSON.parse(res.conditions));
-                    actions = JSON.parse(JSON.parse(res.actions));
-                    test_type = res.test_type;
-                    $(".modal_sieve_filter_test").val(test_type);
-                    conditions.forEach(function (condition) {
-                        add_filter_condition();
-                        $(".add_condition_sieve_filters").last().val(condition.condition);
-                        $(".add_condition_sieve_filters").last().trigger('change');
-                        $(".condition_options").last().val(condition.type);
-                        $("[name^=sieve_selected_extra_option_value]").last().val(condition.extra_option_value);
-                        if ($("[name^=sieve_selected_option_value]").last().is('input')) {
-                            $("[name^=sieve_selected_option_value]").last().val(condition.value);
-                        }
-                    });
+    $(document).off('click', '.edit_filter').on('click', '.edit_filter', function (e) {
+        e.preventDefault();
+        let obj = $(this);
+        current_account = $(this).attr('account');
+        current_account_element = $(this);
+        is_editing_filter = true;
+        current_editing_filter_name = $(this).attr('script_name');
+        current_account = $(this).attr('imap_account');
+        current_account_element = $(this);
+        // $('#stop_filtering').prop('checked', false);
+        $('.modal_sieve_filter_name').val($(this).attr('script_name_parsed'));
+        $('.modal_sieve_filter_priority').val($(this).attr('priority'));
+        $('.sieve_list_conditions_modal').html('');
+        $('.filter_actions_modal_table').html('');
+        Hm_Ajax.request(
+            [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_edit_filter'},
+                {'name': 'imap_account', 'value': $(this).attr('imap_account')},
+                {'name': 'sieve_script_name', 'value': $(this).attr('script_name')}],
+            function(res) {
+                conditions = JSON.parse(JSON.parse(res.conditions));
+                actions = JSON.parse(JSON.parse(res.actions));
+                test_type = res.test_type;
+                $(".modal_sieve_filter_test").val(test_type);
+                conditions.forEach(function (condition) {
+                    add_filter_condition();
+                    $(".add_condition_sieve_filters").last().val(condition.condition);
+                    $(".add_condition_sieve_filters").last().trigger('change');
+                    $(".condition_options").last().val(condition.type);
+                    $("[name^=sieve_selected_extra_option_value]").last().val(condition.extra_option_value);
+                    if ($("[name^=sieve_selected_option_value]").last().is('input')) {
+                        $("[name^=sieve_selected_option_value]").last().val(condition.value);
+                    }
+                });
 
-                    actions.forEach(function (action) {
-                        if (action.action === "stop") {
-                            $('#stop_filtering').prop('checked', true);
-                        } else {
-                            add_filter_action(action.value);
-                            $(".sieve_actions_select").last().val(action.action);
-                            $(".sieve_actions_select").last().trigger('change');
-                            $("[name^=sieve_selected_extra_action_value]").last().val(action.extra_option_value);
-                            if ($("[name^=sieve_selected_action_value]").last().is('input')) {
-                                $("[name^=sieve_selected_action_value]").last().val(action.value);
-                            } else if ($("[name^=sieve_selected_action_value]").last().is('textarea')) {
-                                $("[name^=sieve_selected_action_value]").last().text(action.value);
-                            }
+                actions.forEach(function (action) {
+                    if (action.action === "stop") {
+                        $('#stop_filtering').prop('checked', true);
+                    } else {
+                        add_filter_action(action.value);
+                        $(".sieve_actions_select").last().val(action.action);
+                        $(".sieve_actions_select").last().trigger('change');
+                        $("[name^=sieve_selected_extra_action_value]").last().val(action.extra_option_value);
+                        if ($("[name^=sieve_selected_action_value]").last().is('input')) {
+                            $("[name^=sieve_selected_action_value]").last().val(action.value);
+                        } else if ($("[name^=sieve_selected_action_value]").last().is('textarea')) {
+                            $("[name^=sieve_selected_action_value]").last().text(action.value);
                         }
-                    });
-                    edit_filter_modal.setTitle(current_editing_filter_name);
-                    edit_filter_modal.open();
-                }
-            );
-        });
-    }
+                    }
+                });
+                edit_filter_modal.setTitle(current_editing_filter_name);
+                edit_filter_modal.open();
+            }
+        );
+    });
 
     /**
      * Actions Drag and Drop
@@ -1004,8 +1006,6 @@ const hm_sieve_button_events = (edit_filter_modal, edit_script_modal) => {
             ghostClass: "sortable-ghost",
         });
     }
-
-    return true;
 };
 
 function blockListPageHandlers() {
@@ -1244,7 +1244,7 @@ function sieveFiltersPageHandler() {
     /**************************************************************************************
      * Initialize sieve button events
      **************************************************************************************/
-    hm_sieve_button_events(edit_filter_modal, edit_script_modal);
+    registerSievePageEvents(edit_filter_modal, edit_script_modal);
 
     const save_script = Hm_Filters.save_script;
     // const save_filter = Hm_Filters.save_filter;
@@ -1616,8 +1616,6 @@ function escapeHtml(text) {
 }
 
 $(function () {
-    hm_sieve_button_events();
-
     $(document).on('change', '#block_action', function(e) {
         if ($(this).val() == 'reject_with_message') {
             $('<div id="reject_message"><label>'+hm_trans('Message')+'</label><textarea id="reject_message_textarea"></textarea></div>').insertAfter($(this));
@@ -1831,6 +1829,8 @@ $(function () {
             },
         );
     });
+
+    registerSieveModalEvents();
 
     $(document).on('click', '.remove-chip', function () {
         $(this).parent().remove();


### PR DESCRIPTION
## Fixes
- Duplicate modals are causing duplicated inputs and validation messages
- Modal buttons not working outside the sieve filters page
- Missing ALL/ANY match mode when editing filters
- Sieve parser error from `require [];`
- Invalid inclusion of non-existent `blocked_senders` script

## Changes

### site.js
- Remove existing modal with the same ID in `Hm_Modal.init()` to prevent duplicates
- Split `hm_sieve_button_events()` into:
  - `registerSieveModalEvents()` (global modal handlers)
  - `registerSievePageEvents()` (page-specific handlers)
- Add missing `add_filter_match_mode()` call when editing filters

### functions.php
- Skip empty `require` in `format_main_script()` to avoid `require [];` parser error
- Include `blocked_senders` in `generate_main_script()` only if it exists
