### PR TITLE
fix(backend): fix errors related to EWS when manipulating folders

### DIFF
--- a/modules/imap/hm-ews.php
+++ b/modules/imap/hm-ews.php
@@ -215,7 +215,7 @@ class Hm_EWS {
         if ($this->is_distinguished_folder($folder)) {
             $folderObj = new Type\DistinguishedFolderIdType($folder);
         } else {
-            $folderObj = new Type\FolderIdType(hex2bin($folder));
+            $folderObj = new Type\FolderIdType($folder);
         }
         $new_folder = new Type\FolderType();
         $new_folder->displayName = $new_name;
@@ -245,8 +245,7 @@ class Hm_EWS {
             if ($this->is_distinguished_folder($parent)) {
                 $parentObj = new Type\DistinguishedFolderIdType($parent);
             } else {
-                // Convert hex ID to binary for EWS
-                $parentObj = new Type\FolderIdType(hex2bin($parent));
+                $parentObj = new Type\FolderIdType($parent);
             }
             $request = [
                 'FolderIds' => Utilities\getFolderIds([$folderObj]),
@@ -265,7 +264,7 @@ class Hm_EWS {
 
     public function delete_folder($folder) {
         try {
-            return $this->api->deleteFolder(new Type\FolderIdType(hex2bin($folder)));
+            return $this->api->deleteFolder(new Type\FolderIdType($folder));
         } catch(\Exception $e) {
             Hm_Msgs::add($e->getMessage(), 'danger');
             return false;

--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -118,7 +118,12 @@ class Hm_Handler_process_special_folder extends Hm_Handler_Module {
         Hm_Msgs::add('Special folder assigned');
 
         $this->session->record_unsaved('Special folder assigned');
-        $this->out('imap_special_name', $new_folder);
+        if ($mailbox->is_imap()) {
+            $this->out('imap_special_name', $new_folder);
+        } else {
+            $status = $mailbox->get_folder_status($new_folder);
+            $this->out('imap_special_name', $status['name'] ?? $new_folder);
+        }
     }
 }
 


### PR DESCRIPTION
Some errors:
```
PHP Warning:  hex2bin(): Input string must be hexadecimal string in /cypht/modules/imap/hm-ews.php on line 218
PHP Warning:  hex2bin(): Input string must be hexadecimal string in /cypht/modules/imap/hm-ews.php on line 268
```

While assigning a folder to Trash, we used to get a long string instead of a human-readable string, e.g.:
Trash Folder: 
```
AAMkADk5Njk2ZjM0LTZmMWItNGIwZS05YTBjLTUzZWE4ZTExN2I5OQAuAAAAAADoTzuWq76VRIeNlYRsLpeUAQDwSoBO6tE6QZYs8Ixm76GUAAAzNmMdAAA=
```