### PR TITLE
fix(other): fix cache return default when memcached get is not successful

### DIFF
--- a/lib/cache.php
+++ b/lib/cache.php
@@ -550,12 +550,12 @@ class Hm_Cache {
      */
     protected function memcache_get($key, $default) {
         $res = $this->backend->get($this->key_hash($key), $this->session->enc_key);
-        if (!$res && $this->backend->last_err() == Memcached::RES_NOTFOUND) {
-            $this->log($key, 'miss');
-            return $default;
+        if ($this->backend->last_err() === Memcached::RES_SUCCESS) {
+            $this->log($key, 'hit');
+            return $res;
         }
-        $this->log($key, 'hit');
-        return $res;
+        $this->log($key, 'miss');
+        return $default;
     }
 
     /*

--- a/tests/phpunit/hm_cache.php
+++ b/tests/phpunit/hm_cache.php
@@ -86,6 +86,21 @@ class Hm_Test_Hm_Cache extends TestCase {
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
+    public function test_memcache_get_returns_default_on_connection_failure() {
+        $this->config->set('enable_memcached', true);
+        $this->config->set('memcached_server', 'asdf');
+        $this->config->set('memcached_port', 10);
+        Hm_Mock_Memcached::$result_code = 3;
+        $session = new Hm_Mock_Session();
+        $cache = new Hm_Cache($this->config, $session);
+        $this->assertEquals('memcache', $cache->type);
+        $this->assertEquals(array(), $cache->get('imap_folders_imap_test_', array()));
+        Hm_Mock_Memcached::$result_code = 16;
+    }
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
     public function test_del() {
         $session = new Hm_Mock_Session();
         $cache = new Hm_Cache($this->config, $session);

--- a/tests/phpunit/mocks.php
+++ b/tests/phpunit/mocks.php
@@ -75,6 +75,7 @@ class Hm_Mock_Memcached_No {
 class Hm_Mock_Memcached {
     protected $data = array();
     public static $set_failure = false;
+    public static $result_code = 16;
     const RES_NOTFOUND = 1;
     const OPT_BINARY_PROTOCOL = false;
     function addServer($server, $port) {
@@ -88,9 +89,14 @@ class Hm_Mock_Memcached {
         return true;
     }
     function get($key) {
+        if (self::$result_code === 3) {
+            return false;
+        }
         if (array_key_exists($key, $this->data)) {
+            self::$result_code = 0;
             return $this->data[$key];
         }
+        self::$result_code = 16;
         return false;
     }
     function delete($key) {
@@ -110,7 +116,7 @@ class Hm_Mock_Memcached {
         return true;
     }
     function getResultCode() {
-        return 16;
+        return self::$result_code;
     }
 }
 


### PR DESCRIPTION
## Issue

With default config (`ENABLE_MEMCACHED=true`) and no Memcached server running, Cypht still selects the memcache cache backend. `Hm_Cache::get($key, [])` then returned `false` instead of `[]`, which triggered:
`PHP Fatal error: Uncaught TypeError: array_merge(): Argument #1 must be of type array, false given`.

The old logic only treated `RES_NOTFOUND`.

## Solution

Treat only `RES_SUCCESS` as a cache hit; otherwise log a miss and return the provided default.

These previous pull requests https://github.com/cypht-org/cypht/pull/1978 and https://github.com/cypht-org/cypht/pull/1976 didn't fix the root cause