### PR TITLE
fix(backend): ews exclude contact items from FindItem results to prevent GetItem crash

### DIFF
--- a/modules/imap/hm-ews.php
+++ b/modules/imap/hm-ews.php
@@ -361,7 +361,10 @@ class Hm_EWS {
         $request = array(
             'Traversal' => 'Shallow',
             'ItemShape' => array(
-                'BaseShape' => 'IdOnly'
+                'BaseShape' => 'IdOnly',
+                'AdditionalProperties' => [
+                    'FieldURI' => ['FieldURI' => 'item:ItemClass'],
+                ],
             ),
             'IndexedPageItemView' => [
                 'MaxEntriesReturned' => $limit,
@@ -536,6 +539,13 @@ class Hm_EWS {
 
         $itemIds = [];
         foreach ($items as $item) {
+            // Skip contacts — they cannot be rendered as mail messages and requesting
+            // their full properties via GetItem crashes the EWS library when a contact
+            // has a single email address (SOAP returns stdClass instead of array).
+            $itemClass = method_exists($item, 'getItemClass') ? (string) $item->getItemClass() : '';
+            if (stripos($itemClass, 'IPM.Contact') === 0 || stripos($itemClass, 'IPM.DistList') === 0) {
+                continue;
+            }
             $itemIds[] = bin2hex($item->getItemId()->getId());
         }
         return [$result->getTotalItemsInView(), $itemIds];


### PR DESCRIPTION
## Problem

Navigating to page 2 (or any page beyond the first) of an EWS inbox
throws a 500 Internal Server Error:

> PHP Fatal error: Uncaught SoapFault: During class fetch: Uncaught
> TypeError: ContactType::setEmailAddresses(): Argument #1 ($value) must
> be of type array|string, stdClass given

### Root cause

`search()` calls `FindItem` with `BaseShape: IdOnly`. At that shape level,
Exchange returns every item in the folder — including contacts — as a bare
ID, and the PHP-EWS library routes them all through `getMessage()`. Those
IDs are then passed to `get_message_list()`, which calls `GetItem` with
`AllProperties`. Exchange responds with the true item type (`ContactType`),
and if that contact has exactly **one** email address, SOAP deserializes
`EmailAddresses.Entry` as a bare `stdClass` instead of an array. The
library's `setEmailAddresses(array|string $value)` rejects it, causing the
fatal error.

The crash only appears on page 2+ because the offending contact item
happened to fall outside the first page's offset range.
