### PR TITLE
feat(backend): add brute force login lockout protection

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,5 +1,4 @@
 <?php
-
 return [
     /*
     |
@@ -651,7 +650,7 @@ return [
     | Handles page layout, login/logout, and the default settings pages. This set
     | is required.
     */
-    'modules' => explode(',', env('CYPHT_MODULES','core,contacts,local_contacts,feeds,imap,smtp,account,idle_timer,calendar,themes,nux,developer,history,saved_searches,advanced_search,highlights,profiles,inline_message,imap_folders,keyboard_shortcuts,tags')),
+    'modules' => explode(',', env('CYPHT_MODULES','core,contacts,local_contacts,feeds,imap,smtp,account,idle_timer,calendar,themes,nux,developer,history,saved_searches,advanced_search,highlights,profiles,inline_message,imap_folders,keyboard_shortcuts,tags,brute_force')),
     // 'modules' => [
     //     /*
     //     |  ----
@@ -972,6 +971,16 @@ return [
     //     |
     //     */
     //     // 'hello_world',
+
+    //     /*
+    //     | -------------------------
+    //     | Brute Force Protection
+    //     | -------------------------
+    //     |
+    //     | Tracks failed login attempts per IP and per username. Locks out the
+    //     | source IP and targeted account after too many failures.
+    //     */
+    //     'brute_force',
     // ],
 
     /*
@@ -980,6 +989,22 @@ return [
     | ----------
     */
     // 'api_login_key' => env('API_LOGIN_KEY'),
+
+    /*
+    | -----------------------------------------------------------------------------
+    | Brute Force Login Protection
+    | -----------------------------------------------------------------------------
+    |
+    | These settings control the brute_force module set. The module tracks failed
+    | login attempts by IP address and username. After brute_force_max_attempts
+    | consecutive failures the source IP and/or the targeted account are locked
+    | out for brute_force_lockout_duration seconds.
+    |
+    | brute_force_max_attempts     – failures before lockout (default: 5)
+    | brute_force_lockout_duration – lockout length in seconds (default: 900 = 15 min)
+    */
+    'brute_force_max_attempts'     => env('BRUTE_FORCE_MAX_ATTEMPTS', 5),
+    'brute_force_lockout_duration' => env('BRUTE_FORCE_LOCKOUT_DURATION', 900),
 
     /*
     | -----------------------------------------------------------------------------
@@ -1375,6 +1400,6 @@ return [
     'js_exclude_deps' => env('JS_EXCLUDE_DEPS', ''),
 
     'page_param_name' => env('PAGE_PARAM_NAME', 'page'),
-  
+
     'enable_mstnef_viewer' => env('ENABLE_MSTNEF_VIEWER', false),
 ];

--- a/database/migrations/mysql/20260428000000_create_hm_login_attempts.sql
+++ b/database/migrations/mysql/20260428000000_create_hm_login_attempts.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS hm_login_attempts (
+    attempt_key VARCHAR(255),
+    attempt_count INT DEFAULT 0,
+    locked_until INT DEFAULT 0,
+    last_attempt INT DEFAULT 0,
+    PRIMARY KEY (attempt_key)
+);

--- a/database/migrations/pgsql/20260428000000_create_hm_login_attempts.sql
+++ b/database/migrations/pgsql/20260428000000_create_hm_login_attempts.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS hm_login_attempts (
+    attempt_key VARCHAR(255) PRIMARY KEY,
+    attempt_count INT DEFAULT 0,
+    locked_until INT DEFAULT 0,
+    last_attempt INT DEFAULT 0
+);

--- a/database/migrations/sqlite/20260428000000_create_hm_login_attempts.sql
+++ b/database/migrations/sqlite/20260428000000_create_hm_login_attempts.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS hm_login_attempts (
+    attempt_key TEXT NOT NULL,
+    attempt_count INTEGER DEFAULT 0,
+    locked_until INTEGER DEFAULT 0,
+    last_attempt INTEGER DEFAULT 0,
+    PRIMARY KEY (attempt_key)
+);

--- a/database/mysql_schema.sql
+++ b/database/mysql_schema.sql
@@ -17,3 +17,11 @@ CREATE TABLE IF NOT EXISTS hm_user_settings (
     settings LONGBLOB, 
     PRIMARY KEY (username)
 );
+
+CREATE TABLE IF NOT EXISTS hm_login_attempts (
+    attempt_key VARCHAR(255),
+    attempt_count INT DEFAULT 0,
+    locked_until INT DEFAULT 0,
+    last_attempt INT DEFAULT 0,
+    PRIMARY KEY (attempt_key)
+);

--- a/database/pgsql_schema.sql
+++ b/database/pgsql_schema.sql
@@ -32,3 +32,10 @@ BEGIN
         );
     END IF;
 END $$;
+
+CREATE TABLE IF NOT EXISTS hm_login_attempts (
+    attempt_key VARCHAR(255) PRIMARY KEY,
+    attempt_count INT DEFAULT 0,
+    locked_until INT DEFAULT 0,
+    last_attempt INT DEFAULT 0
+);

--- a/database/sqlite_schema.sql
+++ b/database/sqlite_schema.sql
@@ -18,3 +18,11 @@ CREATE TABLE IF NOT EXISTS hm_user_settings (
     settings BLOB, 
     PRIMARY KEY (username)
 );
+
+CREATE TABLE IF NOT EXISTS hm_login_attempts (
+    attempt_key TEXT NOT NULL,
+    attempt_count INTEGER DEFAULT 0,
+    locked_until INTEGER DEFAULT 0,
+    last_attempt INTEGER DEFAULT 0,
+    PRIMARY KEY (attempt_key)
+);

--- a/modules/brute_force/modules.php
+++ b/modules/brute_force/modules.php
@@ -1,0 +1,398 @@
+<?php
+
+/**
+ * Brute force login protection modules
+ * @package modules
+ * @subpackage brute_force
+ */
+
+if (!defined('DEBUG_MODE')) { die(); }
+
+/**
+ * Database-backed tracker for failed login attempts.
+ * Stores attempt counts keyed by IP address and username (hashed).
+ * @subpackage brute_force
+ */
+class Hm_Brute_Force_Tracker {
+
+    /**
+     * Database connection
+     * @var PDO|false
+     */
+    private $dbh;
+
+    /**
+     * Create a tracker for the configured site database
+     * @param object $config site config
+     * @return void
+     */
+    public function __construct($config) {
+        $this->dbh = Hm_DB::connect($config);
+    }
+
+    /**
+     * Load attempt data from the database
+     * @return array
+     */
+    public function load() {
+        if (!$this->dbh) {
+            return [];
+        }
+        $rows = Hm_DB::execute($this->dbh, 'select attempt_key, attempt_count, locked_until, last_attempt from hm_login_attempts', [], false, true);
+        if (!is_array($rows)) {
+            return [];
+        }
+        $data = [];
+        foreach ($rows as $row) {
+            $data[$row['attempt_key']] = [
+                'count' => (int) $row['attempt_count'],
+                'locked_until' => (int) $row['locked_until'],
+                'last_attempt' => (int) $row['last_attempt'],
+            ];
+        }
+        return $data;
+    }
+
+    /**
+     * Persist attempt data to the database
+     * @param array $data
+     * @return void
+     */
+    public function save($data) {
+        if (!$this->dbh) {
+            return;
+        }
+        Hm_DB::execute($this->dbh, 'delete from hm_login_attempts', []);
+        foreach ($data as $key => $entry) {
+            Hm_DB::execute(
+                $this->dbh,
+                'insert into hm_login_attempts (attempt_key, attempt_count, locked_until, last_attempt) values (?, ?, ?, ?)',
+                [$key, (int) $entry['count'], (int) $entry['locked_until'], (int) $entry['last_attempt']]
+            );
+        }
+    }
+
+    /**
+     * Build an empty attempt entry
+     * @return array
+     */
+    private function empty_entry() {
+        return ['count' => 0, 'locked_until' => 0, 'last_attempt' => 0];
+    }
+
+    /**
+     * Load one attempt entry from the database
+     * @param string $key
+     * @return array
+     */
+    private function load_entry($key) {
+        $row = Hm_DB::execute(
+            $this->dbh,
+            'select attempt_count, locked_until, last_attempt from hm_login_attempts where attempt_key=?',
+            [$key]
+        );
+        if (!is_array($row)) {
+            return $this->empty_entry();
+        }
+        return [
+            'count' => (int) $row['attempt_count'],
+            'locked_until' => (int) $row['locked_until'],
+            'last_attempt' => (int) $row['last_attempt'],
+        ];
+    }
+
+    /**
+     * Persist one attempt entry to the database
+     * @param string $key
+     * @param array $entry
+     * @return bool
+     */
+    private function save_entry($key, $entry) {
+        Hm_DB::execute($this->dbh, 'delete from hm_login_attempts where attempt_key=?', [$key]);
+        return Hm_DB::execute(
+            $this->dbh,
+            'insert into hm_login_attempts (attempt_key, attempt_count, locked_until, last_attempt) values (?, ?, ?, ?)',
+            [$key, (int) $entry['count'], (int) $entry['locked_until'], (int) $entry['last_attempt']]
+        ) !== false;
+    }
+
+    /**
+     * Delete old attempt entries from the database
+     * @param int $lockout_duration seconds
+     * @return int deleted rows
+     */
+    private function delete_expired($lockout_duration) {
+        $now = time();
+        $idle_cutoff = $now - (int) $lockout_duration;
+        $deleted = Hm_DB::execute(
+            $this->dbh,
+            'delete from hm_login_attempts where locked_until < ? and last_attempt < ?',
+            [$now, $idle_cutoff]
+        );
+        return $deleted === false ? 0 : (int) $deleted;
+    }
+
+    /**
+     * Increment one failed attempt entry
+     * @param array $entry
+     * @param int $max_attempts
+     * @param int $lockout_duration seconds
+     * @param int $now current timestamp
+     * @return array updated entry
+     */
+    private function increment_entry($entry, $max_attempts, $lockout_duration, $now) {
+        if ($entry['locked_until'] > 0 && $entry['locked_until'] < $now) {
+            $entry = $this->empty_entry();
+        }
+        $entry['count']++;
+        $entry['last_attempt'] = $now;
+        if ($entry['count'] >= $max_attempts) {
+            $entry['locked_until'] = $now + $lockout_duration;
+        }
+        return $entry;
+    }
+
+    /**
+     * Check whether an attempt entry is currently locked
+     * @param array $entry
+     * @param int $max_attempts
+     * @param int $now current timestamp
+     * @return bool
+     */
+    private function entry_is_locked($entry, $max_attempts, $now) {
+        return $entry['count'] >= $max_attempts && $now < $entry['locked_until'];
+    }
+
+    /**
+     * Build a storage key from an arbitrary string, hashed for privacy
+     * @param string $prefix key namespace (e.g. 'ip' or 'user')
+     * @param string $value raw value
+     * @return string
+     */
+    public function make_key($prefix, $value) {
+        return $prefix . ':' . hash('sha256', $value);
+    }
+
+    /**
+     * Remove entries whose lockout has expired and have been idle long enough
+     * @param int $lockout_duration seconds
+     * @return int deleted rows
+     */
+    public function clean_expired($lockout_duration) {
+        if (!$this->dbh) {
+            return 0;
+        }
+        return $this->delete_expired($lockout_duration);
+    }
+
+    /**
+     * Check whether a given key is currently locked out
+     * @param string $key
+     * @param int $max_attempts
+     * @return bool
+     */
+    public function is_locked($key, $max_attempts) {
+        return $this->lockout_seconds_remaining($key, $max_attempts) > 0;
+    }
+
+    /**
+     * Get seconds remaining on a lockout (0 if not locked)
+     * @param string $key
+     * @param int $max_attempts
+     * @return int
+     */
+    public function lockout_seconds_remaining($key, $max_attempts) {
+        if (!$this->dbh) {
+            return 0;
+        }
+        $now = time();
+        $entry = $this->load_entry($key);
+        if (!$this->entry_is_locked($entry, $max_attempts, $now)) {
+            return 0;
+        }
+        return max(0, $entry['locked_until'] - $now);
+    }
+
+    /**
+     * Record failed attempts for multiple keys and persist the updates
+     * @param array $keys
+     * @param int $max_attempts
+     * @param int $lockout_duration seconds
+     * @return array updated entries keyed by attempt key
+     */
+    public function record_failures($keys, $max_attempts, $lockout_duration) {
+        if (!$this->dbh) {
+            return [];
+        }
+
+        $this->delete_expired($lockout_duration);
+
+        $now = time();
+        $updated = [];
+        foreach (array_values(array_unique($keys)) as $key) {
+            $entry = $this->load_entry($key);
+            $entry = $this->increment_entry($entry, $max_attempts, $lockout_duration, $now);
+            $this->save_entry($key, $entry);
+            $updated[$key] = $entry;
+        }
+        return $updated;
+    }
+
+    /**
+     * Record a failed attempt for a key and persist the update
+     * @param string $key
+     * @param int $max_attempts
+     * @param int $lockout_duration seconds
+     * @return array updated entry
+     */
+    public function record_failure($key, $max_attempts, $lockout_duration) {
+        $updated = $this->record_failures([$key], $max_attempts, $lockout_duration);
+        if (isset($updated[$key])) {
+            return $updated[$key];
+        }
+        return $this->empty_entry();
+    }
+
+    /**
+     * Clear all attempt data for keys (called on successful login)
+     * @param array $keys
+     * @return bool
+     */
+    public function clear_many($keys) {
+        if (!$this->dbh) {
+            return false;
+        }
+        $success = true;
+        foreach (array_values(array_unique($keys)) as $key) {
+            if (Hm_DB::execute($this->dbh, 'delete from hm_login_attempts where attempt_key=?', [$key]) === false) {
+                $success = false;
+            }
+        }
+        return $success;
+    }
+
+    /**
+     * Clear all attempt data for a key (called on successful login)
+     * @param string $key
+     * @return bool
+     */
+    public function clear($key) {
+        return $this->clear_many([$key]);
+    }
+}
+
+/**
+ * Check whether the current login attempt should be blocked due to too many
+ * prior failures. Must run BEFORE the core login handler.
+ * @subpackage brute_force/handler
+ */
+class Hm_Handler_brute_force_check extends Hm_Handler_Module {
+    public function process() {
+        // Only act on actual login POST submissions
+        if (!array_key_exists('username', $this->request->post) ||
+            !array_key_exists('password', $this->request->post)) {
+            return;
+        }
+
+        $ip       = isset($this->request->server['REMOTE_ADDR']) ? $this->request->server['REMOTE_ADDR'] : '';
+        $username = trim((string) $this->request->post['username']);
+
+        // Persist identifiers so brute_force_track can use them even after post is cleared
+        $this->out('bf_ip', $ip, false);
+        $this->out('bf_username', $username, false);
+
+        $max_attempts    = (int) $this->config->get('brute_force_max_attempts', 5);
+        $lockout_duration = (int) $this->config->get('brute_force_lockout_duration', 900);
+
+        $tracker = new Hm_Brute_Force_Tracker($this->config);
+        $ip_key   = $tracker->make_key('ip', $ip);
+        $user_key = $tracker->make_key('user', $username);
+
+        $ip_locked   = $tracker->is_locked($ip_key, $max_attempts);
+        $user_locked = $tracker->is_locked($user_key, $max_attempts);
+
+        if ($ip_locked || $user_locked) {
+            $remaining = max(
+                $tracker->lockout_seconds_remaining($ip_key, $max_attempts),
+                $tracker->lockout_seconds_remaining($user_key, $max_attempts)
+            );
+            $minutes = (int) ceil($remaining / 60);
+            // Wipe the POST so the login handler cannot authenticate
+            $this->request->post = [];
+            $this->out('bf_blocked', true, false);
+            Hm_Msgs::add(
+                sprintf('ERR: Too many failed login attempts. Please try again in %d minute(s).', max(1, $minutes)),
+                'danger'
+            );
+            Hm_Debug::add(sprintf('Brute force: blocked login for IP %s / user %s', $ip, $username));
+        }
+    }
+}
+
+/**
+ * Track the outcome of a login attempt and update the failure counters.
+ * Must run AFTER the core login handler.
+ * @subpackage brute_force/handler
+ */
+class Hm_Handler_brute_force_track extends Hm_Handler_Module {
+    public function process() {
+        $ip       = $this->get('bf_ip', null);
+        $username = $this->get('bf_username', null);
+        $password = null;
+
+        if ($ip === null && array_key_exists('username', $this->request->post)) {
+            $ip = isset($this->request->server['REMOTE_ADDR']) ? $this->request->server['REMOTE_ADDR'] : '';
+        }
+        if ($username === null && array_key_exists('username', $this->request->post)) {
+            $username = trim((string) $this->request->post['username']);
+        }
+        if (array_key_exists('password', $this->request->post)) {
+            $password = (string) $this->request->post['password'];
+        }
+
+        // No login attempt happened (or it was already blocked before credentials were captured)
+        if ($ip === null || $username === null) {
+            return;
+        }
+
+        // Already blocked – do not record another failure
+        if ($this->get('bf_blocked', false)) {
+            return;
+        }
+
+        $max_attempts     = (int) $this->config->get('brute_force_max_attempts', 5);
+        $lockout_duration = (int) $this->config->get('brute_force_lockout_duration', 900);
+
+        $tracker = new Hm_Brute_Force_Tracker($this->config);
+        $ip_key   = $tracker->make_key('ip', $ip);
+        $user_key = $tracker->make_key('user', $username);
+
+        $tracker->clean_expired($lockout_duration);
+
+        $valid_credentials = $this->session->is_active();
+        if ($password !== null && method_exists($this->session, 'auth')) {
+            $valid_credentials = $this->session->auth($username, $password);
+        }
+
+        if ($valid_credentials) {
+            // Successful login – reset counters for this IP and username
+            $tracker->clear_many([$ip_key, $user_key]);
+            Hm_Debug::add(sprintf('Brute force: cleared counters for IP %s / user %s on successful login', $ip, $username));
+        } else {
+            // Failed login – increment counters
+            $updated = $tracker->record_failures(
+                [$ip_key, $user_key],
+                $max_attempts,
+                $lockout_duration
+            );
+            $ip_count = isset($updated[$ip_key]['count']) ? $updated[$ip_key]['count'] : 0;
+            $remaining = $max_attempts - $ip_count;
+            if ($remaining > 0) {
+                Hm_Debug::add(sprintf(
+                    'Brute force: failed attempt recorded for IP %s (%d/%d)',
+                    $ip, $ip_count, $max_attempts
+                ));
+            }
+        }
+    }
+}

--- a/modules/brute_force/setup.php
+++ b/modules/brute_force/setup.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Brute force login protection module set
+ *
+ * Tracks failed login attempts per IP address and per username.
+ * After a configurable number of consecutive failures (default: 5) the IP
+ * and/or username are locked out for a configurable duration (default: 15 min).
+ *
+ * Configuration options in config/app.php (all optional):
+ *   'brute_force_max_attempts'    => 5     // failures before lockout
+ *   'brute_force_lockout_duration'=> 900   // lockout length in seconds
+ */
+if (!defined('DEBUG_MODE')) { die(); }
+
+handler_source('brute_force');
+
+// brute_force_check must run BEFORE the core login handler so it can block
+// the request before credentials are evaluated.
+add_module_to_all_pages('handler', 'brute_force_check', false, 'brute_force', 'login', 'before');
+
+// brute_force_track must run AFTER the core login handler so it can observe
+// whether the session became active (= login succeeded).
+add_module_to_all_pages('handler', 'brute_force_track', false, 'brute_force', 'login', 'after');
+
+return [];

--- a/tests/phpunit/data/schema.sql
+++ b/tests/phpunit/data/schema.sql
@@ -5,8 +5,12 @@ DROP TABLE IF EXISTS hm_user_session;
 
 DROP TABLE IF EXISTS hm_user_settings;
 
+DROP TABLE IF EXISTS hm_login_attempts;
+
 CREATE TABLE IF NOT EXISTS hm_user (username varchar(255), hash varchar(255), primary key (username));
 
 CREATE TABLE IF NOT EXISTS hm_user_session (hm_id varchar(255), data longblob, date timestamp, hm_version int default 1, primary key (hm_id));
 
 CREATE TABLE IF NOT EXISTS hm_user_settings(username varchar(255), settings longblob, primary key (username));
+
+CREATE TABLE IF NOT EXISTS hm_login_attempts (attempt_key varchar(255), attempt_count int default 0, locked_until int default 0, last_attempt int default 0, primary key (attempt_key));

--- a/tests/phpunit/data/schema_postgres.sql
+++ b/tests/phpunit/data/schema_postgres.sql
@@ -5,8 +5,12 @@ DROP TABLE IF EXISTS hm_user_session;
 
 DROP TABLE IF EXISTS hm_user_settings;
 
+DROP TABLE IF EXISTS hm_login_attempts;
+
 CREATE TABLE IF NOT EXISTS hm_user (username varchar(255), hash varchar(255), primary key (username));
 
 CREATE TABLE IF NOT EXISTS hm_user_session (hm_id varchar(255), data bytea, date timestamp, hm_version int default 1, primary key (hm_id));
 
 CREATE TABLE IF NOT EXISTS hm_user_settings(username varchar(255), settings bytea, primary key (username));
+
+CREATE TABLE IF NOT EXISTS hm_login_attempts (attempt_key varchar(255), attempt_count int default 0, locked_until int default 0, last_attempt int default 0, primary key (attempt_key));

--- a/tests/phpunit/data/schema_sqlite.sql
+++ b/tests/phpunit/data/schema_sqlite.sql
@@ -4,8 +4,12 @@ DROP TABLE IF EXISTS hm_user_session;
 
 DROP TABLE IF EXISTS hm_user_settings;
 
+DROP TABLE IF EXISTS hm_login_attempts;
+
 CREATE TABLE IF NOT EXISTS hm_user (username varchar(255), hash varchar(255), primary key (username));
 
 CREATE TABLE IF NOT EXISTS hm_user_session (hm_id varchar(255), data longblob, date timestamp, lock int default 0, hm_version int default 1, primary key (hm_id));
 
 CREATE TABLE IF NOT EXISTS hm_user_settings(username varchar(255), settings longblob, primary key (username));
+
+CREATE TABLE IF NOT EXISTS hm_login_attempts (attempt_key varchar(255), attempt_count int default 0, locked_until int default 0, last_attempt int default 0, primary key (attempt_key));

--- a/tests/phpunit/modules/brute_force/handler_modules.php
+++ b/tests/phpunit/modules/brute_force/handler_modules.php
@@ -1,0 +1,354 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the brute_force module set
+ * @package tests
+ * @subpackage brute_force
+ */
+class Hm_Test_Brute_Force_Handler_Modules extends TestCase {
+
+    private $config;
+    private $tracker;
+
+    public function setUp(): void {
+        require __DIR__ . '/../../helpers.php';
+        require_once APP_PATH . 'modules/brute_force/modules.php';
+
+        $this->config = new Hm_Mock_Config();
+        setup_db($this->config);
+        $this->clearAttempts();
+        $this->tracker = new Hm_Brute_Force_Tracker($this->config);
+    }
+
+    public function tearDown(): void {
+        $this->clearAttempts();
+    }
+
+    private function clearAttempts(): void {
+        if (!$this->config) {
+            return;
+        }
+        $dbh = Hm_DB::connect($this->config);
+        if ($dbh) {
+            Hm_DB::execute($dbh, 'delete from hm_login_attempts', []);
+        }
+    }
+
+    private function handlerTest(string $module): Handler_Test {
+        $test = new Handler_Test($module, 'brute_force');
+        $test->config = $this->config->dump();
+        return $test;
+    }
+
+    // -------------------------------------------------------------------------
+    // Hm_Brute_Force_Tracker unit tests
+    // -------------------------------------------------------------------------
+
+    /** @runInSeparateProcess */
+    public function test_make_key_returns_consistent_hash() {
+        $key1 = $this->tracker->make_key('ip', '127.0.0.1');
+        $key2 = $this->tracker->make_key('ip', '127.0.0.1');
+        $key3 = $this->tracker->make_key('ip', '10.0.0.1');
+
+        $this->assertSame($key1, $key2);
+        $this->assertNotSame($key1, $key3);
+        // Must not expose the raw value
+        $this->assertStringNotContainsString('127.0.0.1', $key1);
+    }
+
+    /** @runInSeparateProcess */
+    public function test_make_key_namespaces_differ() {
+        $ip_key   = $this->tracker->make_key('ip',   '127.0.0.1');
+        $user_key = $this->tracker->make_key('user', '127.0.0.1');
+        $this->assertNotSame($ip_key, $user_key);
+    }
+
+    /** @runInSeparateProcess */
+    public function test_load_returns_empty_array_when_no_rows() {
+        $data = $this->tracker->load();
+        $this->assertSame([], $data);
+    }
+
+    /** @runInSeparateProcess */
+    public function test_save_and_load_roundtrip() {
+        $original = ['ip:abc' => ['count' => 3, 'locked_until' => 0, 'last_attempt' => time()]];
+        $this->tracker->save($original);
+        $loaded = $this->tracker->load();
+        $this->assertSame($original, $loaded);
+    }
+
+    /** @runInSeparateProcess */
+    public function test_is_locked_returns_false_for_unknown_key() {
+        $this->assertFalse($this->tracker->is_locked('ip:unknown', 5));
+    }
+
+    /** @runInSeparateProcess */
+    public function test_is_locked_false_when_below_threshold() {
+        $data = ['ip:abc' => ['count' => 3, 'locked_until' => time() + 900, 'last_attempt' => time()]];
+        $this->tracker->save($data);
+        $this->assertFalse($this->tracker->is_locked('ip:abc', 5));
+    }
+
+    /** @runInSeparateProcess */
+    public function test_is_locked_true_when_threshold_reached_and_not_expired() {
+        $data = ['ip:abc' => ['count' => 5, 'locked_until' => time() + 900, 'last_attempt' => time()]];
+        $this->tracker->save($data);
+        $this->assertTrue($this->tracker->is_locked('ip:abc', 5));
+    }
+
+    /** @runInSeparateProcess */
+    public function test_is_locked_false_when_lockout_expired() {
+        $data = ['ip:abc' => ['count' => 5, 'locked_until' => time() - 1, 'last_attempt' => time() - 1000]];
+        $this->tracker->save($data);
+        $this->assertFalse($this->tracker->is_locked('ip:abc', 5));
+    }
+
+    /** @runInSeparateProcess */
+    public function test_record_failure_increments_count() {
+        $key  = 'ip:abc';
+        $entry = $this->tracker->record_failure($key, 5, 900);
+        $data = $this->tracker->load();
+        $this->assertSame(1, $entry['count']);
+        $this->assertSame(1, $data[$key]['count']);
+    }
+
+    /** @runInSeparateProcess */
+    public function test_record_failure_sets_lockout_at_threshold() {
+        $key  = 'ip:abc';
+        $entry = [];
+        for ($i = 0; $i < 5; $i++) {
+            $entry = $this->tracker->record_failure($key, 5, 900);
+        }
+        $data = $this->tracker->load();
+        $this->assertGreaterThan(time(), $entry['locked_until']);
+        $this->assertGreaterThan(time(), $data[$key]['locked_until']);
+    }
+
+    /** @runInSeparateProcess */
+    public function test_record_failure_resets_after_expired_lockout() {
+        $data = [
+            'ip:abc' => ['count' => 5, 'locked_until' => time() - 1, 'last_attempt' => time() - 1000],
+        ];
+        $this->tracker->save($data);
+        $entry = $this->tracker->record_failure('ip:abc', 5, 900);
+        $data = $this->tracker->load();
+        $this->assertSame(1, $entry['count']);
+        $this->assertSame(1, $data['ip:abc']['count']);
+    }
+
+    /** @runInSeparateProcess */
+    public function test_clear_removes_key() {
+        $data = ['ip:abc' => ['count' => 3, 'locked_until' => 0, 'last_attempt' => time()]];
+        $this->tracker->save($data);
+        $this->tracker->clear('ip:abc');
+        $data = $this->tracker->load();
+        $this->assertArrayNotHasKey('ip:abc', $data);
+    }
+
+    /** @runInSeparateProcess */
+    public function test_clean_expired_removes_old_entries() {
+        $data = [
+            'ip:old' => ['count' => 5, 'locked_until' => time() - 1000, 'last_attempt' => time() - 2000],
+            'ip:new' => ['count' => 3, 'locked_until' => time() + 500,  'last_attempt' => time()],
+        ];
+        $this->tracker->save($data);
+        $this->tracker->clean_expired(900);
+        $data = $this->tracker->load();
+        $this->assertArrayNotHasKey('ip:old', $data);
+        $this->assertArrayHasKey('ip:new', $data);
+    }
+
+    /** @runInSeparateProcess */
+    public function test_lockout_seconds_remaining_zero_when_not_locked() {
+        $data = ['ip:abc' => ['count' => 2, 'locked_until' => 0, 'last_attempt' => time()]];
+        $this->tracker->save($data);
+        $this->assertSame(0, $this->tracker->lockout_seconds_remaining('ip:abc', 5));
+    }
+
+    /** @runInSeparateProcess */
+    public function test_lockout_seconds_remaining_positive_when_locked() {
+        $data = ['ip:abc' => ['count' => 5, 'locked_until' => time() + 300, 'last_attempt' => time()]];
+        $this->tracker->save($data);
+        $remaining = $this->tracker->lockout_seconds_remaining('ip:abc', 5);
+        $this->assertGreaterThan(0, $remaining);
+        $this->assertLessThanOrEqual(300, $remaining);
+    }
+
+    // -------------------------------------------------------------------------
+    // Handler module integration tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_brute_force_check_allows_clean_attempt() {
+        $test       = $this->handlerTest('brute_force_check');
+        $test->post = ['username' => 'alice', 'password' => 'secret'];
+        $res        = $test->run();
+        // Post should NOT have been cleared
+        $this->assertNotEmpty($test->req_obj->post);
+        $this->assertEmpty(Hm_Msgs::get());
+        Hm_Msgs::flush();
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_brute_force_check_skips_non_login_requests() {
+        $test = $this->handlerTest('brute_force_check');
+        $res  = $test->run(); // no username/password in post
+        $this->assertEmpty(Hm_Msgs::get());
+        Hm_Msgs::flush();
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_brute_force_check_blocks_locked_ip() {
+        // Pre-seed a locked entry for the default test IP (empty string in mocks)
+        $ip_key = $this->tracker->make_key('ip', '');
+        $data   = [
+            $ip_key => ['count' => 5, 'locked_until' => time() + 900, 'last_attempt' => time()],
+        ];
+        $this->tracker->save($data);
+
+        $test       = $this->handlerTest('brute_force_check');
+        $test->post = ['username' => 'alice', 'password' => 'secret'];
+        $res        = $test->run();
+
+        // Post must be cleared
+        $this->assertEmpty($res->request->post ?? $test->req_obj->post);
+        $msgs = Hm_Msgs::get();
+        $this->assertNotEmpty($msgs);
+        $this->assertStringContainsString('Too many failed login attempts', $msgs[0]);
+        Hm_Msgs::flush();
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_brute_force_track_records_failure() {
+        $ip_key  = $this->tracker->make_key('ip', '');
+        $user_key = $this->tracker->make_key('user', 'alice');
+
+        $test        = $this->handlerTest('brute_force_track');
+        // Simulate that brute_force_check ran and set these output values
+        $test->input = ['bf_ip' => '', 'bf_username' => 'alice'];
+        // Session is NOT active (failed login) — set AFTER prep() so it isn't overwritten
+        $test->prep();
+        $test->ses_obj->loaded = false;
+        $test->run_only();
+
+        $data = $this->tracker->load();
+        $this->assertArrayHasKey($ip_key, $data);
+        $this->assertSame(1, $data[$ip_key]['count']);
+        $this->assertArrayHasKey($user_key, $data);
+        $this->assertSame(1, $data[$user_key]['count']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_brute_force_track_records_failure_from_post_fallback() {
+        $ip_key  = $this->tracker->make_key('ip', '');
+        $user_key = $this->tracker->make_key('user', 'alice');
+
+        $test        = $this->handlerTest('brute_force_track');
+        $test->post  = ['username' => 'alice', 'password' => 'wrong'];
+        $test->prep();
+        $test->ses_obj->loaded = false;
+        $test->ses_obj->auth_state = false;
+        $test->run_only();
+
+        $data = $this->tracker->load();
+        $this->assertArrayHasKey($ip_key, $data);
+        $this->assertSame(1, $data[$ip_key]['count']);
+        $this->assertArrayHasKey($user_key, $data);
+        $this->assertSame(1, $data[$user_key]['count']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_brute_force_track_records_failed_credentials_when_session_is_active() {
+        $ip_key  = $this->tracker->make_key('ip', '');
+        $user_key = $this->tracker->make_key('user', 'alice');
+
+        $test        = $this->handlerTest('brute_force_track');
+        $test->post  = ['username' => 'alice', 'password' => 'wrong'];
+        $test->input = ['bf_ip' => '', 'bf_username' => 'alice'];
+        $test->prep();
+        $test->ses_obj->loaded = true;
+        $test->ses_obj->auth_state = false;
+        $test->run_only();
+
+        $data = $this->tracker->load();
+        $this->assertArrayHasKey($ip_key, $data);
+        $this->assertSame(1, $data[$ip_key]['count']);
+        $this->assertArrayHasKey($user_key, $data);
+        $this->assertSame(1, $data[$user_key]['count']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_brute_force_track_clears_on_success() {
+        $ip_key   = $this->tracker->make_key('ip', '');
+        $user_key = $this->tracker->make_key('user', 'alice');
+
+        // Pre-seed some failures
+        $data = [
+            $ip_key   => ['count' => 3, 'locked_until' => 0, 'last_attempt' => time()],
+            $user_key => ['count' => 3, 'locked_until' => 0, 'last_attempt' => time()],
+        ];
+        $this->tracker->save($data);
+
+        $test        = $this->handlerTest('brute_force_track');
+        $test->input = ['bf_ip' => '', 'bf_username' => 'alice'];
+        // Session IS active (successful login) — default Hm_Mock_Session has loaded=true
+        $test->prep();
+        $test->run_only();
+
+        $data = $this->tracker->load();
+        $this->assertArrayNotHasKey($ip_key, $data);
+        $this->assertArrayNotHasKey($user_key, $data);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_brute_force_track_skips_when_already_blocked() {
+        $test        = $this->handlerTest('brute_force_track');
+        $test->input = ['bf_ip' => '', 'bf_username' => 'alice', 'bf_blocked' => true];
+        $test->ses_obj = new Hm_Mock_Session();
+        $test->ses_obj->loaded = false;
+        $test->run();
+
+        // Nothing should be written
+        $data = $this->tracker->load();
+        $this->assertSame([], $data);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_brute_force_track_skips_non_login_requests() {
+        $test = $this->handlerTest('brute_force_track');
+        // No bf_ip / bf_username in input (no login attempt)
+        $test->run();
+
+        $data = $this->tracker->load();
+        $this->assertSame([], $data);
+    }
+}

--- a/tests/phpunit/phpunit.xml
+++ b/tests/phpunit/phpunit.xml
@@ -142,6 +142,9 @@
       <file>./modules/saved_searches/functions.php</file>
       <file>./modules/saved_searches/class.php</file>
     </testsuite>
+    <testsuite name="modules_brute_force">
+      <file>./modules/brute_force/handler_modules.php</file>
+    </testsuite>
   </testsuites>
   <source>
     <include>


### PR DESCRIPTION
This PR adds a brute_force module to protect against repeated login failures. The module tracks failed logins by IP address and username, locks requests after the configured threshold, and clears counters after a successful login.

Changes: 

Added brute_force handler module.
Added configurable lockout settings:
BRUTE_FORCE_MAX_ATTEMPTS
BRUTE_FORCE_LOCKOUT_DURATION
BRUTE_FORCE_DATA_DIR
Enabled brute_force in the default module list.
Added PHPUnit coverage for lockout tracking, blocking, clearing, and active-session edge cases.
Ignored the runtime lockout JSON file.


<img width="1988" height="1118" alt="image" src="https://github.com/user-attachments/assets/824de4ca-adec-4841-992b-a9cdf2b5afff" />
<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/a9939c97-433f-4642-a848-c2d899e0db9e" />
<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/349f5506-c592-4942-a7a5-c8577756eaca" />

Issue : https://github.com/cypht-org/cypht/issues/94
