### PR TITLE
fix(e2e): fix CI sqlite setup and replace flaky navigation wait with deterministic counter + AJAX idle check

### DIFF
--- a/.github/tests/setup.sh
+++ b/.github/tests/setup.sh
@@ -24,6 +24,7 @@ setup_cypht() {
     if [ "$DB" = "sqlite" ]; then
         # .env
         sed -i 's/DB_DRIVER=mysql/DB_DRIVER=sqlite/' .env
+        sed -i 's|DB_NAME=.*|DB_NAME=/tmp/test.db|' .env
         # mocks.php
         sed -i 's/mysql/sqlite/' tests/phpunit/mocks.php
         sed -i "s/'host'/'socket'/" tests/phpunit/mocks.php
@@ -144,6 +145,7 @@ setup_site() {
 	sudo -u www-data cp .github/tests/.env .
 	if [ "$DB" = "sqlite" ]; then
 		sudo -u www-data sed -i 's/DB_DRIVER=mysql/DB_DRIVER=sqlite/' .env
+		sudo -u www-data sed -i 's|DB_NAME=.*|DB_NAME=/tmp/test.db|' .env
 	fi
 	sudo -u www-data sed -i "s|ATTACHMENT_DIR=.*|ATTACHMENT_DIR=/var/www/cypht/hm3/attachments|" .env
 	sudo -u www-data php scripts/config_gen.php

--- a/modules/core/navigation/navigation.js
+++ b/modules/core/navigation/navigation.js
@@ -2,6 +2,12 @@ const unMountSubscribers = {};
 
 let previousLocationSearch = window.location.search;
 
+// E2E test hook: a counter that increases on every navigation completion,
+// whether successful or not. Tests capture this value before a click
+// and wait for it to increase, ensuring assertions run only after the
+// navigation they triggered has fully settled.
+window.cyphtNavDone = 0;
+
 function trackLocationSearchChanges() {
     previousLocationSearch = window.location.search;
 }
@@ -172,6 +178,7 @@ async function navigate(url, loaderMessage) {
         Hm_Notices.show(error.message, 'danger');
         console.log(error);
     } finally {
+        window.cyphtNavDone++;
         hideRoutingToast();
     }
 }

--- a/tests/selenium/base.py
+++ b/tests/selenium/base.py
@@ -23,6 +23,7 @@ import os
 class WebTest:
 
     driver = None
+    _pre_click_nav_count = None
 
     def __init__(self, cap=None):
         self.read_ini()
@@ -228,16 +229,28 @@ class WebTest:
 
     def wait_for_navigation_to_complete(self, timeout=60):
         print(" - waiting for the navigation to complete...")
-        # Wait for the main content to be updated and any loading indicators to disappear
+        # Wait for the SPA navigation to finish. The counter is captured before
+        # the triggering click and checked here so we wait for the specific
+        # navigation we initiated, not a previous one.
+        expected = (self._pre_click_nav_count or 0) + 1
+        self._pre_click_nav_count = None
         try:
             WebDriverWait(self.driver, timeout).until(
-                lambda driver: driver.execute_script("return window.routingToast === null;")
+                lambda d: (d.execute_script("return window.cyphtNavDone || 0;") or 0) >= expected
             )
+        except Exception:
+            print(" - navigation completion check timed out, continuing...")
+            pass
+        # Wait for any background requests to finish. Some pages fetch their
+        # content asynchronously after the page shell has loaded.
+        try:
             WebDriverWait(self.driver, timeout).until(
-                lambda driver: driver.execute_script("return document.getElementById('nprogress') === null;")
+                lambda d: d.execute_script(
+                    "return (typeof Hm_Ajax !== 'undefined') ? Hm_Ajax.active_reqs === 0 : true;"
+                )
             )
-        except:
-            print(" - routing toast or nprogress check failed, continuing...")
+        except Exception:
+            print(" - AJAX idle check timed out, continuing...")
             pass
 
     def wait_for_page_ready(self, timeout=60):
@@ -291,6 +304,7 @@ class WebTest:
 
     def click_when_clickable(self, el):
         print(" - waiting for element to be clickable")
+        self._capture_nav_count()
         try:
             # Scroll element into view
             self.driver.execute_script("arguments[0].scrollIntoView({block: 'center', behavior: 'instant'});", el)
@@ -319,9 +333,17 @@ class WebTest:
                 print(f" - JavaScript click also failed: {js_error}")
                 raise e
 
+    def _capture_nav_count(self):
+        """Capture the current navigation done-count before a click."""
+        try:
+            self._pre_click_nav_count = self.driver.execute_script("return window.cyphtNavDone || 0;")
+        except Exception:
+            self._pre_click_nav_count = None
+
     def safe_click(self, element):
         """Safely click an element with retry logic"""
         print(" - safely clicking element")
+        self._capture_nav_count()
         max_attempts = 3
         for attempt in range(max_attempts):
             try:

--- a/tests/selenium/profiles.py
+++ b/tests/selenium/profiles.py
@@ -62,7 +62,7 @@ class ProfileTest(SettingsHelpers):
 
 if __name__ == '__main__':
 
-    print("PROFIILE TEST")
+    print("PROFILE TEST")
     test_runner(ProfileTest, [
         'load_profile_page',
         # 'add_profile',


### PR DESCRIPTION
### Issue 1: CI login failures (sqlite DB_NAME misconfiguration)

All Selenium tests were failing in CI at `good_login` and `good_logout`. The setup script `.github/tests/setup.sh` patched `DB_DRIVER=sqlite` in the `.env` file but left `DB_NAME=cypht_test`. Cypht builds its SQLite DSN as `sqlite:{DB_NAME}`, so it tried to open a file literally named `cypht_test` with no tables, causing every authentication attempt to fail.

Related to this change: https://github.com/cypht-org/cypht/pull/1929

### Issue 2: Intermittent navigation timing failures

Selenium tests were failing intermittently on `load_profile_page`, `flagged`, and other navigation-dependent tests in CI and locally. The root cause was a race condition in `wait_for_navigation_to_complete()`:

The previous implementation checked `window.routingToast === null` to detect when SPA navigation had finished. Since `routingToast` is `null` both _before_ a navigation starts and _after_ it completes, the check would often pass immediately — causing the test to assert on page content before it had actually loaded.

A second issue compounded this: some pages (e.g. Profiles) load their actual content via a background AJAX call _after_ the page shell is injected by `navigate()`. No wait existed for that second async step.
