### PR TITLE
fix(frontend): init markdown editor on SPA compose navigation

### DIFF
--- a/modules/smtp/js_modules/markdownEditor.js
+++ b/modules/smtp/js_modules/markdownEditor.js
@@ -1,0 +1,45 @@
+function loadMarkdownStylesheet(href) {
+    if (document.querySelector('link[href="' + href + '"]')) {
+        return Promise.resolve();
+    }
+    return new Promise(function(resolve, reject) {
+        var link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = href;
+        link.onload = resolve;
+        link.onerror = reject;
+        document.head.appendChild(link);
+    });
+}
+
+function loadMarkdownScript(src) {
+    if (document.querySelector('script[src="' + src + '"]')) {
+        return Promise.resolve();
+    }
+    return new Promise(function(resolve, reject) {
+        var script = document.createElement('script');
+        script.src = src;
+        script.onload = resolve;
+        script.onerror = reject;
+        document.head.appendChild(script);
+    });
+}
+
+function useMarkdownEditor() {
+    var root = hm_web_root_path();
+    var cssUrl = root + 'modules/smtp/assets/markdown/editor.css';
+    var editorUrl = root + 'modules/smtp/assets/markdown/editor.js';
+    var markedUrl = root + 'modules/smtp/assets/markdown/marked.js';
+    var textarea = document.getElementById('compose_body');
+
+    if (!textarea) {
+        return;
+    }
+
+    loadMarkdownStylesheet(cssUrl)
+        .then(function() { return loadMarkdownScript(editorUrl); })
+        .then(function() { return loadMarkdownScript(markedUrl); })
+        .then(function() {
+            window.mdEditor = new Editor({ element: textarea });
+        });
+}

--- a/modules/smtp/js_modules/route_handlers.js
+++ b/modules/smtp/js_modules/route_handlers.js
@@ -6,8 +6,13 @@ function applySmtpComposePageHandlers(routeParams) {
         $('.smtp_send_placeholder').trigger('click');
     });
 
-    if (window.HTMLEditor) {
+    const composeType = Number($('.compose_form').data('compose-type'));
+
+    if (composeType === 1) {
         useKindEditor();
+    }
+    else if (composeType === 2) {
+        useMarkdownEditor();
     }
 
     var interval = Hm_Utils.get_from_global('compose_save_interval', 30);

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1024,7 +1024,7 @@ class Hm_Output_compose_form_start extends Hm_Output_Module {
         $res = '<div class="container">';
         $res .= '<div class="row justify-content-md-center">';
         $res .= '<div class="col col-lg-10 col-xl-8">';
-        $res .= '<form class="compose_form p-4" method="post" action="'.$this->build_page_url('compose').'" data-reminder="' . $this->get('enable_attachment_reminder', 0) . '">';
+        $res .= '<form class="compose_form p-4" method="post" action="'.$this->build_page_url('compose').'" data-reminder="' . $this->get('enable_attachment_reminder', 0) . '" data-compose-type="'.$this->get('smtp_compose_type', DEFAULT_SMTP_COMPOSE_TYPE).'">';
         return $res;
     }
 }
@@ -1183,13 +1183,7 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
         if (count($this->get('smtp_servers', array())) == 0) {
             $send_disabled = 'disabled="disabled" ';
         }
-        $res = '';
-        if ($html == 1) {
-            // TODO: The client should be provided all relevant configs so it can tell what appropriate js code to execute. This should not be handled by backend modules.
-            $res .= '<script type="text/javascript">window.HTMLEditor = true</script>';
-        }
-
-        $res .= '<input type="hidden" name="hm_page_key" value="'.$this->html_safe(Hm_Request_Key::generate()).'" />'.
+        $res = '<input type="hidden" name="hm_page_key" value="'.$this->html_safe(Hm_Request_Key::generate()).'" />'.
                 '<input type="hidden" name="compose_msg_path" value="'.$this->html_safe($msg_path).'" />'.
                 '<input type="hidden" name="post_archive" class="compose_post_archive" value="0" />'.
                 '<input type="hidden" name="next_email_post" class="compose_next_email_data" value="" />'.
@@ -1230,12 +1224,6 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
                 if($this->get('enable_compose_delivery_receipt_setting')) {
                     $res .= '<div class="form-check mb-3"><input value="1" name="compose_delivery_receipt" disabled id="compose_delivery_receipt" type="checkbox" class="form-check-input" checked/><label for="compose_delivery_receipt" class="form-check-label">'.$this->trans('Request a delivery receipt').'</label></div>';
                 }
-        if ($html == 2) {
-            $res .= '<link href="'.WEB_ROOT.'modules/smtp/assets/markdown/editor.css" rel="stylesheet" />'.
-                '<script type="text/javascript" src="'.WEB_ROOT.'modules/smtp/assets/markdown/editor.js"></script>'.
-                '<script type="text/javascript" src="'.WEB_ROOT.'modules/smtp/assets/markdown/marked.js"></script>'.
-                '<script type="text/javascript">window.mdEditor = new Editor(); mdEditor.render();</script>';
-        }
         $res .= '<table class="uploaded_files">';
 
         foreach ($files as $file) {


### PR DESCRIPTION
## Issue
When the **Outbound mail format** setting is set to **Markdown**, navigating to the Compose page via the sidebar (SPA navigation) does not load the markdown editor. The textarea stays as a plain `<textarea>`. The editor only appears after a full browser refresh. Plain text and HTML formats work correctly.