### PR TITLE
fix(module/carddav_contacts): preserve port in url_concat when building CardDAV URLs

### DIFF
--- a/modules/carddav_contacts/hm-carddav.php
+++ b/modules/carddav_contacts/hm-carddav.php
@@ -251,8 +251,12 @@ class Hm_Carddav {
         $parsed = parse_url($this->url);
         $host = $parsed['host'];
         // If parsed URL contains a port, reappend it to host.
-        if (!empty($parsed['port'])) { 
-            $host .= ':' . $parsed['port']; 
+        if (!empty($parsed['port'])) {
+            // Wrap IPv6 addresses in brackets before appending port
+            if (strpos($host, ':') !== false) {
+                $host = '[' . $host . ']';
+            }
+            $host .= ':' . $parsed['port'];
         }
         return sprintf('%s://%s/%s', $parsed['scheme'], $host, preg_replace('#^/#', '', $path));
     }

--- a/modules/carddav_contacts/hm-carddav.php
+++ b/modules/carddav_contacts/hm-carddav.php
@@ -249,7 +249,12 @@ class Hm_Carddav {
 
     private function url_concat($path) {
         $parsed = parse_url($this->url);
-        return sprintf('%s://%s/%s', $parsed['scheme'], $parsed['host'], preg_replace('#^/#', '', $path));
+        $host = $parsed['host'];
+        // If parsed URL contains a port, reappend it to host.
+        if (!empty($parsed['port'])) { 
+            $host .= ':' . $parsed['port']; 
+        }
+        return sprintf('%s://%s/%s', $parsed['scheme'], $host, preg_replace('#^/#', '', $path));
     }
 
     private function auth_headers() {


### PR DESCRIPTION
`url_concat()` uses `parse_url()` to decompose `$this->url`, but only reads
`$parsed['host']` when rebuilding the URL. `parse_url()` separates the port
into its own key, so any server running on a non-standard port has its port
silently dropped. All subsequent CardDAV discovery PROPFIND requests hit port
80 instead of the configured port, causing contacts to fail with no visible error.

Fix appends `$parsed['port']` to the host when present.

### Reproduction
To reproduce: configure a CardDAV server on any non-standard port (e.g. 5232), add it to Cypht, and open Contacts. Discovery silently fails because all PROPFIND requests go to port 80.

### Issues
- None

### Todo
- [X] None
