### PR TITLE
fix(other): correct 'booelan' typo to 'boolean' in Hm_MessagesStore to respect "Don't flag message as read on open" setting

### DIFF
--- a/modules/core/js_modules/Hm_MessagesStore.js
+++ b/modules/core/js_modules/Hm_MessagesStore.js
@@ -87,7 +87,7 @@ class Hm_MessagesStore {
                 this.pages = parseInt(pages);
                 this.newMessages = this.getNewMessages(updatedMessages);
 
-                if (typeof do_not_flag_as_read_on_open == 'booelan') {
+                if (typeof do_not_flag_as_read_on_open == 'boolean') {
                     this.flagAsReadOnOpen = !do_not_flag_as_read_on_open;
                 }
 


### PR DESCRIPTION
Related issue: https://github.com/cypht-org/cypht/issues/769