### PR TITLE
fix(frontend): pass sidebar search_terms on SPA search icon click

### DIFF
--- a/modules/core/navigation/navigation.js
+++ b/modules/core/navigation/navigation.js
@@ -117,6 +117,10 @@ function autoAppendParamsForNavigation(href)
                     }
                 }
             }
+            const sidebarSearchTerms = $('.menu_search form [name=search_terms]').val();
+            if (sidebarSearchTerms && sidebarSearchTerms.trim()) {
+                target.set('search_terms', sidebarSearchTerms.trim());
+            }
             return href.split('?')[0] + '?' + target.toString();
         }
     }


### PR DESCRIPTION
## Issue

The left sidebar has a search box with a magnifying-glass control and a text field. Pressing Enter runs a search as expected. Clicking the magnifying glass only opens the search page and does not run the search with what you typed.

That happens because Enter submits the sidebar form, so the URL includes search_terms. The icon is a link to ?page=search only. SPA navigation follows that link and does not add the text from the sidebar field, so the query never reaches the search page.