### PR TITLE
fix(module/smtp): correct SCRAM authentication command and mechanism selection

### DIFF
--- a/lib/scram.php
+++ b/lib/scram.php
@@ -118,4 +118,19 @@ public function authenticateScram($scramAlgorithm, $username, $password, $getSer
     }
     return false; // Authentication failed
 }
+
+private function extractChallenge($response, $protocol) {
+    if ($protocol === 'smtp') {
+        // SMTP get_response() returns a chunked array: [['334', ['base64data']], ...]
+        if (!empty($response) && isset($response[0][0]) && $response[0][0] === '334') {
+            return $response[0][1][0] ?? '';
+        }
+        return null;
+    }
+    // IMAP get_response() returns raw strings; continuation lines start with '+ '
+    if (!empty($response) && mb_substr($response[0], 0, 2) === '+ ') {
+        return mb_substr($response[0], 2);
+    }
+    return null;
+}
 }

--- a/lib/scram.php
+++ b/lib/scram.php
@@ -44,17 +44,24 @@ public function generateClientProof($username, $password, $salt, $clientNonce, $
     return $clientProof;
 }
 
-public function authenticateScram($scramAlgorithm, $username, $password, $getServerResponse, $sendCommand) {
+public function authenticateScram($scramAlgorithm, $username, $password, $getServerResponse, $sendCommand, $protocol = 'imap') {
     $algorithm = $this->getHashAlgorithm($scramAlgorithm);
 
-    // Send initial SCRAM command
-    $scramCommand = 'AUTHENTICATE ' . $scramAlgorithm . "\r\n";
-    $sendCommand($scramCommand);
+    // SMTP uses "AUTH <mech>"; IMAP uses "AUTHENTICATE <mech>".
+    // SMTP's send_command() appends \r\n internally, so we must not include it here.
+    // IMAP's send_command() sends exactly what it receives, so \r\n must be included.
+    if ($protocol === 'smtp') {
+        $sendCommand('AUTH ' . $scramAlgorithm);
+    } else {
+        $sendCommand('AUTHENTICATE ' . $scramAlgorithm . "\r\n");
+    }
     $response = $getServerResponse();
-    if (!empty($response) && mb_substr($response[0], 0, 2) == '+ ') {
-        $this->log("Received server challenge: " . $response[0]);
+
+    $challenge = $this->extractChallenge($response, $protocol);
+    if ($challenge !== null) {
+        $this->log("Received server challenge: " . $challenge);
         // Extract salt and server nonce from the server's challenge
-        $serverChallenge = base64_decode(mb_substr($response[0], 2));
+        $serverChallenge = base64_decode($challenge);
         $parts = explode(',', $serverChallenge);
         $serverNonce = base64_decode(substr($parts[0], strpos($parts[0], "=") + 1));
         $salt = base64_decode(substr($parts[1], strpos($parts[1], "=") + 1));

--- a/lib/scram.php
+++ b/lib/scram.php
@@ -78,13 +78,19 @@ public function authenticateScram($scramAlgorithm, $username, $password, $getSer
         $clientFinalMessage = $channelBindingData . 'r=' . $serverNonce . $clientNonce . ',p=' . $clientProof;
         $clientFinalMessageEncoded = base64_encode($clientFinalMessage);
         $this->log("Sending client final message: " . $clientFinalMessageEncoded);
-        // Send client final message to server
-        $sendCommand($clientFinalMessageEncoded . "\r\n");
+
+        // Send client final message to server (same \r\n handling as the initial command)
+        if ($protocol === 'smtp') {
+            $sendCommand($clientFinalMessageEncoded);
+        } else {
+            $sendCommand($clientFinalMessageEncoded . "\r\n");
+        }
 
         // Verify server's response
         $response = $getServerResponse();
-        if (!empty($response) && mb_substr($response[0], 0, 2) == '+ ') {
-            $serverFinalMessage = base64_decode(mb_substr($response[0], 2));
+        $challenge2 = $this->extractChallenge($response, $protocol);
+        if ($challenge2 !== null) {
+            $serverFinalMessage = base64_decode($challenge2);
             $parts = explode(',', $serverFinalMessage);
             $serverProof = substr($parts[0], strpos($parts[0], "=") + 1);
 

--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -142,16 +142,16 @@ class Hm_SMTP {
             $this->starttls = true;
         }
         $this->request_auths = array(
-            'scram-sha-1',
-            'scram-sha-1-plus',
-            'scram-sha-256',
-            'scram-sha-256-plus',
-            'scram-sha-224',
-            'scram-sha-224-plus',
-            'scram-sha-384',
-            'scram-sha-384-plus',
-            'scram-sha-512',
             'scram-sha-512-plus',
+            'scram-sha-512',
+            'scram-sha-384-plus',
+            'scram-sha-384',
+            'scram-sha-256-plus',
+            'scram-sha-256',
+            'scram-sha-224-plus',
+            'scram-sha-224',
+            'scram-sha-1-plus',
+            'scram-sha-1',
             'cram-md5',
             'login',
             'plain');

--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -378,7 +378,8 @@ class Hm_SMTP {
                 $username,
                 $password,
                 [$this, 'get_response'],
-                [$this, 'send_command']
+                [$this, 'send_command'],
+                'smtp'
             );
             if ($result) {
                 return 'Authentication successful';


### PR DESCRIPTION
Related issue: https://github.com/cypht-org/cypht/issues/1466