### PR TITLE
fix(module/imap_folders): clear parent folder cache on subfolder creation

### DIFF
--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -182,6 +182,9 @@ class Hm_Handler_process_folder_create extends Hm_Handler_Module {
                 if ($form['folder'] && $mailbox->create_folder($form['folder'], $parent)) {
                     Hm_Msgs::add('Folder created');
                     $this->cache->del('imap_folders_imap_'.$form['imap_server_id'].'_');
+                    if ($parent !== false) {
+                        $this->cache->del('imap_folders_imap_'.$form['imap_server_id'].'_'.bin2hex($parent));
+                    }
                     $this->out('imap_folders_success', true);
                 }
                 else {


### PR DESCRIPTION
## Issue

When creating a level-2+ folder (a subfolder of an existing subfolder), the new folder would not appear in the folder tree until the user logged out and back in.

`Hm_Handler_process_folder_create` correctly invalidated the root-level folder list cache (`imap_folders_imap_{server_id}_`) after a successful creation, but did not invalidate the **parent folder's** expanded subfolder cache.

When the user re-expanded the parent folder, `Hm_Handler_imap_folder_expand` found a valid cache entry for it and returned the stale list without the newly created child. Only a full session reset (logout/login) cleared all cache entries and forced a fresh IMAP query.
