### PR TITLE
fix(other): use db_name for SQLite DSN instead of db_socket

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -66,7 +66,7 @@ class Hm_DB {
      */
     static public function build_dsn() {
         if (self::$config['db_driver'] == 'sqlite') {
-            return sprintf('%s:%s', self::$config['db_driver'], self::$config['db_socket']);
+            return sprintf('%s:%s', self::$config['db_driver'], self::$config['db_name']);
         }
         if (self::$config['db_conn_type'] == 'socket') {
             return sprintf('%s:unix_socket=%s;dbname=%s', self::$config['db_driver'], self::$config['db_socket'], self::$config['db_name']);

--- a/tests/phpunit/auth.php
+++ b/tests/phpunit/auth.php
@@ -108,6 +108,7 @@ class Hm_Test_Auth extends TestCase {
         $this->assertFalse($auth->change_pass('nobody', 'nopass'));
 
         $this->config->set('db_pass', 'asdf');
+        $this->config->set('db_name', '/root/cantgetthere.db');
         $this->config->set('db_socket', '/root/cantgetthere.db');
         $this->config->set('db_connection_type', 'socket');
         $auth = new Hm_Auth_DB($this->config);

--- a/tests/phpunit/db.php
+++ b/tests/phpunit/db.php
@@ -26,11 +26,12 @@ class Hm_Test_DB extends TestCase {
             $this->assertEquals('pgsql:host=127.0.0.1;dbname='.$db_name, Hm_DB::build_dsn());
         }
         $this->config->data['db_driver'] = 'sqlite';
-        $this->config->data['db_socket'] = '/tmp/test.db';
+        $this->config->data['db_name'] = '/tmp/test.db';
         $type = gettype(Hm_DB::connect($this->config));
         $this->assertTrue($type == 'boolean' || $type == 'object');
         $this->assertEquals('sqlite:/tmp/test.db', Hm_DB::build_dsn());
         $this->config->data['db_driver'] = 'mysql';
+        $this->config->data['db_name'] = $db_name;
         $this->config->data['db_connection_type'] = 'socket';
         $this->config->data['db_socket'] = '/test';
         $this->assertEquals('boolean', gettype(Hm_DB::connect($this->config)));

--- a/tests/phpunit/run.sh
+++ b/tests/phpunit/run.sh
@@ -27,8 +27,9 @@ if [ "$DB" = "sqlite" ]; then
 
     FILE=/tmp/test.db
 
-    export DB_CONNECTION_TYPE=socket
-    export DB_SOCKET=${FILE}
+    # DB_NAME is the file path for SQLite (used directly in the DSN: sqlite:<path>)
+    export DB_NAME=${FILE}
+    export DB_CONNECTION_TYPE=host
 
     cat ${SCRIPT_DIR}/data/schema_sqlite.sql | sqlite3 ${FILE}
     cat ${SCRIPT_DIR}/data/seed_sqlite.sql | sqlite3 ${FILE}


### PR DESCRIPTION
## Issue

`build_dsn()` was building the SQLite DSN from db_socket, which is intended for MySQL/PostgreSQL unix socket connections. This caused containers configured with `DB_DRIVER=sqlite` to fail on startup because the mysql socket path from .env.example was used instead of the user-supplied `DB_NAME` file path.

Related issue: https://github.com/cypht-org/cypht/issues/1928