### PR TITLE
fix(docker): remove misleading unused nginx default site config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN set -eux \
     && curl -sSL https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - | sh -s \
         xdebug redis gnupg memcached ldap \
     && rm -rf /var/lib/apt/lists/* \
+    && rm -f /etc/nginx/sites-enabled/default /etc/nginx/sites-available/default \
     && mkdir -p /var/log/php /var/log/supervisord \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log \


### PR DESCRIPTION
## Summary

When `nginx` is installed via `apt` on Debian (bookworm), it automatically creates:
- `/etc/nginx/sites-available/default`
- `/etc/nginx/sites-enabled/default` (symlink to the above)

However, the custom `docker/nginx.conf` copied into the image defines the full
`http {}` block inline and contains no `include /etc/nginx/sites-enabled/*;`
directive. This means these files are **never loaded at runtime**. They just
sit in the image as dead configuration.

This is misleading when debugging inside the container, as one might inspect
`/etc/nginx/sites-enabled/default` and incorrectly assume it is the active
nginx configuration.

Related comment: https://github.com/cypht-org/cypht/issues/1928#issuecomment-4313800660