### PR TITLE
fix(other): remove php 7.1 7.2 and 7.4 deprecations

### DIFF
--- a/lib/ini_set.php
+++ b/lib/ini_set.php
@@ -54,13 +54,6 @@ ini_set('session.use_trans_sid', 0);
 /* don't allow dynamic page caching */
 ini_set('session.cache_limiter', 'nocache');
 
-/* session hash mechanism */
-if (version_compare(PHP_VERSION, 8.1, '==')) {
-    ini_set('session.hash_function', 1);
-} else {
-    ini_set('session.hash_function', 'sha256');
-}
-
 /* session name */
 ini_set('session.name', 'hm_session');
 

--- a/lib/ini_set.php
+++ b/lib/ini_set.php
@@ -57,9 +57,6 @@ ini_set('session.cache_limiter', 'nocache');
 /* session name */
 ini_set('session.name', 'hm_session');
 
-/* disable remote includes */
-ini_set('allow_url_include', 0);
-
 /* when display_errors is on PHP returns a 200 when it should be a 500 */
 ini_set('display_errors', 0);
 ini_set('display_start_up_errors', 0);

--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -568,26 +568,19 @@ class Hm_SMTP {
 
     /* NTLM compatible DES encryption */
     function des_encrypt($string, $challenge='KGS!@#$%') {
-        $key = array();
         $tmp = array();
         $len = strlen($string);
         for ($i=0; $i<7; ++$i)
             $tmp[] = $i < $len ? ord($string[$i]) : 0;
-        $key[] = $tmp[0] & 254;
-        $key[] = ($tmp[0] << 7) | ($tmp[1] >> 1);
-        $key[] = ($tmp[1] << 6) | ($tmp[2] >> 2);
-        $key[] = ($tmp[2] << 5) | ($tmp[3] >> 3);
-        $key[] = ($tmp[3] << 4) | ($tmp[4] >> 4);
-        $key[] = ($tmp[4] << 3) | ($tmp[5] >> 5);
-        $key[] = ($tmp[5] << 2) | ($tmp[6] >> 6);
-        $key[] = $tmp[6] << 1;
-        $is = mcrypt_get_iv_size(MCRYPT_DES, MCRYPT_MODE_ECB);
-        $iv = mcrypt_create_iv($is, MCRYPT_RAND);
-        $key0 = "";
-        foreach ($key as $k)
-            $key0 .= chr($k);
-        $crypt = mcrypt_encrypt(MCRYPT_DES, $key0, $challenge, MCRYPT_MODE_ECB, $iv);
-        return $crypt;
+        $key  = chr($tmp[0] & 254);
+        $key .= chr(($tmp[0] << 7) | ($tmp[1] >> 1));
+        $key .= chr(($tmp[1] << 6) | ($tmp[2] >> 2));
+        $key .= chr(($tmp[2] << 5) | ($tmp[3] >> 3));
+        $key .= chr(($tmp[3] << 4) | ($tmp[4] >> 4));
+        $key .= chr(($tmp[4] << 3) | ($tmp[5] >> 5));
+        $key .= chr(($tmp[5] << 2) | ($tmp[6] >> 6));
+        $key .= chr($tmp[6] << 1);
+        return openssl_encrypt($challenge, 'DES-ECB', $key, OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
     }
 
     /* Send a message */


### PR DESCRIPTION
Issues

* `allow_url_include` removed in PHP 7.4.0 https://www.php.net/manual/en/filesystem.configuration.php 
* `session.hash_function` removed in PHP 7.1.0 https://www.php.net/manual/en/session.configuration.php
* `mcrypt` was deprecated in PHP 7.1 and **removed in PHP 7.2** https://www.php.net/manual/en/book.mcrypt.php