### PR TITLE
fix(e2e): resolve intermittent test failures in search and servers

### DIFF
--- a/.github/tests/selenium/creds.py
+++ b/.github/tests/selenium/creds.py
@@ -16,6 +16,7 @@ chrome_options.add_argument("--disable-dev-shm-usage")
 chrome_options.add_experimental_option("excludeSwitches", ["enable-automation", "enable-logging"])
 chrome_options.add_experimental_option('useAutomationExtension', False)
 chrome_options.add_argument('--disable-blink-features=AutomationControlled')
+chrome_options.add_experimental_option('prefs', {'profile.password_manager_leak_detection': False})
 
 # Enable browser console logs
 chrome_options.set_capability("goog:loggingPrefs", {"browser": "ALL"})

--- a/tests/selenium/search.py
+++ b/tests/selenium/search.py
@@ -24,7 +24,8 @@ class SearchTest(WebTest):
         terms = self.by_id('search_terms')
         terms.send_keys('test')
         Select(self.by_name('search_since')).select_by_value('-5 years')
-        self.by_class('search_update').click();
+        # Use JavaScript click to avoid issues with elements being obscured or not interactable
+        self.driver.execute_script("document.querySelector('.search_update').click();")
         self.wait_with_folder_list()
         sleep(1)
         table = self.by_class('message_table_body')

--- a/tests/selenium/servers.py
+++ b/tests/selenium/servers.py
@@ -72,9 +72,9 @@ class ServersTest(WebTest):
         signature.send_keys('Test')
         elem = self.by_id('step_config_action_finish')
         self.driver.execute_script("arguments[0].scrollIntoView({behavior: 'instant'})", elem)
-        WebDriverWait(self.driver, 60).until(EC.element_to_be_clickable(elem))
+        WebDriverWait(self.driver, 30).until(EC.element_to_be_clickable(elem))
         elem.click()
-        wait = WebDriverWait(self.driver, 30)
+        wait = WebDriverWait(self.driver, 60)
         element = wait.until(EC.visibility_of_element_located((By.CLASS_NAME, "sys_messages")))
         sys_message_text = element.text
         sys_message_texts = sys_message_text.split('\n')


### PR DESCRIPTION
## Issues

* When running Selenium tests in headless Chrome, Chrome's built-in password manager leak detection occasionally triggers a dialog or background alert that interferes with test execution, causing unexpected failures unrelated to the actual test logic.
* The search test clicks `.search_update` using a direct Selenium `.click()`. In headless mode, this element is occasionally obscured by overlapping UI elements at the time of the click, causing `ElementClickInterceptedException` and a test failure.