### PR TITLE
fix(other): run composer install before setup.sh in Test-phpunit job

### DIFF
--- a/.github/workflows/Test-Build.yml
+++ b/.github/workflows/Test-Build.yml
@@ -72,13 +72,13 @@ jobs:
           update: true
           fail-fast: true
 
-      - name: "Script: setup.sh"
-        run: bash .github/tests/setup.sh
-
       - name: "Composer Install Dependencies"
         run: |
             composer install
             composer require --dev php-coveralls/php-coveralls
+
+      - name: "Script: setup.sh"
+        run: bash .github/tests/setup.sh
 
       - name: "Script: test.sh"
         run: bash tests/phpunit/run.sh


### PR DESCRIPTION
## Issue

```
PHP Warning:  require(/home/runner/work/cypht/cypht/vendor/autoload.php): Failed to open stream: No such file or directory in /home/runner/work/cypht/cypht/scripts/config_gen.php on line 18
PHP Fatal error:  Uncaught Error: Failed opening required '/home/runner/work/cypht/cypht/vendor/autoload.php' (include_path='.:/usr/share/php') in /home/runner/work/cypht/cypht/scripts/config_gen.php:18
```

Related job: https://github.com/cypht-org/cypht/actions/runs/24914039249/job/72962122237?pr=1932 `Scripts: setup.sh`