### PR TITLE
fix(backend): ensure Hm_Mailbox is constructed with a connection type

### DIFF
--- a/lib/servers.php
+++ b/lib/servers.php
@@ -184,6 +184,23 @@ trait Hm_Server_List {
         self::initRepo($name, $user_config, $session, self::$server_list);
     }
 
+
+    /**
+     * Assign a server type to servers that do not have one.
+     * Servers added after the introduction of the type field already include it,
+     * so this only applies to migrating older server lists.
+     * The type field is required because Hm_Mailbox relies on it to construct the connection object.
+     * @param string $type
+     * @return void
+     */
+    protected static function bindServerTypes($type) {
+        foreach (self::$entities as $id => $server) {
+            if (! array_key_exists('type', $server)) {
+                self::edit($id, ['type' => $type]);
+            }
+        }
+    }
+
     /**
      * Add a server definition
      * @param array $atts server details

--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -29,6 +29,7 @@ class Hm_IMAP_List {
 
     public static function init($user_config, $session) {
         self::initRepo('imap_servers', $user_config, $session, self::$server_list);
+        self::bindServerTypes('imap');
         self::$user_config = $user_config;
         self::$session = $session;
     }

--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -19,6 +19,7 @@ class Hm_SMTP_List {
 
     public static function init($user_config, $session) {
         self::initRepo('smtp_servers', $user_config, $session, self::$server_list);
+        self::bindServerTypes('smtp');
         self::$user_config = $user_config;
         self::$session = $session;
     }


### PR DESCRIPTION
Saving drafts and scheduling messages fail because `Hm_Mailbox` cannot detect a valid server type. This issue occurs on some servers but not others.

After debugging, I found that servers from the user config object were missing the type field when they had been added some time ago. After removing and reconfiguring them, the type field was correctly set.

These changes aim to spare other users from having to go through that process.