### PR TITLE
fix(frontend): extra headers buttons missalignment

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -467,7 +467,7 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
             }
             $txt .= '<a class="hlink text-decoration-none btn btn-sm btn-outline-secondary" id="show_message_source" href="#">' . $this->trans('Show Source') . '</a>';
 
-            $txt .= '</div><span id="extra-header-buttons"></span>';
+            $txt .= '<span id="extra-header-buttons"></span></div>';
             $txt .= '<input type="hidden" class="move_to_type" value="" />';
             $txt .= '<input type="hidden" class="move_to_string1" value="'.$this->trans('Move to ...').'" />';
             $txt .= '<input type="hidden" class="move_to_string2" value="'.$this->trans('Copy to ...').'" />';


### PR DESCRIPTION

<img width="1280" height="206" alt="5170664102517476421_121" src="https://github.com/user-attachments/assets/989fcf9a-f5e6-40a5-9084-f0a494894de0" />

Extra header buttons where missaligned.

