### PR TITLE
refactor(frontend): imap folders page to show wich folder is being edited

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e3a0c9dbc183230b1e11a15592a2a3c",
+    "content-hash": "d98284078a3e3bcc02e9490c573994d1",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
-            "version": "v3.1.1",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Bacon/BaconQrCode.git",
-                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2"
+                "reference": "3feed0e212b8412cc5d2612706744789b0615824"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
-                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/3feed0e212b8412cc5d2612706744789b0615824",
+                "reference": "3feed0e212b8412cc5d2612706744789b0615824",
                 "shasum": ""
             },
             "require": {
@@ -57,9 +57,9 @@
             "homepage": "https://github.com/Bacon/BaconQrCode",
             "support": {
                 "issues": "https://github.com/Bacon/BaconQrCode/issues",
-                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.1.1"
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.0.4"
             },
-            "time": "2026-04-05T21:06:35+00:00"
+            "time": "2026-03-16T01:01:30+00:00"
         },
         {
             "name": "christian-riesen/base32",
@@ -931,16 +931,16 @@
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.11",
+            "version": "v2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "d1af40ac4a6ccc12bd062a7184f63c9995a63bdd"
+                "reference": "870fc81d2f879903dfc5b60bf8a0f94a1609e669"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/d1af40ac4a6ccc12bd062a7184f63c9995a63bdd",
-                "reference": "d1af40ac4a6ccc12bd062a7184f63c9995a63bdd",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/870fc81d2f879903dfc5b60bf8a0f94a1609e669",
+                "reference": "870fc81d2f879903dfc5b60bf8a0f94a1609e669",
                 "shasum": ""
             },
             "require": {
@@ -988,7 +988,7 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-04-07T13:32:18+00:00"
+            "time": "2026-02-20T19:59:49+00:00"
         },
         {
             "name": "league/commonmark",
@@ -1980,16 +1980,16 @@
         },
         {
             "name": "sentry/sentry",
-            "version": "4.24.0",
+            "version": "4.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "5055cc792f630a427fdf9dcccd88faa94b50fd30"
+                "reference": "121a674d5fffcdb8e414b75c1b76edba8e592b66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/5055cc792f630a427fdf9dcccd88faa94b50fd30",
-                "reference": "5055cc792f630a427fdf9dcccd88faa94b50fd30",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/121a674d5fffcdb8e414b75c1b76edba8e592b66",
+                "reference": "121a674d5fffcdb8e414b75c1b76edba8e592b66",
                 "shasum": ""
             },
             "require": {
@@ -2057,7 +2057,7 @@
             ],
             "support": {
                 "issues": "https://github.com/getsentry/sentry-php/issues",
-                "source": "https://github.com/getsentry/sentry-php/tree/4.24.0"
+                "source": "https://github.com/getsentry/sentry-php/tree/4.23.0"
             },
             "funding": [
                 {
@@ -2069,7 +2069,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-04-01T14:34:34+00:00"
+            "time": "2026-03-23T13:15:52+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2140,16 +2140,16 @@
         },
         {
             "name": "symfony/dotenv",
-            "version": "v6.4.36",
+            "version": "v6.4.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "cae019cc92a46fe9e498ea011107f26bdf5d897f"
+                "reference": "148138ead5d7bb582e93a9cc19b134b42a370365"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/cae019cc92a46fe9e498ea011107f26bdf5d897f",
-                "reference": "cae019cc92a46fe9e498ea011107f26bdf5d897f",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/148138ead5d7bb582e93a9cc19b134b42a370365",
+                "reference": "148138ead5d7bb582e93a9cc19b134b42a370365",
                 "shasum": ""
             },
             "require": {
@@ -2194,7 +2194,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v6.4.36"
+                "source": "https://github.com/symfony/dotenv/tree/v6.4.35"
             },
             "funding": [
                 {
@@ -2214,7 +2214,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T07:25:04+00:00"
+            "time": "2026-02-26T10:15:49+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d98284078a3e3bcc02e9490c573994d1",
+    "content-hash": "7e3a0c9dbc183230b1e11a15592a2a3c",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
-            "version": "v3.0.4",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Bacon/BaconQrCode.git",
-                "reference": "3feed0e212b8412cc5d2612706744789b0615824"
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/3feed0e212b8412cc5d2612706744789b0615824",
-                "reference": "3feed0e212b8412cc5d2612706744789b0615824",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
                 "shasum": ""
             },
             "require": {
@@ -57,9 +57,9 @@
             "homepage": "https://github.com/Bacon/BaconQrCode",
             "support": {
                 "issues": "https://github.com/Bacon/BaconQrCode/issues",
-                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.0.4"
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.1.1"
             },
-            "time": "2026-03-16T01:01:30+00:00"
+            "time": "2026-04-05T21:06:35+00:00"
         },
         {
             "name": "christian-riesen/base32",
@@ -931,16 +931,16 @@
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.10",
+            "version": "v2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "870fc81d2f879903dfc5b60bf8a0f94a1609e669"
+                "reference": "d1af40ac4a6ccc12bd062a7184f63c9995a63bdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/870fc81d2f879903dfc5b60bf8a0f94a1609e669",
-                "reference": "870fc81d2f879903dfc5b60bf8a0f94a1609e669",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/d1af40ac4a6ccc12bd062a7184f63c9995a63bdd",
+                "reference": "d1af40ac4a6ccc12bd062a7184f63c9995a63bdd",
                 "shasum": ""
             },
             "require": {
@@ -988,7 +988,7 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-02-20T19:59:49+00:00"
+            "time": "2026-04-07T13:32:18+00:00"
         },
         {
             "name": "league/commonmark",
@@ -1980,16 +1980,16 @@
         },
         {
             "name": "sentry/sentry",
-            "version": "4.23.0",
+            "version": "4.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "121a674d5fffcdb8e414b75c1b76edba8e592b66"
+                "reference": "5055cc792f630a427fdf9dcccd88faa94b50fd30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/121a674d5fffcdb8e414b75c1b76edba8e592b66",
-                "reference": "121a674d5fffcdb8e414b75c1b76edba8e592b66",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/5055cc792f630a427fdf9dcccd88faa94b50fd30",
+                "reference": "5055cc792f630a427fdf9dcccd88faa94b50fd30",
                 "shasum": ""
             },
             "require": {
@@ -2057,7 +2057,7 @@
             ],
             "support": {
                 "issues": "https://github.com/getsentry/sentry-php/issues",
-                "source": "https://github.com/getsentry/sentry-php/tree/4.23.0"
+                "source": "https://github.com/getsentry/sentry-php/tree/4.24.0"
             },
             "funding": [
                 {
@@ -2069,7 +2069,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-03-23T13:15:52+00:00"
+            "time": "2026-04-01T14:34:34+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2140,16 +2140,16 @@
         },
         {
             "name": "symfony/dotenv",
-            "version": "v6.4.35",
+            "version": "v6.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "148138ead5d7bb582e93a9cc19b134b42a370365"
+                "reference": "cae019cc92a46fe9e498ea011107f26bdf5d897f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/148138ead5d7bb582e93a9cc19b134b42a370365",
-                "reference": "148138ead5d7bb582e93a9cc19b134b42a370365",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/cae019cc92a46fe9e498ea011107f26bdf5d897f",
+                "reference": "cae019cc92a46fe9e498ea011107f26bdf5d897f",
                 "shasum": ""
             },
             "require": {
@@ -2194,7 +2194,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v6.4.35"
+                "source": "https://github.com/symfony/dotenv/tree/v6.4.36"
             },
             "funding": [
                 {
@@ -2214,7 +2214,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-26T10:15:49+00:00"
+            "time": "2026-03-30T07:25:04+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/modules/imap_folders/js_modules/route_handlers.js
+++ b/modules/imap_folders/js_modules/route_handlers.js
@@ -1,17 +1,5 @@
 function applyFoldersPageHandlers() {
-    $('#imap_server_folder').on("change", function() {
-        $(this).parent().parent().submit();
-    });
-    $('.settings_subtitle').on("click", function() { return Hm_Utils.toggle_page_section($(this).data('target')); });
-    
     bindFoldersEventHandlers();
-    $(function() {
-        const form = $('#form_folder_imap');
-        const autoSubmit = form.data('auto-submit');
-        if (autoSubmit && autoSubmit === 1) {
-            form.submit();
-        }
-    })
 }
 
 function applyFoldersSubscriptionPageHandlers() {
@@ -27,6 +15,4 @@ function applyFoldersSubscriptionPageHandlers() {
     if (email_folder_server && $(email_folder_server[0]).children().length) {
         $($('.subscribe_parent_folder_select .imap_parent_folder_link')[0]).trigger('click');
     }
-
-    bindFoldersEventHandlers();
 }

--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -104,6 +104,7 @@ class Hm_Handler_process_special_folder extends Hm_Handler_Module {
             return;
         }
         $new_folder = $mailbox->prep_folder_name($form['folder']);
+        Hm_Msgs::add('Selected folder: ' . $new_folder, 'warning');
         if (! $new_folder || ! $mailbox->get_folder_status($new_folder)) {
             Hm_Msgs::add('Selected folder not found', 'warning');
             return;

--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -104,7 +104,6 @@ class Hm_Handler_process_special_folder extends Hm_Handler_Module {
             return;
         }
         $new_folder = $mailbox->prep_folder_name($form['folder']);
-        Hm_Msgs::add('Selected folder: ' . $new_folder, 'warning');
         if (! $new_folder || ! $mailbox->get_folder_status($new_folder)) {
             Hm_Msgs::add('Selected folder not found', 'warning');
             return;

--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -332,6 +332,82 @@ class Hm_Handler_process_only_subscribed_folders_setting extends Hm_Handler_Modu
 }
 
 /**
+ * @subpackage imap_folders/handler
+ */
+class Hm_Handler_process_folder_list_all extends Hm_Handler_Module {
+    public function process() {
+        list($success, $form) = $this->process_form(array('imap_server_id'));
+        if (!$success) {
+            return;
+        }
+        $mailbox = Hm_IMAP_List::get_connected_mailbox($form['imap_server_id'], $this->cache);
+        if (!$mailbox || !$mailbox->authed()) {
+            Hm_Msgs::add('Unable to connect to the selected IMAP server', 'danger');
+            return;
+        }
+        $only_subscribed = $this->user_config->get('only_subscribed_folders_setting', false);
+        $folders = $mailbox->get_subfolders('', $only_subscribed, false, false);
+        $all_folders = array();
+        $this->collect_all_folders($mailbox, $folders, $all_folders, $only_subscribed);
+
+        $specials = $this->user_config->get('special_imap_folders', array());
+        $server_specials = array();
+        if (array_key_exists($form['imap_server_id'], $specials)) {
+            $server_specials = $specials[$form['imap_server_id']];
+        }
+        $this->out('imap_all_folders', $all_folders);
+        $this->out('imap_server_specials', $server_specials);
+        $this->out('imap_server_id_out', $form['imap_server_id']);
+    }
+
+    private function collect_all_folders($mailbox, $folders, &$all_folders, $only_subscribed) {
+        foreach ($folders as $folder_name => $folder) {
+            $all_folders[$folder_name] = $folder;
+            if ($folder['children']) {
+                $sub = $mailbox->get_subfolders($folder_name, $only_subscribed, false, false);
+                if (!empty($sub)) {
+                    $this->collect_all_folders($mailbox, $sub, $all_folders, $only_subscribed);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @subpackage imap_folders/output
+ */
+class Hm_Output_filter_folder_list_all extends Hm_Output_Module {
+    protected function output() {
+        $folders = $this->get('imap_all_folders', array());
+        $specials = $this->get('imap_server_specials', array());
+        $server_id = $this->get('imap_server_id_out', '');
+        if (empty($folders)) {
+            return;
+        }
+        $result = array();
+        foreach ($folders as $folder_name => $folder) {
+            $hex_name = bin2hex($folder_name);
+            $special_type = '';
+            foreach ($specials as $type => $assigned_folder) {
+                if ($assigned_folder && $assigned_folder === $folder_name) {
+                    $special_type = $type;
+                    break;
+                }
+            }
+            $result[] = array(
+                'name' => $folder_name,
+                'hex_name' => $hex_name,
+                'basename' => $folder['basename'],
+                'noselect' => !empty($folder['noselect']),
+                'children' => !empty($folder['children']),
+                'special' => $special_type,
+            );
+        }
+        $this->out('imap_folder_list_all', json_encode($result));
+    }
+}
+
+/**
  * @subpackage imap_folders/output
  */
 class Hm_Output_folders_server_select extends Hm_Output_Module {
@@ -753,6 +829,46 @@ class Hm_Output_folders_subscription_content_start extends Hm_Output_Module {
 class Hm_Output_folders_content_start extends Hm_Output_Module {
     protected function output() {
         $res = '<div class="content_title">'.$this->trans('Folders').'</div>';
+        $res .= '<input type="hidden" id="not_set_string" value="'.$this->trans('Not set').'" />';
+        $res .= '<input type="hidden" id="server_error" value="'.$this->trans('You must select a mail account first').'" />';
+        $res .= '<input type="hidden" id="folder_name_error" value="'.$this->trans('New folder name is required').'" />';
+        $res .= '<input type="hidden" id="delete_folder_error" value="'.$this->trans('Folder to delete is required').'" />';
+        $res .= '<input type="hidden" id="delete_folder_confirm" value="'.$this->trans('Are you sure you want to delete this folder, and all the messages in it?').'" />';
+        $res .= '<input type="hidden" id="rename_folder_error" value="'.$this->trans('Folder to rename is required').'" />';
+        $res .= '<div class="folders_page mt-3">';
+        $res .= '<div class="account_folders_list">';
+        $servers = $this->get('imap_servers', array());
+        $specials = $this->get('special_imap_folders', array());
+        if (empty($servers)) {
+            $res .= '<p class="text-muted">'.$this->trans('No mail accounts configured').'</p>';
+        }
+        foreach ($servers as $id => $server) {
+            $server_specials = isset($specials[$id]) ? $specials[$id] : array();
+            $res .= '<div class="account_folder_block card mb-3" data-server-id="'.$this->html_safe($id).'">';
+            $res .= '<div class="card-header account_folder_header d-flex justify-content-between align-items-center" role="button">';
+            $res .= '<div><i class="bi bi-chevron-right account_expand_icon me-2"></i>';
+            $res .= '<i class="bi bi-envelope-fill me-2"></i>';
+            $res .= '<strong>'.$this->html_safe($server['name']).'</strong></div>';
+            $res .= '<span class="badge bg-secondary folder-count-badge" style="display:none;"></span>';
+            $res .= '</div>';
+            $res .= '<div class="card-body account_folder_body" style="display:none;">';
+            $res .= '<div class="d-flex justify-content-between align-items-center mb-3">';
+            $res .= '<button class="btn btn-primary btn-sm create_folder_btn" data-server-id="'.$this->html_safe($id).'">';
+            $res .= '<i class="bi bi-folder-plus me-1"></i>'.$this->trans('Create Folder').'</button>';
+            $res .= '<div class="spinner-border spinner-border-sm text-info folder_loading_spinner" role="status" style="display:none;"><span class="visually-hidden">Loading...</span></div>';
+            $res .= '</div>';
+            $res .= '<div class="folder_table_container">';
+            $res .= '<table class="table table-sm table-hover folder_table" style="display:none;">';
+            $res .= '<thead><tr>';
+            $res .= '<th>'.$this->trans('Folder').'</th>';
+            $res .= '<th>'.$this->trans('Role').'</th>';
+            $res .= '<th class="text-end">'.$this->trans('Actions').'</th>';
+            $res .= '</tr></thead>';
+            $res .= '<tbody class="folder_table_body"></tbody>';
+            $res .= '</table></div>';
+            $res .= '</div></div>';
+        }
+        $res .= '</div></div>';
         return $res;
     }
 }

--- a/modules/imap_folders/setup.php
+++ b/modules/imap_folders/setup.php
@@ -17,22 +17,9 @@ setup_base_page('folders', 'core');
 add_handler('folders', 'folders_server_id', true, 'imap_folders', 'load_user_data', 'after');
 add_handler('folders', 'special_folders', true, 'imap_folders', 'folders_server_id', 'after');
 add_output('folders', 'folders_content_start', true, 'imap_folders', 'version_upgrade_checker', 'after');
-add_output('folders', 'folders_server_select', true, 'imap_folders', 'folders_folder_subscription_button', 'after');
-add_output('folders', 'folders_create_dialog', true, 'imap_folders', 'folders_server_select', 'after');
-add_output('folders', 'folders_rename_dialog', true, 'imap_folders', 'folders_create_dialog', 'after');
-add_output('folders', 'folders_delete_dialog', true, 'imap_folders', 'folders_rename_dialog', 'after');
-add_output('folders', 'folders_folder_subscription_button', true, 'imap_folders', 'folders_content_start', 'after');
 
 add_handler('ajax_imap_folder_expand', 'add_folder_manage_link', true, 'imap_folders', 'imap_folder_expand', 'after');
 add_handler('folders', 'get_only_subscribed_folders_setting', true, 'imap_folders');
-
-// Commented out during development
-add_output('folders', 'folders_trash_dialog', true, 'imap_folders', 'folders_delete_dialog', 'after');
-add_output('folders', 'folders_sent_dialog', true, 'imap_folders', 'folders_trash_dialog', 'after');
-add_output('folders', 'folders_archive_dialog', true, 'imap_folders', 'folders_sent_dialog', 'after');
-add_output('folders', 'folders_draft_dialog', true, 'imap_folders', 'folders_archive_dialog', 'after');
-add_output('folders', 'folders_junk_dialog', true, 'imap_folders', 'folders_draft_dialog', 'after');
-add_output('folders', 'folders_folder_subscription', true, 'imap_folders', 'folders_server_select', 'after');
 
 add_handler('compose', 'special_folders', true, 'imap_folders', 'load_user_data', 'after');
 
@@ -88,6 +75,11 @@ add_handler('ajax_imap_folder_subscription', 'load_imap_servers_from_config', tr
 add_handler('ajax_imap_folder_subscription', 'process_imap_folder_subscription', true, 'imap_folders', 'load_imap_servers_from_config', 'after');
 add_handler('ajax_imap_folder_subscription', 'save_user_data', true, 'core', 'process_special_folder', 'after');
 
+setup_base_ajax_page('ajax_imap_folders_list_all', 'core');
+add_handler('ajax_imap_folders_list_all', 'load_imap_servers_from_config', true, 'imap', 'load_user_data', 'after');
+add_handler('ajax_imap_folders_list_all', 'process_folder_list_all', true, 'imap_folders', 'load_imap_servers_from_config', 'after');
+add_output('ajax_imap_folders_list_all', 'filter_folder_list_all', true, 'imap_folders');
+
 return array(
     'allowed_pages' => array(
         'folders',
@@ -98,12 +90,14 @@ return array(
         'ajax_imap_special_folder',
         'ajax_imap_clear_special_folder',
         'ajax_imap_accept_special_folders',
-        'ajax_imap_folder_subscription'
+        'ajax_imap_folder_subscription',
+        'ajax_imap_folders_list_all'
     ),
     'allowed_output' => array(
         'imap_folders_success' => array(FILTER_VALIDATE_INT, false),
         'imap_special_name' => array(FILTER_UNSAFE_RAW, false),
         'imap_folder_subscription' => array(FILTER_UNSAFE_RAW, false),
+        'imap_folder_list_all' => array(FILTER_UNSAFE_RAW, false),
     ),
     'allowed_get' => array(),
     'allowed_post' => array(

--- a/modules/imap_folders/site.css
+++ b/modules/imap_folders/site.css
@@ -53,6 +53,12 @@
 .badge-role-draft { background-color: #fff3cd; color: #cc7a00; border: 1px solid #ffe69c; }
 .badge-role-junk { background-color: #e8d6f5; color: #59359a; border: 1px solid #c5a3e0; }
 
+.folder_table .dropdown-item.active,
+.folder_table .dropdown-item:active {
+    background-color: var(--bs-primary);
+    color: #fff;
+}
+
 /* Folders page - old dialogs (subscription page) */
 .sent_folder_select, .draft_folder_select, .trash_folder_select, .folder_dialog, .delete_folder_select, .rename_folder_select, .rename_parent_folder_select, .parent_folder_select, .archive_folder_select, .junk_folder_select { display: none; }
 .draft_folder_select, .sent_folder_select, .trash_folder_select, .delete_folder_select, .rename_folder_select, .rename_parent_folder_select, .parent_folder_select, .archive_folder_select { width: fit-content; position: absolute; background-color: #fff; padding: 15px; border: solid 1px #ede8e6; font-weight: normal; padding-left: 10px; min-width: 55px; padding-top: 10px; margin-left: 0px !important; margin-top: 0px; }

--- a/modules/imap_folders/site.css
+++ b/modules/imap_folders/site.css
@@ -1,3 +1,29 @@
+/* Special folder status and helper boxes */
+.special-folder-status-box {
+    background: #fffbe6;
+    border: 1px solid #ffe58f;
+    border-radius: 6px;
+    padding: 1em 1.5em 1em 1.5em;
+    margin-bottom: 1em;
+    position: relative;
+    font-size: 1em;
+}
+.special-folder-helper-box {
+    background: #f7f7f7;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    padding: 1em 1.5em 1em 1.5em;
+    margin-bottom: 1em;
+    position: relative;
+    font-size: 0.95em;
+}
+.special-folder-status-box .btn-close,
+.special-folder-helper-box .btn-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    opacity: 0.5;
+}
 /* Folders page - account list */
 .account_folder_block .card-header { cursor: pointer; transition: background-color 0.2s; }
 .account_folder_block .card-header:hover { background-color: rgba(0,0,0,.05); }

--- a/modules/imap_folders/site.css
+++ b/modules/imap_folders/site.css
@@ -8,11 +8,20 @@
 .folder-count-badge { font-weight: normal; font-size: 0.75rem; }
 
 /* Special folder role badges */
-.badge-role-trash { background-color: #dc3545; color: #fff; }
-.badge-role-sent { background-color: #198754; color: #fff; }
-.badge-role-archive { background-color: #0d6efd; color: #fff; }
-.badge-role-draft { background-color: #fd7e14; color: #fff; }
-.badge-role-junk { background-color: #6f42c1; color: #fff; }
+.badge-role {
+    display: inline-block;
+    padding: 4px 12px;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+}
+.badge-role-trash { background-color: #fce4e6; color: #b02a37; border: 1px solid #f1aeb5; }
+.badge-role-sent { background-color: #d1f5e0; color: #146c43; border: 1px solid #a3cfbb; }
+.badge-role-archive { background-color: #cfe2ff; color: #084298; border: 1px solid #9ec5fe; }
+.badge-role-draft { background-color: #fff3cd; color: #cc7a00; border: 1px solid #ffe69c; }
+.badge-role-junk { background-color: #e8d6f5; color: #59359a; border: 1px solid #c5a3e0; }
 
 /* Folders page - old dialogs (subscription page) */
 .sent_folder_select, .draft_folder_select, .trash_folder_select, .folder_dialog, .delete_folder_select, .rename_folder_select, .rename_parent_folder_select, .parent_folder_select, .archive_folder_select, .junk_folder_select { display: none; }

--- a/modules/imap_folders/site.css
+++ b/modules/imap_folders/site.css
@@ -24,6 +24,10 @@
     right: 10px;
     opacity: 0.5;
 }
+
+.create_folder_btn {
+    margin-left: auto;
+}
 /* Folders page - account list */
 .account_folder_block .card-header { cursor: pointer; transition: background-color 0.2s; }
 .account_folder_block .card-header:hover { background-color: rgba(0,0,0,.05); }

--- a/modules/imap_folders/site.css
+++ b/modules/imap_folders/site.css
@@ -1,12 +1,26 @@
-/* .folder_dialog { margin-left: 40px; margin-top: 10px; margin-bottom: 30px; } */
-/* .folder_dialog input { display: inline-block; margin-top: 15px; } */
+/* Folders page - account list */
+.account_folder_block .card-header { cursor: pointer; transition: background-color 0.2s; }
+.account_folder_block .card-header:hover { background-color: rgba(0,0,0,.05); }
+.account_expand_icon { transition: transform 0.2s; font-size: 0.85rem; }
+.folder_table th { font-size: 0.85rem; white-space: nowrap; }
+.folder_table td { vertical-align: middle; font-size: 0.9rem; }
+.folder_table .btn-group { white-space: nowrap; }
+.folder-count-badge { font-weight: normal; font-size: 0.75rem; }
+
+/* Special folder role badges */
+.badge-role-trash { background-color: #dc3545; color: #fff; }
+.badge-role-sent { background-color: #198754; color: #fff; }
+.badge-role-archive { background-color: #0d6efd; color: #fff; }
+.badge-role-draft { background-color: #fd7e14; color: #fff; }
+.badge-role-junk { background-color: #6f42c1; color: #fff; }
+
+/* Folders page - old dialogs (subscription page) */
 .sent_folder_select, .draft_folder_select, .trash_folder_select, .folder_dialog, .delete_folder_select, .rename_folder_select, .rename_parent_folder_select, .parent_folder_select, .archive_folder_select, .junk_folder_select { display: none; }
 .draft_folder_select, .sent_folder_select, .trash_folder_select, .delete_folder_select, .rename_folder_select, .rename_parent_folder_select, .parent_folder_select, .archive_folder_select { width: fit-content; position: absolute; background-color: #fff; padding: 15px; border: solid 1px #ede8e6; font-weight: normal; padding-left: 10px; min-width: 55px; padding-top: 10px; margin-left: 0px !important; margin-top: 0px; }
 .delete_folder_select, .rename_folder_select, .rename_parent_folder_select, .sent_folder_select, .archive_folder_select, .draft_folder_select, .trash_folder_select, .junk_folder_select, .parent_folder_select { z-index: 10; }
 .folder_row { margin-top: 15px; }
 .close { margin-left: 10%; font-size: 100%; color: teal !important; }
 .sp_folder_title { font-size: 110%; color: #777; }
-/* .sp_description { padding-bottom: 20px; } */
 #draft_val, #sent_val, #trash_val, #junk_val { padding-left: 20px; }
 .manage_folder_icon { vertical-align: -3px; opacity: .3 }
 .manage_folder_link { opacity: 0.6; }

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -1,3 +1,5 @@
+
+console.log('imap_folders/site.js loaded');
 'use strict';
 
 var folder_page_folder_list = function(container, title, link_class, target, id_dest, subscription = false) {
@@ -145,6 +147,7 @@ var folder_subscribe = function(name, state) {
 /* ===== New Account-based Folders Page ===== */
 
 var load_account_folders = function(server_id, block) {
+    console.log('load_account_folders called for', server_id, block);
     var spinner = block.find('.folder_loading_spinner');
     var table = block.find('.folder_table');
     var tbody = block.find('.folder_table_body');
@@ -203,13 +206,14 @@ var get_special_badge_class = function(type) {
 };
 
 var render_folder_table = function(folders, tbody, server_id) {
+    console.log('Folders for account', server_id, folders);
     tbody.empty();
     folders.forEach(function(folder) {
         if (folder.noselect) return;
 
         var specialBadge = '';
         if (folder.special) {
-            specialBadge = '<span class="badge ' + get_special_badge_class(folder.special) + '"><i class="bi ' + get_special_icon(folder.special) + ' me-1"></i>' + hm_trans(get_special_label(folder.special)) + '</span>';
+            specialBadge = '<span class="badge-role ' + get_special_badge_class(folder.special) + '"><i class="bi ' + get_special_icon(folder.special) + ' me-1"></i>' + hm_trans(get_special_label(folder.special)) + '</span>';
         }
 
         var indent = 0;
@@ -223,7 +227,7 @@ var render_folder_table = function(folders, tbody, server_id) {
         var displayName = folder.basename;
         var indentPx = indent * 20;
 
-        var row = '<tr data-folder-hex="' + folder.hex_name + '" data-folder-name="' + esc_html(folder.basename) + '" data-server-id="' + server_id + '">';
+        var row = '<tr data-folder-hex="' + folder.name + '" data-folder-name="' + esc_html(folder.basename) + '" data-server-id="' + server_id + '">';
         row += '<td style="padding-left:' + (indentPx + 8) + 'px"><i class="bi bi-folder2 me-1"></i>' + esc_html(displayName) + '</td>';
         row += '<td>' + specialBadge + '</td>';
         row += '<td class="text-end">';
@@ -295,7 +299,7 @@ var bind_folder_table_actions = function(tbody, server_id) {
         var folderHex = tr.data('folder-hex');
         var block = tr.closest('.account_folder_block');
         // Find what special type this folder currently has
-        var currentBadge = tr.find('.badge.bg-info');
+        var currentBadge = tr.find('.badge-role');
         if (currentBadge.length === 0) return;
         // Determine the type from the set_special_btn that is active
         var activeBtn = tr.find('.set_special_btn.active');

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -270,7 +270,8 @@ var bind_folder_table_actions = function(tbody, server_id) {
         var tr = $(this).closest('tr');
         var folderHex = tr.data('folder-hex');
         var folderName = tr.data('folder-name');
-        show_rename_modal(server_id, folderHex, folderName, tr);
+        var fullFolderName = 'imap_' + server_id + '_' + folderHex;
+        show_rename_modal(server_id, fullFolderName, folderName, tr);
         return false;
     });
 
@@ -278,7 +279,8 @@ var bind_folder_table_actions = function(tbody, server_id) {
         var tr = $(this).closest('tr');
         var folderHex = tr.data('folder-hex');
         var folderName = tr.data('folder-name');
-        show_delete_modal(server_id, folderHex, folderName, tr);
+        var fullFolderName = 'imap_' + server_id + '_' + folderHex;
+        show_delete_modal(server_id, fullFolderName, folderName, tr);
         return false;
     });
 
@@ -299,10 +301,8 @@ var bind_folder_table_actions = function(tbody, server_id) {
         var tr = $(this).closest('tr');
         var folderHex = tr.data('folder-hex');
         var block = tr.closest('.account_folder_block');
-        // Find what special type this folder currently has
         var currentBadge = tr.find('.badge-role');
         if (currentBadge.length === 0) return;
-        // Determine the type from the set_special_btn that is active
         var activeBtn = tr.find('.set_special_btn.active');
         if (activeBtn.length === 0) return;
         var type = activeBtn.data('type');

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -1,5 +1,3 @@
-
-console.log('imap_folders/site.js loaded');
 'use strict';
 
 var folder_page_folder_list = function(container, title, link_class, target, id_dest, subscription = false) {
@@ -388,7 +386,7 @@ var render_folder_table = function(folders, tbody, server_id) {
             row += '</a></li>';
         });
         row += '<li><hr class="dropdown-divider"></li>';
-        row += '<li><a class="dropdown-item clear_special_btn" href="#"><i class="bi bi-x-circle me-2"></i>' + hm_trans('Clear role') + '</a></li>';
+        row += '<li><a class="dropdown-item clear_special_btn" href="#" data-type="' + (folder.special || '') + '"><i class="bi bi-x-circle me-2"></i>' + hm_trans('Clear role') + '</a></li>';
         row += '</ul></div>';
 
         row += '</div></td></tr>';
@@ -441,17 +439,42 @@ var bind_folder_table_actions = function(tbody, server_id) {
         e.preventDefault();
         var tr = $(this).closest('tr');
         var folderHex = tr.data('folder-hex');
+        var folderName = tr.data('folder-name');
+        var type = $(this).data('type');
         var block = tr.closest('.account_folder_block');
-        var currentBadge = tr.find('.badge-role');
-        if (currentBadge.length === 0) return;
-        var activeBtn = tr.find('.set_special_btn.active');
-        if (activeBtn.length === 0) return;
-        var type = activeBtn.data('type');
+        if (!type) return;
         var fullFolderName = 'imap_' + server_id + '_' + folderHex;
-        clear_special_folder(type, fullFolderName, function() {
+        show_clear_special_modal(server_id, fullFolderName, folderName, type, block);
+    });
+};
+
+var show_clear_special_modal = function(server_id, folderHex, folderName, type, block) {
+    var sf = get_special_folder(type);
+    var modal = new Hm_Modal({
+        modalId: 'clearSpecialFolderModal',
+        title: hm_trans('Clear Folder Role'),
+        btnSize: 'sm'
+    });
+
+    var roleLabel = sf ? sf.label : type;
+    var roleIcon = sf ? sf.icon : 'bi-x-circle';
+    var content = '<div class="d-flex align-items-start gap-3 mb-3">';
+    content += '<i class="bi ' + roleIcon + ' fs-2 text-secondary mt-1"></i>';
+    content += '<div>';
+    content += '<div class="fw-semibold fs-6">' + esc_html(folderName) + '</div>';
+    content += '<div class="text-muted small">' + hm_trans('will no longer be set as the') + ' <strong>' + esc_html(roleLabel) + '</strong> ' + hm_trans('folder') + '</div>';
+    content += '</div></div>';
+
+    modal.setContent(content);
+    modal.addFooterBtn(hm_trans('Clear role'), 'btn-warning', function() {
+        var btn = $(this);
+        btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1" role="status"></span>' + hm_trans('Saving...'));
+        clear_special_folder(type, server_id, function() {
+            modal.hide();
             load_account_folders(server_id, block);
         });
     });
+    modal.open();
 };
 
 var show_assign_special_modal = function(server_id, folderHex, folderName, type, block) {

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -227,7 +227,7 @@ var render_folder_table = function(folders, tbody, server_id) {
         var displayName = folder.basename;
         var indentPx = indent * 20;
 
-        var row = '<tr data-folder-hex="' + folder.name + '" data-folder-name="' + esc_html(folder.basename) + '" data-server-id="' + server_id + '">';
+        var row = '<tr data-folder-hex="' + folder.hex_name + '" data-folder-name="' + esc_html(folder.basename) + '" data-server-id="' + server_id + '">';
         row += '<td style="padding-left:' + (indentPx + 8) + 'px"><i class="bi bi-folder2 me-1"></i>' + esc_html(displayName) + '</td>';
         row += '<td>' + specialBadge + '</td>';
         row += '<td class="text-end">';
@@ -288,7 +288,8 @@ var bind_folder_table_actions = function(tbody, server_id) {
         var folderHex = tr.data('folder-hex');
         var type = $(this).data('type');
         var block = tr.closest('.account_folder_block');
-        assign_special_folder(server_id, folderHex, type, function() {
+        var folderName = 'imap_' + server_id + '_' + folderHex;
+        assign_special_folder(server_id, folderName, type, function() {
             load_account_folders(server_id, block);
         });
     });

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -262,7 +262,52 @@ var render_folder_table = function(folders, tbody, server_id) {
     console.log('Folders for account', server_id, folders);
     tbody.empty();
     var table = tbody.closest('.folder_table');
-    if (table.length && tbody.find('.special-folder-helper').length === 0 && !window.localStorage.getItem('specialFolderHelperDismissed')) {
+
+    var specialTypes = ['trash', 'sent', 'archive', 'draft', 'junk'];
+    var found = {};
+    folders.forEach(function(folder) {
+        if (folder.special && specialTypes.includes(folder.special)) {
+            found[folder.special] = folder.basename;
+        }
+    });
+    var missing = specialTypes.filter(function(type) { return !found[type]; });
+
+    tbody.closest('.folder_table').parent().find('.special-folder-status').remove();
+    var statusKey = 'specialFolderStatusDismissed_' + server_id;
+    if ((missing.length > 0 || Object.keys(found).length > 0) && !window.localStorage.getItem(statusKey)) {
+        var msg = '<div class="alert alert-warning special-folder-status-box">';
+        msg += '<button type="button" class="btn-close special-folder-status-close" aria-label="' + hm_trans('Close') + '"></button>';
+        if (missing.length > 0) {
+            msg += '<strong>' + hm_trans('Some special folders are not set for this account:') + '</strong>';
+            msg += '<ul style="margin-bottom:0.5em">';
+            missing.forEach(function(type) {
+                msg += '<li>' + hm_trans(get_special_label(type)) + '</li>';
+            });
+            msg += '</ul>';
+        } else {
+            msg += '<strong>' + hm_trans('All special folders are set for this account.') + '</strong>';
+        }
+        if (Object.keys(found).length > 0) {
+            msg += '<div style="margin-top:0.5em">' + hm_trans('Already set:') + ' ';
+            var setList = Object.keys(found).map(function(type) {
+                return '<span class="badge bg-success me-1">' + hm_trans(get_special_label(type)) + ': ' + esc_html(found[type]) + '</span>';
+            });
+            msg += setList.join(' ');
+            msg += '</div>';
+        }
+        msg += '</div>';
+        var statusRow = $('<tr class="special-folder-status"><td colspan="3">' + msg + '</td></tr>');
+        tbody.before(statusRow);
+        setTimeout(function() {
+            $('.special-folder-status-close').on('click', function() {
+                window.localStorage.setItem(statusKey, '1');
+                statusRow.remove();
+            });
+        }, 0);
+    }
+
+    tbody.closest('.folder_table').parent().find('.special-folder-helper').remove();
+    if (table.length && !window.localStorage.getItem('specialFolderHelperDismissed')) {
         var helperRow = $('<tr class="special-folder-helper"><td colspan="3">' + render_special_folder_helpers() + '</td></tr>');
         tbody.before(helperRow);
         setTimeout(function() {
@@ -274,6 +319,7 @@ var render_folder_table = function(folders, tbody, server_id) {
             });
         }, 0);
     }
+
     folders.forEach(function(folder) {
         if (folder.noselect) return;
 
@@ -372,7 +418,8 @@ var bind_folder_table_actions = function(tbody, server_id) {
         var activeBtn = tr.find('.set_special_btn.active');
         if (activeBtn.length === 0) return;
         var type = activeBtn.data('type');
-        clear_special_folder(type, server_id, function() {
+        var fullFolderName = 'imap_' + server_id + '_' + folderHex;
+        clear_special_folder(type, fullFolderName, function() {
             load_account_folders(server_id, block);
         });
     });

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -153,19 +153,41 @@ var load_account_folders = function(server_id, block) {
     var tbody = block.find('.folder_table_body');
     var badge = block.find('.folder-count-badge');
 
-    spinner.show();
     tbody.empty();
     table.hide();
+    var loadingRow = $('<tr class="loading-folders-row"><td colspan="3" class="text-center py-4">'
+        + '<div class="spinner-border text-info me-2" role="status"></div>'
+        + '<span>' + hm_trans('Loading folders...') + '</span>'
+        + '</td></tr>');
+    tbody.append(loadingRow);
+    table.show();
+    spinner.show();
 
     Hm_Ajax.request(
         [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_list_all'},
         {'name': 'imap_server_id', 'value': server_id}],
         function(res) {
             spinner.hide();
+            tbody.find('.loading-folders-row').remove();
             if (res.imap_folder_list_all) {
                 var folders = JSON.parse(res.imap_folder_list_all);
                 badge.text(folders.length + ' folders').show();
-                render_folder_table(folders, tbody, server_id);
+                if (folders.length === 0) {
+                    var noneRow = $('<tr class="no-folders-row"><td colspan="3" class="text-center py-4 text-muted">'
+                        + '<i class="bi bi-folder-x me-2"></i>'
+                        + hm_trans('No folders found.')
+                        + '</td></tr>');
+                    tbody.append(noneRow);
+                } else {
+                    render_folder_table(folders, tbody, server_id);
+                }
+                table.show();
+            } else {
+                var errorRow = $('<tr class="no-folders-row"><td colspan="3" class="text-center py-4 text-muted">'
+                    + '<i class="bi bi-folder-x me-2"></i>'
+                    + hm_trans('No folders found.')
+                    + '</td></tr>');
+                tbody.append(errorRow);
                 table.show();
             }
         }
@@ -205,9 +227,53 @@ var get_special_badge_class = function(type) {
     return classes[type] || 'bg-secondary';
 };
 
+var specialFolderHelperMessages = {
+    'trash': hm_trans('If set, all deleted messages will automatically go to this folder.'),
+    'junk': hm_trans('If set, all messages marked as spam will be moved here.'),
+    'sent': hm_trans('If set, all sent messages will be saved in this folder.'),
+    'archive': hm_trans('If set, archived messages will be stored here.'),
+    'draft': hm_trans('If set, message drafts will be saved here.')
+};
+
+function render_special_folder_helpers() {
+    var html = '<div class="special-folder-helper-box" style="background:#f7f7f7;border:1px solid #e0e0e0;border-radius:6px;padding:1em 1.5em 1em 1.5em;margin-bottom:1em;position:relative;font-size:0.95em">';
+    html += '<button type="button" class="btn-close special-folder-helper-close" aria-label="' + hm_trans('Close') + '" style="position:absolute;top:10px;right:10px;opacity:0.5"></button>';
+    html += '<strong>' + hm_trans('How to set special folders:') + '</strong><ul class="mb-1">';
+    html += '<li>' + hm_trans('Use the <i class=\"bi bi-tag\"></i> <b>Set as...</b> button next to a folder to assign a special role (Trash, Sent, Junk, etc).') + '</li>';
+    html += '<li>' + hm_trans('Each special folder changes how messages are handled automatically:') + '</li>';
+    html += '<ul style="margin-bottom:0">';
+    html += '<li><b>' + hm_trans('Trash') + '</b>: ' + specialFolderHelperMessages['trash'] + '</li>';
+    html += '<li><b>' + hm_trans('Junk') + '</b>: ' + specialFolderHelperMessages['junk'] + '</li>';
+    html += '<li><b>' + hm_trans('Sent') + '</b>: ' + specialFolderHelperMessages['sent'] + '</li>';
+    html += '<li><b>' + hm_trans('Archive') + '</b>: ' + specialFolderHelperMessages['archive'] + '</li>';
+    html += '<li><b>' + hm_trans('Draft') + '</b>: ' + specialFolderHelperMessages['draft'] + '</li>';
+    html += '</ul>';
+    html += '</ul>';
+    html += hm_trans('You can clear a special role using the <b>Clear role</b> option in the same menu.');
+    html += '<div class="form-check mt-3" style="user-select:none">';
+    html += '<input class="form-check-input" type="checkbox" value="1" id="dontShowSpecialHelperAgain">';
+    html += '<label class="form-check-label" for="dontShowSpecialHelperAgain" style="font-weight:normal">' + hm_trans("Don't show this message again") + '</label>';
+    html += '</div>';
+    html += '</div>';
+    return html;
+}
+
 var render_folder_table = function(folders, tbody, server_id) {
     console.log('Folders for account', server_id, folders);
     tbody.empty();
+    var table = tbody.closest('.folder_table');
+    if (table.length && tbody.find('.special-folder-helper').length === 0 && !window.localStorage.getItem('specialFolderHelperDismissed')) {
+        var helperRow = $('<tr class="special-folder-helper"><td colspan="3">' + render_special_folder_helpers() + '</td></tr>');
+        tbody.before(helperRow);
+        setTimeout(function() {
+            $('.special-folder-helper-close').on('click', function() {
+                if ($('#dontShowSpecialHelperAgain').is(':checked')) {
+                    window.localStorage.setItem('specialFolderHelperDismissed', '1');
+                }
+                helperRow.remove();
+            });
+        }, 0);
+    }
     folders.forEach(function(folder) {
         if (folder.noselect) return;
 
@@ -438,7 +504,6 @@ function bindFoldersEventHandlers() {
         }
     });
 
-    // Create folder button
     $('.create_folder_btn').on('click', function() {
         var server_id = $(this).data('server-id');
         var block = $(this).closest('.account_folder_block');

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -194,46 +194,69 @@ var load_account_folders = function(server_id, block) {
     );
 };
 
-var get_special_icon = function(type) {
-    var icons = {
-        'trash': 'bi-trash3',
-        'sent': 'bi-send-check-fill',
-        'archive': 'bi-archive',
-        'draft': 'bi-pencil-square',
-        'junk': 'bi-envelope-x-fill'
-    };
-    return icons[type] || '';
-};
 
-var get_special_label = function(type) {
-    var labels = {
-        'trash': 'Trash',
-        'sent': 'Sent',
-        'archive': 'Archive',
-        'draft': 'Draft',
-        'junk': 'Junk'
-    };
-    return labels[type] || '';
-};
+// Unified special folder definitions
+var specialFolders = [
+    {
+        type: 'trash',
+        icon: 'bi-trash3',
+        label: hm_trans('Trash'),
+        badgeClass: 'badge-role-trash',
+        helper: hm_trans('If set, all deleted messages will automatically go to this folder.')
+    },
+    {
+        type: 'sent',
+        icon: 'bi-send-check-fill',
+        label: hm_trans('Sent'),
+        badgeClass: 'badge-role-sent',
+        helper: hm_trans('If set, all sent messages will be saved in this folder.')
+    },
+    {
+        type: 'archive',
+        icon: 'bi-archive',
+        label: hm_trans('Archive'),
+        badgeClass: 'badge-role-archive',
+        helper: hm_trans('If set, archived messages will be stored here.')
+    },
+    {
+        type: 'draft',
+        icon: 'bi-pencil-square',
+        label: hm_trans('Draft'),
+        badgeClass: 'badge-role-draft',
+        helper: hm_trans('If set, message drafts will be saved here.')
+    },
+    {
+        type: 'junk',
+        icon: 'bi-envelope-x-fill',
+        label: hm_trans('Junk'),
+        badgeClass: 'badge-role-junk',
+        helper: hm_trans('If set, all messages marked as spam will be moved here.')
+    }
+];
 
-var get_special_badge_class = function(type) {
-    var classes = {
-        'trash': 'badge-role-trash',
-        'sent': 'badge-role-sent',
-        'archive': 'badge-role-archive',
-        'draft': 'badge-role-draft',
-        'junk': 'badge-role-junk'
-    };
-    return classes[type] || 'bg-secondary';
-};
+function get_special_folder(type) {
+    return specialFolders.find(function(f) { return f.type === type; });
+}
 
-var specialFolderHelperMessages = {
-    'trash': hm_trans('If set, all deleted messages will automatically go to this folder.'),
-    'junk': hm_trans('If set, all messages marked as spam will be moved here.'),
-    'sent': hm_trans('If set, all sent messages will be saved in this folder.'),
-    'archive': hm_trans('If set, archived messages will be stored here.'),
-    'draft': hm_trans('If set, message drafts will be saved here.')
-};
+function get_special_icon(type) {
+    var f = get_special_folder(type);
+    return f ? f.icon : '';
+}
+
+function get_special_label(type) {
+    var f = get_special_folder(type);
+    return f ? f.label : '';
+}
+
+function get_special_badge_class(type) {
+    var f = get_special_folder(type);
+    return f ? f.badgeClass : 'bg-secondary';
+}
+
+function get_special_helper(type) {
+    var f = get_special_folder(type);
+    return f ? f.helper : '';
+}
 
 function render_special_folder_helpers() {
     var html = '<div class="special-folder-helper-box" style="background:#f7f7f7;border:1px solid #e0e0e0;border-radius:6px;padding:1em 1.5em 1em 1.5em;margin-bottom:1em;position:relative;font-size:0.95em">';
@@ -242,11 +265,9 @@ function render_special_folder_helpers() {
     html += '<li>' + hm_trans('Use the <i class=\"bi bi-tag\"></i> <b>Set as...</b> button next to a folder to assign a special role (Trash, Sent, Junk, etc).') + '</li>';
     html += '<li>' + hm_trans('Each special folder changes how messages are handled automatically:') + '</li>';
     html += '<ul style="margin-bottom:0">';
-    html += '<li><b>' + hm_trans('Trash') + '</b>: ' + specialFolderHelperMessages['trash'] + '</li>';
-    html += '<li><b>' + hm_trans('Junk') + '</b>: ' + specialFolderHelperMessages['junk'] + '</li>';
-    html += '<li><b>' + hm_trans('Sent') + '</b>: ' + specialFolderHelperMessages['sent'] + '</li>';
-    html += '<li><b>' + hm_trans('Archive') + '</b>: ' + specialFolderHelperMessages['archive'] + '</li>';
-    html += '<li><b>' + hm_trans('Draft') + '</b>: ' + specialFolderHelperMessages['draft'] + '</li>';
+    specialFolders.forEach(function(f) {
+        html += '<li><b>' + f.label + '</b>: ' + f.helper + '</li>';
+    });
     html += '</ul>';
     html += '</ul>';
     html += hm_trans('You can clear a special role using the <b>Clear role</b> option in the same menu.');
@@ -263,7 +284,7 @@ var render_folder_table = function(folders, tbody, server_id) {
     tbody.empty();
     var table = tbody.closest('.folder_table');
 
-    var specialTypes = ['trash', 'sent', 'archive', 'draft', 'junk'];
+    var specialTypes = specialFolders.map(function(f) { return f.type; });
     var found = {};
     folders.forEach(function(folder) {
         if (folder.special && specialTypes.includes(folder.special)) {
@@ -346,21 +367,15 @@ var render_folder_table = function(folders, tbody, server_id) {
         row += '<div class="btn-group btn-group-sm" role="group">';
         row += '<button class="btn btn-outline-primary btn-sm folder_rename_btn" title="' + hm_trans('Rename') + '"><i class="bi bi-pencil"></i></button>';
         row += '<button class="btn btn-outline-danger btn-sm folder_delete_btn" title="' + hm_trans('Delete') + '"><i class="bi bi-trash"></i></button>';
+        row += '<button class="btn btn-outline-success btn-sm folder_create_child_btn" title="' + hm_trans('Create subfolder') + '"><i class="bi bi-folder-plus"></i></button>';
 
-        var roleButtons = [
-            {type: 'trash', icon: 'bi-trash3', label: 'Trash'},
-            {type: 'archive', icon: 'bi-archive', label: 'Archive'},
-            {type: 'draft', icon: 'bi-pencil-square', label: 'Draft'},
-            {type: 'junk', icon: 'bi-envelope-x-fill', label: 'Junk'},
-            {type: 'sent', icon: 'bi-send-check-fill', label: 'Sent'}
-        ];
 
         row += '<div class="btn-group btn-group-sm dropdown" role="group">';
         row += '<button class="btn btn-outline-secondary btn-sm dropdown-toggle" data-bs-toggle="dropdown" title="' + hm_trans('Set as...') + '"><i class="bi bi-tag"></i></button>';
         row += '<ul class="dropdown-menu dropdown-menu-end">';
-        roleButtons.forEach(function(rb) {
+        specialFolders.forEach(function(rb) {
             var active = folder.special === rb.type ? ' active' : '';
-            row += '<li><a class="dropdown-item set_special_btn' + active + '" href="#" data-type="' + rb.type + '"><i class="bi ' + rb.icon + ' me-2"></i>' + hm_trans(rb.label);
+            row += '<li><a class="dropdown-item set_special_btn' + active + '" href="#" data-type="' + rb.type + '"><i class="bi ' + rb.icon + ' me-2"></i>' + rb.label;
             if (folder.special === rb.type) {
                 row += ' <i class="bi bi-check-lg ms-2"></i>';
             }
@@ -378,6 +393,15 @@ var render_folder_table = function(folders, tbody, server_id) {
 };
 
 var bind_folder_table_actions = function(tbody, server_id) {
+        tbody.find('.folder_create_child_btn').off('click').on('click', function() {
+            var tr = $(this).closest('tr');
+            var folderHex = tr.data('folder-hex');
+            var folderName = tr.data('folder-name');
+            var block = tr.closest('.account_folder_block');
+            // Pass parent folder hex to modal
+            show_create_folder_modal(server_id, block, folderHex, tr);
+            return false;
+        });
     tbody.find('.folder_rename_btn').off('click').on('click', function() {
         var tr = $(this).closest('tr');
         var folderHex = tr.data('folder-hex');
@@ -494,14 +518,18 @@ var show_delete_modal = function(server_id, folderHex, folderName, tr) {
     modal.open();
 };
 
-var show_create_folder_modal = function(server_id, block) {
+var show_create_folder_modal = function(server_id, block, parentHex, parentTr) {
     var modal = new Hm_Modal({
         modalId: 'createFolderModal',
         title: hm_trans('Create a New Folder'),
         btnSize: 'sm'
     });
 
-    var content = '<div class="form-floating mb-3">';
+    var content = '';
+    if (parentHex) {
+        content += '<div class="mb-2"><small>' + hm_trans('Parent folder:') + ' <span class="badge bg-secondary">' + esc_html(parentTr ? parentTr.data('folder-name') : '') + '</span></small></div>';
+    }
+    content += '<div class="form-floating mb-3">';
     content += '<input type="text" class="form-control" id="modal_create_value" placeholder="' + hm_trans('New Folder Name') + '">';
     content += '<label for="modal_create_value">' + hm_trans('New Folder Name') + '</label>';
     content += '</div>';
@@ -513,10 +541,14 @@ var show_create_folder_modal = function(server_id, block) {
             Hm_Notices.show($('#folder_name_error').val(), 'danger');
             return;
         }
+        var fullFolderName = folder;
+        if (parentHex) {
+            fullFolderName = parentTr ? parentTr.data('folder-name') + '/' + folder : folder;
+        }
         Hm_Ajax.request(
             [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_create'},
             {'name': 'imap_server_id', 'value': server_id},
-            {'name': 'folder', 'value': folder}],
+            {'name': 'folder', 'value': fullFolderName}],
             function(res) {
                 if (res.imap_folders_success) {
                     modal.hide();

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -230,7 +230,7 @@ var specialFolders = [
         icon: 'bi-envelope-x-fill',
         label: hm_trans('Junk'),
         badgeClass: 'badge-role-junk',
-        helper: hm_trans('If set, all messages marked as spam will be moved here.')
+        helper: hm_trans('If set, all junk and spam messages will be moved here.')
     }
 ];
 
@@ -423,12 +423,11 @@ var bind_folder_table_actions = function(tbody, server_id) {
         e.preventDefault();
         var tr = $(this).closest('tr');
         var folderHex = tr.data('folder-hex');
+        var folderName = tr.data('folder-name');
         var type = $(this).data('type');
         var block = tr.closest('.account_folder_block');
-        var folderName = 'imap_' + server_id + '_' + folderHex;
-        assign_special_folder(server_id, folderName, type, function() {
-            load_account_folders(server_id, block);
-        });
+        var fullFolderName = 'imap_' + server_id + '_' + folderHex;
+        show_assign_special_modal(server_id, fullFolderName, folderName, type, block);
     });
 
     tbody.find('.clear_special_btn').off('click').on('click', function(e) {
@@ -446,6 +445,38 @@ var bind_folder_table_actions = function(tbody, server_id) {
             load_account_folders(server_id, block);
         });
     });
+};
+
+var show_assign_special_modal = function(server_id, folderHex, folderName, type, block) {
+    var sf = get_special_folder(type);
+    var modal = new Hm_Modal({
+        modalId: 'assignSpecialFolderModal',
+        title: hm_trans('Set Special Folder Role'),
+        btnSize: 'sm'
+    });
+
+    var roleLabel = sf ? sf.label : type;
+    var roleIcon = sf ? sf.icon : '';
+    var content = '<div class="d-flex align-items-start gap-3 mb-3">';
+    content += '<i class="bi ' + roleIcon + ' fs-2 text-secondary mt-1"></i>';
+    content += '<div>';
+    content += '<div class="fw-semibold fs-6">' + esc_html(folderName) + '</div>';
+    content += '<div class="text-muted small">' + hm_trans('will be set as the') + ' <strong>' + esc_html(roleLabel) + '</strong> ' + hm_trans('folder') + '</div>';
+    content += '</div></div>';
+    if (sf) {
+        content += '<div class="alert alert-secondary py-2 px-3 mb-0 small">' + sf.helper + '</div>';
+    }
+
+    modal.setContent(content);
+    modal.addFooterBtn(hm_trans('Confirm'), 'btn-primary', function() {
+        var btn = $(this);
+        btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1" role="status"></span>' + hm_trans('Saving...'));
+        assign_special_folder(server_id, folderHex, type, function() {
+            modal.hide();
+            load_account_folders(server_id, block);
+        });
+    });
+    modal.open();
 };
 
 var show_rename_modal = function(server_id, folderHex, folderName, tr) {

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -173,9 +173,10 @@ var load_account_folders = function(server_id, block) {
                 var folders = JSON.parse(res.imap_folder_list_all);
                 badge.text(folders.length + ' folders').show();
                 if (folders.length === 0) {
-                    var noneRow = $('<tr class="no-folders-row"><td colspan="3" class="text-center py-4 text-muted">'
-                        + '<i class="bi bi-folder-x me-2"></i>'
-                        + hm_trans('No folders found.')
+                    var noneRow = $('<tr class="no-folders-row"><td colspan="3" class="text-center py-5 text-muted">'
+                        + '<i class="bi bi-folder2-open fs-2 d-block mb-2"></i>'
+                        + '<div class="fw-semibold">' + hm_trans('No folders found') + '</div>'
+                        + '<div class="small">' + hm_trans('This account has no folders yet. Use the Create button to add one.') + '</div>'
                         + '</td></tr>');
                     tbody.append(noneRow);
                 } else {
@@ -183,12 +184,18 @@ var load_account_folders = function(server_id, block) {
                 }
                 table.show();
             } else {
-                var errorRow = $('<tr class="no-folders-row"><td colspan="3" class="text-center py-4 text-muted">'
-                    + '<i class="bi bi-folder-x me-2"></i>'
-                    + hm_trans('No folders found.')
+                var errorRow = $('<tr class="no-folders-row"><td colspan="3" class="text-center py-5">'
+                    + '<i class="bi bi-exclamation-triangle fs-2 d-block mb-2 text-warning"></i>'
+                    + '<div class="fw-semibold">' + hm_trans('Could not load folders') + '</div>'
+                    + '<div class="small text-muted">' + hm_trans('There was a problem connecting to this account. Please check your connection and try again.') + '</div>'
+                    + '<button class="btn btn-sm btn-outline-secondary mt-3 retry-load-folders">'
+                    + '<i class="bi bi-arrow-clockwise me-1"></i>' + hm_trans('Retry') + '</button>'
                     + '</td></tr>');
                 tbody.append(errorRow);
                 table.show();
+                errorRow.find('.retry-load-folders').on('click', function() {
+                    load_account_folders(server_id, block);
+                });
             }
         }
     );
@@ -317,8 +324,8 @@ var render_folder_table = function(folders, tbody, server_id) {
             msg += '</div>';
         }
         msg += '</div>';
-        var statusRow = $('<tr class="special-folder-status"><td colspan="3">' + msg + '</td></tr>');
-        tbody.before(statusRow);
+        var statusRow = $('<div class="special-folder-status">' + msg + '</div>');
+        tbody.closest('.folder_table').before(statusRow);
         setTimeout(function() {
             $('.special-folder-status-close').on('click', function() {
                 window.localStorage.setItem(statusKey, '1');
@@ -329,8 +336,8 @@ var render_folder_table = function(folders, tbody, server_id) {
 
     tbody.closest('.folder_table').parent().find('.special-folder-helper').remove();
     if (table.length && !window.localStorage.getItem('specialFolderHelperDismissed')) {
-        var helperRow = $('<tr class="special-folder-helper"><td colspan="3">' + render_special_folder_helpers() + '</td></tr>');
-        tbody.before(helperRow);
+        var helperRow = $('<div class="special-folder-helper">' + render_special_folder_helpers() + '</div>');
+        tbody.closest('.folder_table').before(helperRow);
         setTimeout(function() {
             $('.special-folder-helper-close').on('click', function() {
                 if ($('#dontShowSpecialHelperAgain').is(':checked')) {

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -365,10 +365,9 @@ var render_folder_table = function(folders, tbody, server_id) {
         row += '<td>' + specialBadge + '</td>';
         row += '<td class="text-end">';
         row += '<div class="btn-group btn-group-sm" role="group">';
-        row += '<button class="btn btn-outline-primary btn-sm folder_rename_btn" title="' + hm_trans('Rename') + '"><i class="bi bi-pencil"></i></button>';
-        row += '<button class="btn btn-outline-danger btn-sm folder_delete_btn" title="' + hm_trans('Delete') + '"><i class="bi bi-trash"></i></button>';
-        row += '<button class="btn btn-outline-success btn-sm folder_create_child_btn" title="' + hm_trans('Create subfolder') + '"><i class="bi bi-folder-plus"></i></button>';
-
+        row += '<button class="btn btn-outline-secondary btn-sm folder_rename_btn" title="' + hm_trans('Rename') + '"><i class="bi bi-pencil"></i></button>';
+        row += '<button class="btn btn-outline-secondary btn-sm folder_delete_btn" title="' + hm_trans('Delete') + '"><i class="bi bi-trash"></i></button>';
+        row += '<button class="btn btn-outline-secondary btn-sm folder_create_child_btn" title="' + hm_trans('Create subfolder') + '"><i class="bi bi-folder-plus"></i></button>';
 
         row += '<div class="btn-group btn-group-sm dropdown" role="group">';
         row += '<button class="btn btn-outline-secondary btn-sm dropdown-toggle" data-bs-toggle="dropdown" title="' + hm_trans('Set as...') + '"><i class="bi bi-tag"></i></button>';
@@ -456,21 +455,24 @@ var show_rename_modal = function(server_id, folderHex, folderName, tr) {
         btnSize: 'sm'
     });
 
-    var content = '<div class="mb-3">';
-    content += '<label class="form-label">' + hm_trans('Current name') + ': <strong>' + esc_html(folderName) + '</strong></label>';
-    content += '</div>';
-    content += '<div class="form-floating mb-3">';
-    content += '<input type="text" class="form-control" id="modal_rename_value" placeholder="' + hm_trans('New Folder Name') + '">';
+    var content = '<div class="form-floating mb-3">';
+    content += '<input type="text" class="form-control" id="modal_rename_value" placeholder="' + hm_trans('New Folder Name') + '" value="' + esc_html(folderName) + '">';
     content += '<label for="modal_rename_value">' + hm_trans('New Folder Name') + '</label>';
     content += '</div>';
 
     modal.setContent(content);
+    modal.modal.on('shown.bs.modal', function() {
+        var input = document.getElementById('modal_rename_value');
+        if (input) { input.focus(); input.select(); }
+    });
     modal.addFooterBtn(hm_trans('Rename'), 'btn-primary', function() {
         var newName = $('#modal_rename_value').val().trim();
         if (!newName.length) {
             Hm_Notices.show($('#rename_folder_error').val(), 'danger');
             return;
         }
+        var btn = $(this);
+        btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1" role="status"></span>' + hm_trans('Rename'));
         Hm_Ajax.request(
             [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_rename'},
             {'name': 'imap_server_id', 'value': server_id},
@@ -482,6 +484,8 @@ var show_rename_modal = function(server_id, folderHex, folderName, tr) {
                     var block = tr.closest('.account_folder_block');
                     load_account_folders(server_id, block);
                     Hm_Folders.reload_folders(true);
+                } else {
+                    btn.prop('disabled', false).html(hm_trans('Rename'));
                 }
             }
         );
@@ -501,6 +505,8 @@ var show_delete_modal = function(server_id, folderHex, folderName, tr) {
 
     modal.setContent(content);
     modal.addFooterBtn(hm_trans('Delete'), 'btn-danger', function() {
+        var btn = $(this);
+        btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1" role="status"></span>' + hm_trans('Delete'));
         Hm_Ajax.request(
             [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_delete'},
             {'name': 'imap_server_id', 'value': server_id},
@@ -511,6 +517,8 @@ var show_delete_modal = function(server_id, folderHex, folderName, tr) {
                     var block = tr.closest('.account_folder_block');
                     load_account_folders(server_id, block);
                     Hm_Folders.reload_folders(true);
+                } else {
+                    btn.prop('disabled', false).html(hm_trans('Delete'));
                 }
             }
         );
@@ -541,6 +549,8 @@ var show_create_folder_modal = function(server_id, block, parentHex, parentTr) {
             Hm_Notices.show($('#folder_name_error').val(), 'danger');
             return;
         }
+        var btn = $(this);
+        btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1" role="status"></span>' + hm_trans('Create'));
         var params = [
             {'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_create'},
             {'name': 'imap_server_id', 'value': server_id},
@@ -556,6 +566,8 @@ var show_create_folder_modal = function(server_id, block, parentHex, parentTr) {
                     modal.hide();
                     load_account_folders(server_id, block);
                     Hm_Folders.reload_folders(true);
+                } else {
+                    btn.prop('disabled', false).html(hm_trans('Create'));
                 }
             }
         );

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -541,14 +541,16 @@ var show_create_folder_modal = function(server_id, block, parentHex, parentTr) {
             Hm_Notices.show($('#folder_name_error').val(), 'danger');
             return;
         }
-        var fullFolderName = folder;
+        var params = [
+            {'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_create'},
+            {'name': 'imap_server_id', 'value': server_id},
+            {'name': 'folder', 'value': folder}
+        ];
         if (parentHex) {
-            fullFolderName = parentTr ? parentTr.data('folder-name') + '/' + folder : folder;
+            params.push({'name': 'parent', 'value': 'imap_' + server_id + '_' + parentHex});
         }
         Hm_Ajax.request(
-            [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_create'},
-            {'name': 'imap_server_id', 'value': server_id},
-            {'name': 'folder', 'value': fullFolderName}],
+            params,
             function(res) {
                 if (res.imap_folders_success) {
                     modal.hide();

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -10,23 +10,19 @@ var folder_page_folder_list = function(container, title, link_class, target, id_
     folder_location.prepend(folders);
     folder_location.show();
 
-    // 1. Get the <a> element
     const link = document.querySelector('.'+link_class);
-    // 2. Save the <i> element
     const original_icon = link.querySelector('i');
     const original_icon_clone = original_icon.cloneNode(true);
-    // 3. Create the spinner
     const spinner = document.createElement('div');
     spinner.className = 'spinner-border text-info spinner-border-sm';
     spinner.setAttribute('role', 'status');
     spinner.setAttribute('id', 'imap-spinner');
     spinner.innerHTML = '<span class="sr-only"></span>';
-    // 4. Replace the icon with the spinner
     if (original_icon.parentNode === link) {
         link.replaceChild(spinner, original_icon);
     }
- 
-    var child_link_target =  folder_location.find('a.'+link_class).data('target')
+
+    var child_link_target = folder_location.find('a.'+link_class).data('target');
     $('.' + link_class, folder_location).on("click", function () { return expand_folders_page_list($(this).data('target'), container, link_class, target, id_dest, subscription); });
     $('a', folder_location).not('.'+link_class).not('.close').off('click');
     $('a', folder_location).not('.'+link_class).not('.close').on("click", function() { set_folders_page_value($(this).data('id'), container, target, id_dest); return false; });
@@ -41,7 +37,7 @@ var folder_page_folder_list = function(container, title, link_class, target, id_
     return false;
 };
 
-var expand_folders_page_list = function(path, container, link_class, target, id_dest, lsub, original_icon = null, parent_icon_link = null) {
+var expand_folders_page_list = function(path, container, link_class, target, id_dest, lsub, original_icon, parent_icon_link) {
     var detail = Hm_Utils.parse_folder_path(path, 'imap');
     var list = $('.imap_'+detail.server_id+'_'+Hm_Utils.clean_selector(detail.folder), $('.'+container));
     if ($('li', list).length === 0) {
@@ -68,13 +64,10 @@ var expand_folders_page_list = function(path, container, link_class, target, id_
                             $('.folder_subscription').on("change", function() { folder_subscribe(this.id, $('#'+this.id).is(':checked')); return false; });
                         }
                     }
-                    if(original_icon != null) {
-                        // 5. Restore the icon by removing the spinner element
+                    if(original_icon != null && parent_icon_link != null) {
                         const spinner_element = document.getElementById('imap-spinner');
                         if (spinner_element && spinner_element.parentNode === parent_icon_link) {
-                            if(parent_icon_link != null) {
-                                parent_icon_link.replaceChild(original_icon, spinner_element);
-                            }
+                            parent_icon_link.replaceChild(original_icon, spinner_element);
                         }
                     }
                 }
@@ -105,163 +98,12 @@ var set_folders_page_value = function(id, container, target, id_dest) {
         } else {
             $('#children_number').val(0);
         }
-        
     }
     list.hide();
-
 };
 
-var folder_page_delete = function() {
-    var children_number = parseInt($('#children_number').val());
-    var val = $('#delete_source').val();
-    var id = $('#imap_server_folder').val();
-    if (!id.length) {
-        Hm_Notices.show($('#server_error').val(), 'danger');
-        return;
-    }
-    if (!val.length) {
-        Hm_Notices.show($('#delete_folder_error').val(), 'danger');
-        return;
-    }
-
-    let message = "";
-    if (children_number) {
-        message = `<p>${hm_trans('This folder contains '+ children_number +' sub-folders.')}</p>`;
-    }
-
-    const modal = new Hm_Modal({
-        modalId: 'emptySubjectBodyModal',
-        title: hm_trans("Deletion confirmation"),
-        btnSize: 'sm'
-    });
-
-    modal.addFooterBtn(hm_trans('Delete anyway'), 'btn-warning', handleDeleteFolder);
-    modal.setContent(message + $('#delete_folder_confirm').val());
-    modal.open();
-    function handleDeleteFolder() {
-        Hm_Ajax.request(
-            [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_delete'},
-            {'name': 'imap_server_id', value: id},
-            {'name': 'folder', 'value': val}],
-            function(res) {
-                if (res.imap_folders_success) {
-                    $('#delete_source').val('');
-                    $('.selected_delete').html('');
-                    Hm_Folders.reload_folders(true);
-                }
-            }
-        );
-        modal.hide();
-    };
-};
-
-var folder_page_rename = function() {
-    var val = $('#rename_value').val();
-    var par = $('#rename_parent_source').val().trim();
-    var folder = $('#rename_source').val().trim();
-    var notices = [];
-    var id = $('#imap_server_folder').val();
-    if (!id.length) {
-        Hm_Notices.show($('#server_error').val(), 'danger');
-        return;
-    }
-    if (!val.length) {
-        notices.push($('#rename_folder_error').val());
-    }
-    if (!folder.length) {
-        notices.push($('#folder_name_error').val());
-    }
-    if (notices.length) {
-        notices.forEach((msg) => {
-            Hm_Notices.show(msg, 'danger');
-        });
-        return;
-    }
-    Hm_Ajax.request(
-        [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_rename'},
-        {'name': 'imap_server_id', value: id},
-        {'name': 'folder', 'value': folder},
-        {'name': 'parent', 'value': par},
-        {'name': 'new_folder', 'value': val}],
-        function(res) {
-            if (res.imap_folders_success) {
-                $('#rename_value').val('');
-                $('#rename_source').val('');
-                $('#rename_parent_source').val('');
-                $('.selected_rename').html('');
-                $('.selected_rename_parent').html('');
-                Hm_Folders.reload_folders(true);
-            }
-        }
-    );
-};
-
-
-var folder_page_assign_trash = function() {
-    var id = $('#imap_server_folder').val();
-    var folder = $('#trash_source').val();
-    if (id && folder) {
-        assign_special_folder(id, folder, 'trash', function(res) {
-            $('#trash_val').text(res.imap_special_name);
-            $('.selected_trash').text('');
-        });
-    }
-};
-
-var folder_page_assign_sent = function() {
-    var id = $('#imap_server_folder').val();
-    var folder = $('#sent_source').val();
-    if (id && folder) {
-        assign_special_folder(id, folder, 'sent', function(res) {
-            $('#sent_val').text(res.imap_special_name);
-            $('.selected_sent').text('');
-        });
-    }
-};
-
-var folder_page_assign_archive = function() {
-    var id = $('#imap_server_folder').val();
-    var folder = $('#archive_source').val();
-    if (id && folder) {
-        assign_special_folder(id, folder, 'archive', function(res) {
-            $('#archive_val').text(res.imap_special_name);
-            $('.selected_archive').text('');
-        });
-    }
-};
-
-var folder_page_assign_draft = function() {
-    var id = $('#imap_server_folder').val();
-    var folder = $('#draft_source').val();
-    if (id && folder) {
-        assign_special_folder(id, folder, 'draft', function(res) {
-            $('#draft_val').text(res.imap_special_name);
-            $('.selected_draft').text('');
-        });
-    }
-};
-
-var folder_page_assign_junk = function() {
-    var id = $('#imap_server_folder').val();
-    var folder = $('#junk_source').val();
-    if (id && folder) {
-        assign_special_folder(id, folder, 'junk', function(res) {
-            $('#junk_val').text(res.imap_special_name);
-            $('.selected_junk').text('');
-        });
-    }
-};
-
-var clear_special_folder = function(type) {
-    var id = $('#imap_server_folder').val();
-    if (id) {
-        Hm_Ajax.request(
-            [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_clear_special_folder'},
-            {'name': 'imap_server_id', 'value': id},
-            {'name': 'special_folder_type', 'value': type}],
-            function(res) { $('#'+type+'_val').text($('#not_set_string').val()); }
-        );
-    }
+var esc_html = function(str) {
+    return $('<div>').text(str).html();
 };
 
 var assign_special_folder = function(id, folder, type, callback) {
@@ -270,6 +112,15 @@ var assign_special_folder = function(id, folder, type, callback) {
         {'name': 'imap_server_id', 'value': id},
         {'name': 'special_folder_type', 'value': type},
         {'name': 'folder', 'value': folder}],
+        callback
+    );
+};
+
+var clear_special_folder = function(type, server_id, callback) {
+    Hm_Ajax.request(
+        [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_clear_special_folder'},
+        {'name': 'imap_server_id', 'value': server_id},
+        {'name': 'special_folder_type', 'value': type}],
         callback
     );
 };
@@ -291,57 +142,302 @@ var folder_subscribe = function(name, state) {
     );
 };
 
-var folder_page_create = function() {
-    var par = $('#create_parent').val();
-    var folder = $('#create_value').val().trim();
-    var id = $('#imap_server_folder').val();
-    if (!id.length) {
-        Hm_Notices.show($('#server_error').val());
-        return;
-    }
-    if (!folder.length) {
-        Hm_Notices.show($('#folder_name_error').val());
-        return;
-    }
+/* ===== New Account-based Folders Page ===== */
+
+var load_account_folders = function(server_id, block) {
+    var spinner = block.find('.folder_loading_spinner');
+    var table = block.find('.folder_table');
+    var tbody = block.find('.folder_table_body');
+    var badge = block.find('.folder-count-badge');
+
+    spinner.show();
+    tbody.empty();
+    table.hide();
+
     Hm_Ajax.request(
-        [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_create'},
-        {'name': 'imap_server_id', value: id},
-        {'name': 'folder', 'value': folder},
-        {'name': 'parent', 'value': par}],
+        [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_list_all'},
+        {'name': 'imap_server_id', 'value': server_id}],
         function(res) {
-            if (res.imap_folders_success) {
-                $('#create_value').val('');
-                $('#create_parent').val('');
-                $('.selected_parent').html('');
-                Hm_Folders.reload_folders(true);
+            spinner.hide();
+            if (res.imap_folder_list_all) {
+                var folders = JSON.parse(res.imap_folder_list_all);
+                badge.text(folders.length + ' folders').show();
+                render_folder_table(folders, tbody, server_id);
+                table.show();
             }
         }
     );
+};
 
+var get_special_icon = function(type) {
+    var icons = {
+        'trash': 'bi-trash3',
+        'sent': 'bi-send-check-fill',
+        'archive': 'bi-archive',
+        'draft': 'bi-pencil-square',
+        'junk': 'bi-envelope-x-fill'
+    };
+    return icons[type] || '';
+};
+
+var get_special_label = function(type) {
+    var labels = {
+        'trash': 'Trash',
+        'sent': 'Sent',
+        'archive': 'Archive',
+        'draft': 'Draft',
+        'junk': 'Junk'
+    };
+    return labels[type] || '';
+};
+
+var get_special_badge_class = function(type) {
+    var classes = {
+        'trash': 'badge-role-trash',
+        'sent': 'badge-role-sent',
+        'archive': 'badge-role-archive',
+        'draft': 'badge-role-draft',
+        'junk': 'badge-role-junk'
+    };
+    return classes[type] || 'bg-secondary';
+};
+
+var render_folder_table = function(folders, tbody, server_id) {
+    tbody.empty();
+    folders.forEach(function(folder) {
+        if (folder.noselect) return;
+
+        var specialBadge = '';
+        if (folder.special) {
+            specialBadge = '<span class="badge ' + get_special_badge_class(folder.special) + '"><i class="bi ' + get_special_icon(folder.special) + ' me-1"></i>' + hm_trans(get_special_label(folder.special)) + '</span>';
+        }
+
+        var indent = 0;
+        var name = folder.name || '';
+        var parts = name.split('/');
+        if (parts.length <= 1) {
+            parts = name.split('.');
+        }
+        indent = parts.length - 1;
+
+        var displayName = folder.basename;
+        var indentPx = indent * 20;
+
+        var row = '<tr data-folder-hex="' + folder.hex_name + '" data-folder-name="' + esc_html(folder.basename) + '" data-server-id="' + server_id + '">';
+        row += '<td style="padding-left:' + (indentPx + 8) + 'px"><i class="bi bi-folder2 me-1"></i>' + esc_html(displayName) + '</td>';
+        row += '<td>' + specialBadge + '</td>';
+        row += '<td class="text-end">';
+        row += '<div class="btn-group btn-group-sm" role="group">';
+        row += '<button class="btn btn-outline-primary btn-sm folder_rename_btn" title="' + hm_trans('Rename') + '"><i class="bi bi-pencil"></i></button>';
+        row += '<button class="btn btn-outline-danger btn-sm folder_delete_btn" title="' + hm_trans('Delete') + '"><i class="bi bi-trash"></i></button>';
+
+        var roleButtons = [
+            {type: 'trash', icon: 'bi-trash3', label: 'Trash'},
+            {type: 'archive', icon: 'bi-archive', label: 'Archive'},
+            {type: 'draft', icon: 'bi-pencil-square', label: 'Draft'},
+            {type: 'junk', icon: 'bi-envelope-x-fill', label: 'Junk'},
+            {type: 'sent', icon: 'bi-send-check-fill', label: 'Sent'}
+        ];
+
+        row += '<div class="btn-group btn-group-sm dropdown" role="group">';
+        row += '<button class="btn btn-outline-secondary btn-sm dropdown-toggle" data-bs-toggle="dropdown" title="' + hm_trans('Set as...') + '"><i class="bi bi-tag"></i></button>';
+        row += '<ul class="dropdown-menu dropdown-menu-end">';
+        roleButtons.forEach(function(rb) {
+            var active = folder.special === rb.type ? ' active' : '';
+            row += '<li><a class="dropdown-item set_special_btn' + active + '" href="#" data-type="' + rb.type + '"><i class="bi ' + rb.icon + ' me-2"></i>' + hm_trans(rb.label);
+            if (folder.special === rb.type) {
+                row += ' <i class="bi bi-check-lg ms-2"></i>';
+            }
+            row += '</a></li>';
+        });
+        row += '<li><hr class="dropdown-divider"></li>';
+        row += '<li><a class="dropdown-item clear_special_btn" href="#"><i class="bi bi-x-circle me-2"></i>' + hm_trans('Clear role') + '</a></li>';
+        row += '</ul></div>';
+
+        row += '</div></td></tr>';
+        tbody.append(row);
+    });
+
+    bind_folder_table_actions(tbody, server_id);
+};
+
+var bind_folder_table_actions = function(tbody, server_id) {
+    tbody.find('.folder_rename_btn').off('click').on('click', function() {
+        var tr = $(this).closest('tr');
+        var folderHex = tr.data('folder-hex');
+        var folderName = tr.data('folder-name');
+        show_rename_modal(server_id, folderHex, folderName, tr);
+        return false;
+    });
+
+    tbody.find('.folder_delete_btn').off('click').on('click', function() {
+        var tr = $(this).closest('tr');
+        var folderHex = tr.data('folder-hex');
+        var folderName = tr.data('folder-name');
+        show_delete_modal(server_id, folderHex, folderName, tr);
+        return false;
+    });
+
+    tbody.find('.set_special_btn').off('click').on('click', function(e) {
+        e.preventDefault();
+        var tr = $(this).closest('tr');
+        var folderHex = tr.data('folder-hex');
+        var type = $(this).data('type');
+        var block = tr.closest('.account_folder_block');
+        assign_special_folder(server_id, folderHex, type, function() {
+            load_account_folders(server_id, block);
+        });
+    });
+
+    tbody.find('.clear_special_btn').off('click').on('click', function(e) {
+        e.preventDefault();
+        var tr = $(this).closest('tr');
+        var folderHex = tr.data('folder-hex');
+        var block = tr.closest('.account_folder_block');
+        // Find what special type this folder currently has
+        var currentBadge = tr.find('.badge.bg-info');
+        if (currentBadge.length === 0) return;
+        // Determine the type from the set_special_btn that is active
+        var activeBtn = tr.find('.set_special_btn.active');
+        if (activeBtn.length === 0) return;
+        var type = activeBtn.data('type');
+        clear_special_folder(type, server_id, function() {
+            load_account_folders(server_id, block);
+        });
+    });
+};
+
+var show_rename_modal = function(server_id, folderHex, folderName, tr) {
+    var modal = new Hm_Modal({
+        modalId: 'renameFolderModal',
+        title: hm_trans('Rename Folder'),
+        btnSize: 'sm'
+    });
+
+    var content = '<div class="mb-3">';
+    content += '<label class="form-label">' + hm_trans('Current name') + ': <strong>' + esc_html(folderName) + '</strong></label>';
+    content += '</div>';
+    content += '<div class="form-floating mb-3">';
+    content += '<input type="text" class="form-control" id="modal_rename_value" placeholder="' + hm_trans('New Folder Name') + '">';
+    content += '<label for="modal_rename_value">' + hm_trans('New Folder Name') + '</label>';
+    content += '</div>';
+
+    modal.setContent(content);
+    modal.addFooterBtn(hm_trans('Rename'), 'btn-primary', function() {
+        var newName = $('#modal_rename_value').val().trim();
+        if (!newName.length) {
+            Hm_Notices.show($('#rename_folder_error').val(), 'danger');
+            return;
+        }
+        Hm_Ajax.request(
+            [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_rename'},
+            {'name': 'imap_server_id', 'value': server_id},
+            {'name': 'folder', 'value': folderHex},
+            {'name': 'new_folder', 'value': newName}],
+            function(res) {
+                if (res.imap_folders_success) {
+                    modal.hide();
+                    var block = tr.closest('.account_folder_block');
+                    load_account_folders(server_id, block);
+                    Hm_Folders.reload_folders(true);
+                }
+            }
+        );
+    });
+    modal.open();
+};
+
+var show_delete_modal = function(server_id, folderHex, folderName, tr) {
+    var modal = new Hm_Modal({
+        modalId: 'deleteFolderModal',
+        title: hm_trans('Delete Folder'),
+        btnSize: 'sm'
+    });
+
+    var content = '<p>' + hm_trans('Are you sure you want to delete this folder, and all the messages in it?') + '</p>';
+    content += '<p><strong>' + esc_html(folderName) + '</strong></p>';
+
+    modal.setContent(content);
+    modal.addFooterBtn(hm_trans('Delete'), 'btn-danger', function() {
+        Hm_Ajax.request(
+            [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_delete'},
+            {'name': 'imap_server_id', 'value': server_id},
+            {'name': 'folder', 'value': folderHex}],
+            function(res) {
+                if (res.imap_folders_success) {
+                    modal.hide();
+                    var block = tr.closest('.account_folder_block');
+                    load_account_folders(server_id, block);
+                    Hm_Folders.reload_folders(true);
+                }
+            }
+        );
+    });
+    modal.open();
+};
+
+var show_create_folder_modal = function(server_id, block) {
+    var modal = new Hm_Modal({
+        modalId: 'createFolderModal',
+        title: hm_trans('Create a New Folder'),
+        btnSize: 'sm'
+    });
+
+    var content = '<div class="form-floating mb-3">';
+    content += '<input type="text" class="form-control" id="modal_create_value" placeholder="' + hm_trans('New Folder Name') + '">';
+    content += '<label for="modal_create_value">' + hm_trans('New Folder Name') + '</label>';
+    content += '</div>';
+
+    modal.setContent(content);
+    modal.addFooterBtn(hm_trans('Create'), 'btn-primary', function() {
+        var folder = $('#modal_create_value').val().trim();
+        if (!folder.length) {
+            Hm_Notices.show($('#folder_name_error').val(), 'danger');
+            return;
+        }
+        Hm_Ajax.request(
+            [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folders_create'},
+            {'name': 'imap_server_id', 'value': server_id},
+            {'name': 'folder', 'value': folder}],
+            function(res) {
+                if (res.imap_folders_success) {
+                    modal.hide();
+                    load_account_folders(server_id, block);
+                    Hm_Folders.reload_folders(true);
+                }
+            }
+        );
+    });
+    modal.open();
 };
 
 function bindFoldersEventHandlers() {
-    $('.select_parent_folder').on("click", function() { return folder_page_folder_list('parent_folder_select', 'parent_title', 'imap_parent_folder_link', 'selected_parent', 'create_parent'); });
-    $('.select_rename_folder').on("click", function() { return folder_page_folder_list('rename_folder_select', 'rename_title', 'imap_rename_folder_link', 'selected_rename', 'rename_source'); });
-    $('.select_delete_folder').on("click", function() { return folder_page_folder_list('delete_folder_select', 'delete_title', 'imap_delete_folder_link', 'selected_delete', 'delete_source'); });
-    $('.select_trash_folder').on("click", function() { return folder_page_folder_list('trash_folder_select', 'trash_title', 'imap_trash_folder_link', 'selected_trash', 'trash_source'); });
-    $('.select_sent_folder').on("click", function() { return folder_page_folder_list('sent_folder_select', 'sent_title', 'imap_sent_folder_link', 'selected_sent', 'sent_source'); });
-    $('.select_archive_folder').on("click", function() { return folder_page_folder_list('archive_folder_select', 'archive_title', 'imap_archive_folder_link', 'selected_archive', 'archive_source'); });
-    $('.select_draft_folder').on("click", function() { return folder_page_folder_list('draft_folder_select', 'draft_title', 'imap_draft_folder_link', 'selected_draft', 'draft_source'); });
-    $('.select_junk_folder').on("click", function() { return folder_page_folder_list('junk_folder_select', 'junk_title', 'imap_junk_folder_link', 'selected_junk', 'junk_source'); });
-    $('.select_rename_parent_folder').on("click", function() { return folder_page_folder_list('rename_parent_folder_select', 'rename_parent_title', 'imap_rename_parent_folder_link', 'selected_rename_parent', 'rename_parent_source'); });
-    $('#create_folder').on("click", function() { folder_page_create(); return false; });
-    $('#delete_folder').on("click", function() { folder_page_delete(); return false; });
-    $('#rename_folder').on("click", function() { folder_page_rename(); return false; });
+    // Account expand/collapse
+    $('.account_folder_header').on('click', function() {
+        var block = $(this).closest('.account_folder_block');
+        var body = block.find('.account_folder_body');
+        var icon = block.find('.account_expand_icon');
+        var server_id = block.data('server-id');
+        var visible = body.css('display') !== 'none';
 
-    $('#set_trash_folder').on("click", function() { folder_page_assign_trash(); return false; });
-    $('#set_sent_folder').on("click", function() { folder_page_assign_sent(); return false; });
-    $('#set_archive_folder').on("click", function() { folder_page_assign_archive(); return false; });
-    $('#set_draft_folder').on("click", function() { folder_page_assign_draft(); return false; });
-    $('#set_junk_folder').on("click", function() { folder_page_assign_junk(); return false; });
+        if (visible) {
+            body.css('display', 'none');
+            icon.removeClass('bi-chevron-down').addClass('bi-chevron-right');
+        } else {
+            body.css('display', '');
+            icon.removeClass('bi-chevron-right').addClass('bi-chevron-down');
+            // Load folders if table is empty
+            if (block.find('.folder_table_body tr').length === 0) {
+                load_account_folders(server_id, block);
+            }
+        }
+    });
 
-    $('#clear_trash_folder').on("click", function() { clear_special_folder('trash'); return false; });
-    $('#clear_sent_folder').on("click", function() { clear_special_folder('sent'); return false; });
-    $('#clear_archive_folder').on("click", function() { clear_special_folder('archive'); return false; });
-    $('#clear_draft_folder').on("click", function() { clear_special_folder("draft"); return false; });
+    // Create folder button
+    $('.create_folder_btn').on('click', function() {
+        var server_id = $(this).data('server-id');
+        var block = $(this).closest('.account_folder_block');
+        show_create_folder_modal(server_id, block);
+        return false;
+    });
 }


### PR DESCRIPTION

<img width="1928" height="989" alt="cypht-folder-page" src="https://github.com/user-attachments/assets/c2535dee-f0b2-4332-9bfa-7bcd29d7f97b" />

## Description
This PR redesigns the IMAP folders management page to make it easier to understand and manage folders per account. Instead of scattered per-server dialogs, each account now shows as an expandable card with a clear folder table. Folder actions (rename, delete, create subfolder, assign role) all open focused modals so the user always knows what they're acting on and gets feedback while the action runs.

### Issues
[https://avan.tech/item115321](https://avan.tech/item115321)

### Todo
- [X] Unit Tests
