### PR TITLE
fix(frontend): use attr() over data() to prevent Cash.js hex coercion

### DIFF
--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -400,8 +400,8 @@ var render_folder_table = function(folders, tbody, server_id) {
 var bind_folder_table_actions = function(tbody, server_id) {
         tbody.find('.folder_create_child_btn').off('click').on('click', function() {
             var tr = $(this).closest('tr');
-            var folderHex = tr.data('folder-hex');
-            var folderName = tr.data('folder-name');
+            var folderHex = tr.attr('data-folder-hex');
+            var folderName = tr.attr('data-folder-name');
             var block = tr.closest('.account_folder_block');
             // Pass parent folder hex to modal
             show_create_folder_modal(server_id, block, folderHex, tr);
@@ -409,8 +409,8 @@ var bind_folder_table_actions = function(tbody, server_id) {
         });
     tbody.find('.folder_rename_btn').off('click').on('click', function() {
         var tr = $(this).closest('tr');
-        var folderHex = tr.data('folder-hex');
-        var folderName = tr.data('folder-name');
+        var folderHex = tr.attr('data-folder-hex');
+        var folderName = tr.attr('data-folder-name');
         var fullFolderName = 'imap_' + server_id + '_' + folderHex;
         show_rename_modal(server_id, fullFolderName, folderName, tr);
         return false;
@@ -418,8 +418,8 @@ var bind_folder_table_actions = function(tbody, server_id) {
 
     tbody.find('.folder_delete_btn').off('click').on('click', function() {
         var tr = $(this).closest('tr');
-        var folderHex = tr.data('folder-hex');
-        var folderName = tr.data('folder-name');
+        var folderHex = tr.attr('data-folder-hex');
+        var folderName = tr.attr('data-folder-name');
         var fullFolderName = 'imap_' + server_id + '_' + folderHex;
         show_delete_modal(server_id, fullFolderName, folderName, tr);
         return false;
@@ -428,8 +428,8 @@ var bind_folder_table_actions = function(tbody, server_id) {
     tbody.find('.set_special_btn').off('click').on('click', function(e) {
         e.preventDefault();
         var tr = $(this).closest('tr');
-        var folderHex = tr.data('folder-hex');
-        var folderName = tr.data('folder-name');
+        var folderHex = tr.attr('data-folder-hex');
+        var folderName = tr.attr('data-folder-name');
         var type = $(this).data('type');
         var block = tr.closest('.account_folder_block');
         var fullFolderName = 'imap_' + server_id + '_' + folderHex;
@@ -439,8 +439,8 @@ var bind_folder_table_actions = function(tbody, server_id) {
     tbody.find('.clear_special_btn').off('click').on('click', function(e) {
         e.preventDefault();
         var tr = $(this).closest('tr');
-        var folderHex = tr.data('folder-hex');
-        var folderName = tr.data('folder-name');
+        var folderHex = tr.attr('data-folder-hex');
+        var folderName = tr.attr('data-folder-name');
         var type = $(this).data('type');
         var block = tr.closest('.account_folder_block');
         if (!type) return;


### PR DESCRIPTION
## Summary

Assigning a special folder role to a folder named **"Sent"** always failed with _"Selected folder not found"_, while any other folder name worked fine.

**Root cause:** Cypht uses **Cash.js** which runs `JSON.parse()` on every value read by `.data()`. The hex string for "Sent" (`bin2hex('Sent') = "53656e74"`) is valid JSON scientific notation (`53656 × 10⁷⁴`), so Cash silently coerces it to a float. Concatenating that float into the folder identifier produces `"imap_<id>_5.3656e+78"` — which PHP's `hex2bin()` cannot decode, making `prep_folder_name` return `false`.

Other folder names were not affected because their hex output either contains early `a–f` letters (invalid JSON numbers, so `JSON.parse` throws and Cash falls back to the raw string), or produces a safe integer that round-trips through `String()` unchanged.

**Fix:** Replace `tr.data('folder-hex')` / `tr.data('folder-name')` with `tr.attr('data-folder-hex')` / `tr.attr('data-folder-name')` in `bind_folder_table_actions`. Cash's `.attr()` calls the browser-native `getAttribute()` and returns the raw string with no type coercion.