### PR TITLE
fix(backend): Undefined array key name

### DIFF
--- a/modules/core/message_list_functions.php
+++ b/modules/core/message_list_functions.php
@@ -532,7 +532,8 @@ function list_sources($sources, $output_mod) {
         else {
             $folder = $src['folder_name'];
         }
-        $res .= '<div class="list_src">'.$output_mod->html_safe($src['type']).' '.$output_mod->html_safe($src['name']);
+        $src_name = array_key_exists('name', $src) ? $src['name'] : '';
+        $res .= '<div class="list_src">'.$output_mod->html_safe($src['type']).' '.$output_mod->html_safe($src_name);
         $res .= ' '.$output_mod->html_safe($folder);
         $res .= '</div>';
     }


### PR DESCRIPTION
The following error was making itself visible on the page:

`Undefined array key "name" in jason-munro/cypht/modules/core/message_list_functions.php on line 535`