### PR TITLE
fix(module/carddav_contacts): use carddav config instead of full config dump for carddav_sources

### DIFF
--- a/modules/carddav_contacts/modules.php
+++ b/modules/carddav_contacts/modules.php
@@ -193,7 +193,7 @@ class Hm_Handler_load_carddav_contacts extends Hm_Handler_Module {
             $this->append('contact_sources', 'carddav');
         }
         $this->out('contact_store', $contacts, false);
-        $this->out('carddav_sources', $details);
+        $this->out('carddav_sources', config('carddav'));
     }
 }
 


### PR DESCRIPTION
`load_carddav_contacts` sets `carddav_sources` using `$this->config->dump()`,
which returns all module configuration. `carddav_sources` populates the Account
dropdown in the Add Contact form, so the dropdown showed every internal config
key instead of just the configured CardDAV server names.

Fix replaces `$details` with `config('carddav')` which returns only the CardDAV server list.

### Reproduction
To reproduce: configure a CardDAV server, open Contacts and click "Add Carddav". The Account dropdown will list every internal config key instead of just the configured server name.

### Issues
- None

### Todo
- [X] None