### PR TITLE
fix(frontend): improve responsive layout and truncate long labels

### DIFF
--- a/modules/keyboard_shortcuts/modules.php
+++ b/modules/keyboard_shortcuts/modules.php
@@ -139,11 +139,13 @@ class Hm_Output_shortcut_edit_form extends Hm_Output_Module {
         $res .= '<div class="edit_shortcut_form px-5"><form method="POST" action="'.$this->build_page_url('shortcuts', array('edit_id' => $this->html_safe($details['id']))).'">';
         $res .= '<input type="hidden" name="shortcut_id" value="'.$this->html_safe($details['id']).'" />';
         $res .= '<input type="hidden" name="hm_page_key" value="'.$this->html_safe(Hm_Request_Key::generate()).'" />';
-        $res .= '<table>';
-        $res .= '<tr><th colspan="2">'.$this->trans(ucfirst($details['group'])).' : '.
-            $this->trans($details['label']).'</th></tr>';
-        $res .= '<tr><td>'.$this->trans('Modifier Key(s)').'</td>';
-        $res .= '<td><select class="form-select form-select-sm" required multiple size="5" name="shortcut_meta[]">';
+        $shortcut_title = $this->trans(ucfirst($details['group'])).' : '.$this->trans($details['label']);
+        $safe_shortcut_title = $this->html_safe($shortcut_title);
+        $res .= '<div class="shortcut_edit_fields">';
+        $res .= '<h5 class="shortcut_edit_title mb-3" title="'.$safe_shortcut_title.'">'.$safe_shortcut_title.'</h5>';
+        $res .= '<div class="edit_shortcut_field mb-3">';
+        $res .= '<label class="form-label">'.$this->trans('Modifier Key(s)').'</label>';
+        $res .= '<select class="form-select form-select-sm w-100" required multiple size="5" name="shortcut_meta[]">';
         foreach ($meta as $v) {
             $res .= '<option ';
             if (in_array($v, $details['control_chars'], true)) {
@@ -154,9 +156,10 @@ class Hm_Output_shortcut_edit_form extends Hm_Output_Module {
             }
             $res .= 'value="'.$v.'">'.ucfirst($v).'</option>';
         }
-        $res .= '</select></td></tr>';
-        $res .= '<tr><td>'.$this->trans('Character').'</td>';
-        $res .= '<td><select class="form-select form-select-sm" required " name="shortcut_key">';
+        $res .= '</select></div>';
+        $res .= '<div class="edit_shortcut_field mb-3">';
+        $res .= '<label class="form-label">'.$this->trans('Character').'</label>';
+        $res .= '<select class="form-select form-select-sm w-100" required name="shortcut_key">';
         foreach ($codes as $name => $val) {
             $res .= '<option ';
             if ($val == $details['char']) {
@@ -164,13 +167,11 @@ class Hm_Output_shortcut_edit_form extends Hm_Output_Module {
             }
             $res .= 'value="'.$this->html_safe($val).'">'.$this->html_safe($name).'</option>';
         }
-        $res .= '</select></td></tr>';
-        $res .= '<tr><td colspan="2">
-                        <input type="submit" class="btn btn-primary" value="'.$this->trans('Update').'" />
-                        <input type="button" class="btn btn-light border reset_shortcut" value="'.$this->trans('Cancel').'" />
-                </td></tr>';
-
-        $res .= '</table></form></div>';
+        $res .= '</select></div>';
+        $res .= '<div class="d-flex gap-2 flex-wrap mt-2">';
+        $res .= '<input type="submit" class="btn btn-primary" value="'.$this->trans('Update').'" />';
+        $res .= '<input type="button" class="btn btn-light border reset_shortcut" value="'.$this->trans('Cancel').'" />';
+        $res .= '</div></div></form></div>';
         return $res;
     }
 }

--- a/modules/keyboard_shortcuts/site.css
+++ b/modules/keyboard_shortcuts/site.css
@@ -1,8 +1,26 @@
 /* .shortcut_content { width: 100%; padding-bottom: 30px; }
 .shortcut_content .edit_shortcut_form { width: 1%; margin: 20px; margin-left: 40px; } */
-.edit_shortcut_form table th, .edit_shortcut_form table td { padding-bottom: 10px; padding-right: 20px; text-align: left; font-weight: normal; white-space: nowrap; }
-/* .edit_shortcut_form select { overflow-y: auto; } */
-.edit_shortcut_form table th { font-size: 115%; padding-bottom: 20px; }
+.edit_shortcut_form {
+  max-width: 100%;
+}
+.edit_shortcut_form .shortcut_edit_fields {
+  display: flex;
+  flex-direction: column;
+  max-width: 32rem;
+}
+.edit_shortcut_form .shortcut_edit_title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+}
+.edit_shortcut_form .edit_shortcut_field .form-label {
+  font-weight: normal;
+  margin-bottom: 0.35rem;
+}
 .shortcut_table { width: 50%; }
 /* .kbd_config { cursor: pointer; opacity: .4; } */
 .shortcut_table th { padding-left: 40px; font-weight: normal; padding-top: 6px; padding-bottom: 3px; text-align: left; }
@@ -14,3 +32,10 @@
 .mobile .shortcut_table img { width: 20px; height: 20px; }
 .mobile .shortcut_table th { padding-left: 10px; }
 .mobile .shortcut_table { padding-right: 10px; }
+.mobile .edit_shortcut_form {
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+}
+.mobile .edit_shortcut_form .shortcut_edit_fields {
+  max-width: 100%;
+}

--- a/modules/sievefilters/functions.php
+++ b/modules/sievefilters/functions.php
@@ -535,29 +535,34 @@ if (!hm_exists('get_blocked_senders')){
             ];
             $ret = '';
             foreach ($blocked_senders as $k => $sender) {
-                $reject_message = $blocked_list_actions[$sender]['reject_message'];
-                $ret .= '<tr><td>'.$sender.'</td><td>';
+                $reject_message = ($blocked_list_actions[$sender] ?? [])['reject_message'] ?? '';
+                $sender_esc = $module->html_safe($sender);
+                $behavior_text = '';
                 if (is_array($blocked_list_actions) && array_key_exists($sender, $blocked_list_actions)) {
                     $action = $blocked_list_actions[$sender]['action'] ?: 'default';
-                    $ret .= $actions_map[$action];
+                    $behavior_text = $actions_map[$action];
                     if ($action == 'reject_with_message') {
-                        $ret .= ' - '.$reject_message;
+                        $behavior_text .= ' - '.$reject_message;
                     }
                 } else {
                     $action = 'default';
-                    $ret .= 'Default';
+                    $behavior_text = 'Default';
                 }
-                $ret .= '<a href="#" mailbox_id="'.$mailbox_id.'" data-action="'.$action.'" data-reject-message="'.$reject_message.'" title="'.$module->trans('Change Behavior').'" class="block_sender_link toggle-behavior-dropdown" aria-labelledby="dropdownMenuBlockSender'.$k.'" data-bs-toggle="dropdown" aria-expanded="false"> <i class="bi bi-pencil-fill ms-3"></i></a>';
-                $ret .= block_filter_dropdown($module, $mailbox_id, false, 'edit_blocked_behavior', 'Edit', $k);
+                $behavior_esc = $module->html_safe($behavior_text);
+                $reject_message_esc = $module->html_safe($reject_message);
 
-                $ret .= '</td><td><i class="bi bi-'.$icon_svg.' unblock_button" mailbox_id="'.$mailbox_id.'" data-title="unblock Sender '.$sender.'"></i>';
+                $ret .= '<tr>';
+                $ret .= '<td class="blocked_sender_fld" data-title="'.$sender_esc.'">'.$sender_esc.'</td>';
+                $ret .= '<td><span class="blocked_behavior_fld" data-title="'.$behavior_esc.'">'.$behavior_esc.'</span>';
+                $ret .= '<a href="#" mailbox_id="'.$mailbox_id.'" data-action="'.$action.'" data-reject-message="'.$reject_message_esc.'" title="'.$module->trans('Change Behavior').'" class="block_sender_link toggle-behavior-dropdown" aria-labelledby="dropdownMenuBlockSender'.$k.'" data-bs-toggle="dropdown" aria-expanded="false"> <i class="bi bi-pencil-fill ms-3"></i></a>';
+                $ret .= block_filter_dropdown($module, $mailbox_id, false, 'edit_blocked_behavior', 'Edit', $k);
+                $ret .= '</td>';
+                $ret .= '<td class="text-end blocked_sender_actions" style="width: 100px">';
+                $ret .= '<a href="#" class="unblock_button cursor-pointer" mailbox_id="'.$mailbox_id.'" data-title="'.$module->html_safe('unblock Sender '.$sender).'"><i class="bi bi-'.$icon_svg.' ms-2"></i></a>';
                 if (!mb_strstr($sender, '*')) {
                     $sender_party = explode('@', $sender);
-                    $domain_name = "";
-                    if(isset($sender_party[1])) {
-                        $domain_name = $sender_party[1];
-                    }
-                    $ret .= ' <i class="bi bi-'.$icon_block_domain_svg.' block_domain_button" mailbox_id="'.$mailbox_id.'" data-title="block domain '.$domain_name.'"></i>';
+                    $domain_name = isset($sender_party[1]) ? $sender_party[1] : '';
+                    $ret .= '<a href="#" class="block_domain_button cursor-pointer ms-3" mailbox_id="'.$mailbox_id.'" data-title="'.$module->html_safe('block domain '.$domain_name).'"><i class="bi bi-'.$icon_block_domain_svg.'"></i></a>';
                 }
                 $ret .= '</td></tr>';
             }

--- a/modules/sievefilters/modules.php
+++ b/modules/sievefilters/modules.php
@@ -1344,7 +1344,7 @@ class Hm_Output_blocklist_settings_accounts extends Hm_Output_Module {
         $res .= '<span class="filters_count"><span id="filter_num_' . $mailbox['id'] . '">' . $num_blocked . '</span> ' . $this->trans('blocked') . '</span></div>';
         $res .= '<div class="sievefilters_accounts filter_block py-3 d-none"><div class="filter_subblock">';
         $res .= $default_behaviour_html;
-        $res .= '<table class="filter_details table"><tbody>';
+        $res .= '<table class="filter_details blocked_senders_table table"><tbody>';
         $res .= '<tr><th class="col-sm-6">Sender</th><th class="col-sm-3">Behavior</th><th class="col-sm-3">Actions</th></tr>';
         $res .= get_blocked_senders($mailbox, $mailbox['id'], 'x-circle-fill', 'globe-europe-africa', $this->get('site_config'), $this->get('user_config'), $this);
         $res .= '</tbody></table>';

--- a/modules/sievefilters/site.css
+++ b/modules/sievefilters/site.css
@@ -257,13 +257,27 @@
     padding-top: 20px;
 } */
 
-.unblock_button {
-    width: 16px;
-    cursor: pointer;
+.blocked_senders_table .blocked_sender_fld {
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.block_domain_button {
-    width: 16px;
+.blocked_senders_table .blocked_behavior_fld {
+    max-width: 180px;
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+.mobile .blocked_senders_table .blocked_sender_fld {
+    max-width: 120px;
+}
+
+.blocked_senders_table .blocked_sender_actions a {
     cursor: pointer;
 }
 

--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -1050,7 +1050,8 @@ function blockListPageHandlers() {
         if (!confirm(hm_trans('Do you want to unblock sender?'))) {
             return;
         }
-        let sender = $(this).parent().parent().children().html();
+        let row = $(this).closest('tr');
+        let sender = row.find('.blocked_sender_fld').first().text().trim();
         let elem = $(this);
         Hm_Ajax.request(
             [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_unblock_sender'},
@@ -1058,7 +1059,7 @@ function blockListPageHandlers() {
                 {'name': 'sender', 'value': sender}
             ],
             function(res) {
-                elem.parent().parent().remove();
+                row.remove();
                 var num_filters = $("#filter_num_" + elem.attr('mailbox_id')).html();
                 num_filters = parseInt(num_filters) - 1;
                 $("#filter_num_" + elem.attr('mailbox_id')).html(num_filters);
@@ -1070,7 +1071,7 @@ function blockListPageHandlers() {
         e.preventDefault();
         let parent = $(this).closest('tr');
         let elem = parent.find('.block_action');
-        let sender = $(this).closest('tr').children().first().html();
+        let sender = $(this).closest('tr').find('.blocked_sender_fld').first().text().trim();
         let scope = sender.startsWith('*@') ? 'domain': 'sender';
 
         Hm_Ajax.request(
@@ -1093,8 +1094,7 @@ function blockListPageHandlers() {
 
     $(document).on('click', '.block_domain_button', function(e) {
         e.preventDefault();
-        let sender = $(this).parent().parent().children().html();
-        let elem = $(this);
+        let sender = $(this).closest('tr').find('.blocked_sender_fld').first().text().trim();
         Hm_Ajax.request(
             [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_block_domain'},
                 {'name': 'imap_server_id', 'value': $(this).attr('mailbox_id')},


### PR DESCRIPTION
[related task](https://avan.tech/item104817)

-  **Shortcuts:** Edit a shortcut; form stacks on mobile; long group/label title clamps but shows full text via `title`

-  **Block list:** Open Settings → Block list; long senders truncate with `data-title` tooltip; unblock / block-domain icons are spaced and clickable;

<img width="251" height="513" alt="pase_1" src="https://github.com/user-attachments/assets/aab0e9dc-f2c3-4075-a210-7e11846ea134" />
<img width="248" height="526" alt="pase_2" src="https://github.com/user-attachments/assets/4b29c3a2-a664-4bc9-9dc1-51af90289eb8" />

