### PR TITLE
refactor(frontend): fix mobile layout for advanced search results and truncate long list labels

### DIFF
--- a/modules/advanced_search/site.css
+++ b/modules/advanced_search/site.css
@@ -44,3 +44,29 @@
 .mobile .advanced_search_form .adv_folder_list .inner_list .wrapper > a {
   max-width: min(160px, 45vw);
 }
+
+/* Search results: from + subject only on mobile */
+.mobile .adv_controls + .message_list .message_table td.source,
+.mobile .adv_controls + .message_list .message_table td.msg_date,
+.mobile .adv_controls + .message_list .message_table td.icon,
+.mobile .adv_controls + .message_list .message_table td.dates {
+  display: none !important;
+}
+.mobile .adv_controls + .message_list .message_table {
+  table-layout: auto;
+}
+.mobile .adv_controls + .message_list .message_table td.checkbox_cell {
+  width: 28px;
+}
+.mobile .adv_controls + .message_list .message_table td.from {
+  width: 35%;
+  max-width: 35%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mobile .adv_controls + .message_list .message_table td.subject {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/modules/advanced_search/site.css
+++ b/modules/advanced_search/site.css
@@ -9,4 +9,38 @@
 .adv_search_link { margin-left: 20px; }
 .adv_terms { margin-left: 10px; }
 
+.advanced_search_form .adv_folder_list .wrapper {
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+.advanced_search_form .adv_folder_list .adv_folder_link {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: min(240px, 40vw);
+}
+.advanced_search_form .adv_folder_list .wrapper > .unread_count {
+  flex-shrink: 0;
+}
+.advanced_search_form .adv_folder_list .wrapper > .d-flex.gap-3 {
+  flex-shrink: 0;
+}
+.advanced_search_form .adv_folder_list .inner_list .wrapper > a {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: min(220px, 38vw);
+}
+
 .mobile .search_result_title { position: relative !important; z-index: 99 !important;}
+.mobile .advanced_search_form .adv_folder_list .adv_folder_link {
+  max-width: min(180px, 50vw);
+}
+.mobile .advanced_search_form .adv_folder_list .inner_list .wrapper > a {
+  max-width: min(160px, 45vw);
+}

--- a/modules/advanced_search/site.js
+++ b/modules/advanced_search/site.js
@@ -71,6 +71,15 @@ var add_remove_targets = function(el) {
     });
 };
 
+var set_adv_folder_link_titles = function(container) {
+    $(container).find('.adv_folder_link').each(function() {
+        const label = $(this).text().trim();
+        if (label) {
+            $(this).attr('title', label);
+        }
+    });
+};
+
 var expand_adv_folder = function(res) {
     if (res.imap_expanded_folder_path) {
         var list_container = $('.adv_folder_list');
@@ -84,6 +93,7 @@ var expand_adv_folder = function(res) {
         $('a', list_container).not('.adv_folder_link').off('click');
         $('a', list_container).not('.adv_folder_link').on("click", function() { adv_folder_select($(this).data('id')); return false; });
         modifyInnerLists(foldersWrapper);
+        set_adv_folder_link_titles(list_container);
     }
 };
 
@@ -131,6 +141,7 @@ var adv_select_imap_folder = function(el) {
 
     $('.imap_folder_link', folders).addClass('adv_folder_link').removeClass('imap_folder_link');
     $('.adv_folder_list').html(folders.html());
+    set_adv_folder_link_titles(list_container);
 
     $('.adv_folder_link', list_container).on("click", function() { return expand_adv_folder_list($(this).data('target')); });
     $('a', list_container).not('.adv_folder_link').not('.close_adv_folders').not('.pick_special_folders').off('click');

--- a/modules/core/message_list_functions.php
+++ b/modules/core/message_list_functions.php
@@ -532,9 +532,8 @@ function list_sources($sources, $output_mod) {
         else {
             $folder = $src['folder_name'];
         }
-        $res .= '<div class="list_src">'.$output_mod->html_safe($src['type']).' '.$output_mod->html_safe($src['name']);
-        $res .= ' '.$output_mod->html_safe($folder);
-        $res .= '</div>';
+        $label = trim($src['type'].' '.$src['name'].' '.$folder);
+        $res .= '<div class="list_src" title="'.$output_mod->html_safe($label).'">'.$output_mod->html_safe($label).'</div>';
     }
     $res .= '</div>';
     return $res;

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -1835,7 +1835,11 @@ pre.msg_source {
   .mobile .terms_section .d-flex { display: inline-block !important; }
   .mobile .terms_section .adv_terms { display: inline-block; }
   .mobile .terms_section .adv_term_nots input { margin-top: 10px; }
-  .mobile .source_section .adv_folder_list .folders > li > .d-flex { display: inline-block !important; }
+  .mobile .source_section .adv_folder_list .folders > li > .wrapper {
+    display: flex !important;
+    flex-wrap: wrap;
+    align-items: center;
+  }
   .mobile .targets_section .adv_targets .form-check-label { display: inline; }
   .mobile .time_section .adv_times { display: inline-block !important; }
   .mobile .time_section .new_time { display: block; }

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -1341,6 +1341,16 @@ div.unseen,
   font-size: 85%;
   padding: 15px 20px;
   display: none;
+  box-sizing: border-box;
+  max-width: min(320px, calc(100vw - 2rem));
+}
+.list_sources .list_src {
+  display: block;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .step_config-title {
@@ -1728,7 +1738,11 @@ pre.msg_source {
   color: var(--bs-body-bg) !important;
   background: var(--bs-link-color);
 }
-.content_title .list_sources.w-100 { width: auto !important; }
+.content_title .list_sources.w-100 {
+  width: auto !important;
+  max-width: min(320px, calc(100vw - 2rem));
+  min-width: 0;
+}
 .content_title .list_sources .src_title { font-weight: bold; }
 .total_unread_count, .total_unread_count.badge, .unread_count { color: var(--bs-body-bg) !important; background-color: var(--bs-link-hover-color) !important; }
 .folders a, .unread_link, .logout_link { color: rgba(var(--bs-body-color-rgb), 0.85); }
@@ -1766,7 +1780,11 @@ pre.msg_source {
 .mobile .msg_text_inner { font-size: 120%; padding: 0px !important; }
 .mobile .save_perm_form { margin-bottom: 1.5rem; }
 .mobile .save_perm_form .save_settings { margin-bottom: 0.5rem; }
-.mobile .content_title .list_sources { top: 40px; border: 1px solid var(--bs-border-color); }
+.mobile .content_title .list_sources {
+  top: 40px;
+  border: 1px solid var(--bs-border-color);
+  max-width: min(300px, calc(100vw - 1.5rem));
+}
 .mobile .content_title .path_delim + a { display: contents; }
 .mobile .calendar > .m-4 { margin: 1rem !important; }
 .mobile .quick_add_multiple_server_form { padding-left: 1.5rem; padding-right: 1.5rem; }

--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -853,10 +853,11 @@ class Hm_Output_folders_content_start extends Hm_Output_Module {
             $server_specials = isset($specials[$id]) ? $specials[$id] : array();
             $res .= '<div class="account_folder_block card mb-3" data-server-id="'.$this->html_safe($id).'">';
             $res .= '<div class="card-header account_folder_header d-flex justify-content-between align-items-center" role="button">';
-            $res .= '<div><i class="bi bi-chevron-right account_expand_icon me-2"></i>';
+            $account_name = $this->html_safe($server['name']);
+            $res .= '<div class="account_folder_title"><i class="bi bi-chevron-right account_expand_icon me-2"></i>';
             $res .= '<i class="bi bi-envelope-fill me-2"></i>';
-            $res .= '<strong>'.$this->html_safe($server['name']).'</strong></div>';
-            $res .= '<span class="badge bg-secondary folder-count-badge" style="display:none;"></span>';
+            $res .= '<strong title="'.$account_name.'">'.$account_name.'</strong></div>';
+            $res .= '<span class="badge bg-secondary folder-count-badge flex-shrink-0" style="display:none;"></span>';
             $res .= '</div>';
             $res .= '<div class="card-body account_folder_body" style="display:none;">';
             $res .= '<div class="d-flex justify-content-between align-items-center mb-3">';

--- a/modules/imap_folders/site.css
+++ b/modules/imap_folders/site.css
@@ -32,8 +32,37 @@
 .account_folder_block .card-header { cursor: pointer; transition: background-color 0.2s; }
 .account_folder_block .card-header:hover { background-color: rgba(0,0,0,.05); }
 .account_expand_icon { transition: transform 0.2s; font-size: 0.85rem; }
+.account_folder_title {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+.account_folder_title strong {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+}
+.folder_table {
+  table-layout: fixed;
+  width: 100%;
+}
 .folder_table th { font-size: 0.85rem; white-space: nowrap; }
 .folder_table td { vertical-align: middle; font-size: 0.9rem; }
+.folder_table td.folder-name-cell {
+  max-width: 0;
+  overflow: hidden;
+}
+.folder_table .folder-name-text {
+  display: inline-block;
+  max-width: calc(100% - 1.5rem);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
 .folder_table .btn-group { white-space: nowrap; }
 .folder-count-badge { font-weight: normal; font-size: 0.75rem; }
 

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -366,7 +366,8 @@ var render_folder_table = function(folders, tbody, server_id) {
         var indentPx = indent * 20;
 
         var row = '<tr data-folder-hex="' + folder.hex_name + '" data-folder-name="' + esc_html(folder.basename) + '" data-server-id="' + server_id + '">';
-        row += '<td style="padding-left:' + (indentPx + 8) + 'px"><i class="bi bi-folder2 me-1"></i>' + esc_html(displayName) + '</td>';
+        row += '<td class="folder-name-cell" style="padding-left:' + (indentPx + 8) + 'px"><i class="bi bi-folder2 me-1"></i>'
+            + '<span class="folder-name-text" title="' + esc_html(displayName) + '">' + esc_html(displayName) + '</span></td>';
         row += '<td>' + specialBadge + '</td>';
         row += '<td class="text-end">';
         row += '<div class="btn-group btn-group-sm" role="group">';

--- a/tests/phpunit/modules/core/message_list_functions.php
+++ b/tests/phpunit/modules/core/message_list_functions.php
@@ -122,8 +122,8 @@ class Hm_Test_Core_Message_List_Functions extends TestCase {
     public function test_list_sources() {
         $mod = new Hm_Output_Test(array('foo' => 'bar', 'bar' => 'foo'), array('bar'));
         $this->assertEquals('<div class="list_sources w-100 mt-2"><div class="src_title fs-5 mb-2">Sources</div></div>', list_sources(array(array('group' => 'background', 'type' => 'imap', 'folder' => 'foo')), $mod));
-        $this->assertEquals('<div class="list_sources w-100 mt-2"><div class="src_title fs-5 mb-2">Sources</div><div class="list_src">imap blah foo</div></div>', list_sources(array(array('name' => 'blah', 'type' => 'imap', 'folder' => bin2hex('foo'), 'folder_name' => 'foo')), $mod));
-        $this->assertEquals('<div class="list_sources w-100 mt-2"><div class="src_title fs-5 mb-2">Sources</div><div class="list_src">imap blah INBOX</div></div>', list_sources(array(array('name' => 'blah', 'type' => 'imap')), $mod));
+        $this->assertEquals('<div class="list_sources w-100 mt-2"><div class="src_title fs-5 mb-2">Sources</div><div class="list_src" title="imap blah foo">imap blah foo</div></div>', list_sources(array(array('name' => 'blah', 'type' => 'imap', 'folder' => bin2hex('foo'), 'folder_name' => 'foo')), $mod));
+        $this->assertEquals('<div class="list_sources w-100 mt-2"><div class="src_title fs-5 mb-2">Sources</div><div class="list_src" title="imap blah INBOX">imap blah INBOX</div></div>', list_sources(array(array('name' => 'blah', 'type' => 'imap')), $mod));
     }
     /**
      * @preserveGlobalState disabled


### PR DESCRIPTION
[related task](https://avan.tech/item104817)

- Truncate long source and folder labels with ellipse and tooltips, 
- Limit advanced search result rows on mobile to `From` and `Subject` so the message table remains usable on small screens.
- Truncate long account and folder names on the Folders page with ellipsis and tooltips, keeping the folder count badge and action buttons visible.


<img width="266" height="516" alt="oiu_1" src="https://github.com/user-attachments/assets/8d6b5c68-ec0c-4f48-a9a3-315b5ffb3068" />
<img width="258" height="512" alt="ou1" src="https://github.com/user-attachments/assets/d24b840d-d294-4b90-b5a0-42aa8fb43507" />
<img width="266" height="522" alt="ou4" src="https://github.com/user-attachments/assets/a192d76c-d910-46d7-b4ca-d8f0aee65e8e" />
<img width="257" height="532" alt="ou3" src="https://github.com/user-attachments/assets/4eee72a1-559d-4f67-b0f8-550049e8617b" />
<img width="260" height="520" alt="ou2" src="https://github.com/user-attachments/assets/8faad855-643a-48b1-b370-0c4bd642b983" />


