### PR TITLE
fix(module/inline_message): enable inline reading pane in combined, search, tag and feed views

### DIFF
--- a/modules/inline_message/setup.php
+++ b/modules/inline_message/setup.php
@@ -14,6 +14,15 @@ add_handler('message_list', 'get_inline_message_setting', true, 'inline_message'
 add_handler('search', 'get_inline_message_setting', true, 'inline_message', 'load_user_data', 'after');
 add_handler('history', 'get_inline_message_setting', true, 'inline_message', 'load_user_data', 'after');
 add_handler('ajax_imap_folder_display', 'get_inline_message_setting', true, 'inline_message', 'load_user_data', 'after');
+// Aggregated/combined message lists, search and tags render their rows via dedicated AJAX hooks
+// (not the message_list/search page itself), so get_inline_message_setting must be registered for
+// them as well; otherwise the inline_message_setting output var is empty, subject_callback emits a
+// real href instead of href="#"+data-src, and the SPA navigation interceptor hijacks the click to
+// the full message page (the inline pane only opens for a moment).
+add_handler('ajax_imap_message_list', 'get_inline_message_setting', true, 'inline_message', 'load_user_data', 'after');
+add_handler('ajax_imap_search', 'get_inline_message_setting', true, 'inline_message', 'load_user_data', 'after');
+add_handler('ajax_imap_tag_data', 'get_inline_message_setting', true, 'inline_message', 'load_user_data', 'after');
+add_handler('ajax_feed_combined', 'get_inline_message_setting', true, 'inline_message', 'load_user_data', 'after');
 add_output('message_list', 'inline_message_flag', true, 'inline_message', 'header_end', 'before');
 add_output('history', 'inline_message_flag', true, 'inline_message', 'header_end', 'before');
 add_output('search', 'inline_message_flag', true, 'inline_message', 'header_end', 'before');


### PR DESCRIPTION
## Problem
With **Show messages inline** enabled, the inline reading pane works when opening a message from a
**single IMAP folder**, but **not** from the aggregated views (Everything / Unread / Flagged / All
Email / Junk / Snoozed / Sent / Drafts / Trash), **Search**, or **Tags**. There the pane opens for a
moment and then the app navigates to the full message page instead.

## Root cause
A message row's subject link is rendered by `subject_callback()`
(`modules/core/message_list_functions.php`), which only emits the inline-friendly `href="#"` +
`data-src="…"` when the output variable `inline_message_setting` is set:

```php
$inline_active = $output_mod->get('inline_message_setting') && !$output_mod->get('is_mobile');
$link_href     = $inline_active ? '#' : $safe_url;
$data_src_attr = $inline_active ? ' data-src="' . $safe_url . '"' : '';
```

That variable is populated by the `get_inline_message_setting` handler. In
`modules/inline_message/setup.php` it is registered for the `message_list`/`search`/`history` **pages**
and for the `ajax_imap_folder_display` AJAX hook (single folders) — **but not** for the AJAX hooks that
actually render the rows of the aggregated/search/tag/feed views.

Per `modules/core/js_modules/Hm_MessagesStore.js` (`getRequestConfigs`) those rows are loaded via:
- `ajax_imap_message_list` — combined_inbox, unread, flagged, email, junk, snoozed, sent, drafts, trash
- `ajax_imap_search` — search
- `ajax_imap_tag_data` — tags
- `ajax_feed_combined` — feed rows inside combined/search

Because `inline_message_setting` is empty in those AJAX responses, `subject_callback` emits a **real**
`href`. The global SPA navigation interceptor in `modules/core/navigation/navigation.js` then intercepts
any `.cypht-layout a` with `href !== "#"` and navigates to the full page — overriding the inline pane the
`inline_message` JS just opened. The page-level registrations don't help, because the rows are produced
in a separate AJAX request.

## Fix
Register `get_inline_message_setting` for those four AJAX hooks too, exactly like the existing
`ajax_imap_folder_display` registration. `load_user_data` runs first on all of them (via
`setup_base_ajax_page`; feeds also registers it explicitly), so the user's setting is honored; and
`is_mobile` is set by the login handler in the same request, so the mobile guard (`!is_mobile` in
`subject_callback`) keeps full-page behavior on mobile untouched.

## Testing
Manually verified on a 2.x Docker deployment via a bind-mounted patched `setup.php`: with **Show
messages inline** enabled, clicking a subject in **Search** now opens and keeps the inline pane (no
full-page navigation); single-folder behavior is unchanged; mobile/narrow still navigates to the full
page; follow-up actions (mark-as-read, prev/next, delete/move/archive) work. The combined/unread/
flagged/tags/feed views use the same `subject_callback` + AJAX-hook code path.
