### PR TITLE
fix(other): show nav menu on save page by adding missing route entry and supporting handler-less routes

### DIFF
--- a/modules/core/navigation/routes.js
+++ b/modules/core/navigation/routes.js
@@ -87,6 +87,9 @@ const routes = [
         handler: 'applyTagsPageHandlers'
     },
     {
+        page: 'save'
+    },
+    {
         page: 'logout',
         handler: 'applyLogoutPageHandlers',
         useLayout: false
@@ -96,8 +99,8 @@ const routes = [
 /* 
 Now let's validate and use handlers that are given.
 */
-const ROUTES = routes.filter(route => typeof(window[route.handler]) === 'function').map(route => ({
+const ROUTES = routes.filter(route => !route.handler || typeof(window[route.handler]) === 'function').map(route => ({
     ...route,
-    handler: window[route.handler],
+    handler: route.handler ? window[route.handler] : () => {},
     commonHandler: route.useLayout === false ? window.applyCommonUnwrappedPageHandlers : window.applyCommonWrappedPageHandlers
 }));


### PR DESCRIPTION
## Issue

On the `?page=save` page, the nav menu disappears in two situations:

1. **After saving**, you enter your password and click Save; the form submits (POST) and the page reloads. The menu is gone.
2. **On page refresh**, if you manually refresh `?page=save`, the menu is gone.

Note: the menu *appears* intact when you first click the Save Settings link, because client-side navigation only swaps `<main>`, leaving the previous page's nav DOM in place. The bug only surfaces on a full page load (form submit or browser refresh).

## Root cause

The client-side router (`navigation.js`) calls `renderPage()` on every full page load. That function looks up the current page in the `ROUTES` array and only if a match is found calls `commonHandler`, which triggers the AJAX request that renders the nav menu.

The `save` page had no entry in `routes.js`, so `ROUTES.find()` returned `undefined`, the `if (route)` block was skipped, and the menu was never loaded.