### PR TITLE
fix(unit): add 240+ tests across sievefilters, lib and core modules to improve coverage

### DIFF
--- a/tests/phpunit/auth.php
+++ b/tests/phpunit/auth.php
@@ -128,6 +128,29 @@ class Hm_Test_Auth extends TestCase {
         $auth = new Hm_Auth_DB($this->config);
         $this->assertEquals(2, $auth->create('unittestuser', 'unittestpass'));
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_auth_dynamic_check_credentials_always_returns_false() {
+        $config = new Hm_Mock_Config();
+        $auth = new Hm_Auth_Dynamic($config);
+        $this->assertFalse($auth->check_credentials('any_user', 'any_pass'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_auth_save_auth_detail_is_callable_with_no_effect() {
+        $config = new Hm_Mock_Config();
+        $auth = new Hm_Auth_Dynamic($config);
+        $session = new Hm_Mock_Session();
+        $this->expectNotToPerformAssertions();
+        $auth->save_auth_detail($session);
+    }
+
     public function tearDown(): void {
         unset($this->config);
     }

--- a/tests/phpunit/config.php
+++ b/tests/phpunit/config.php
@@ -154,4 +154,128 @@ class Hm_Test_User_File_Config extends TestCase {
     public function tearDown(): void {
         unset($this->config);
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_set_tz_falls_back_to_default_setting_timezone() {
+        $this->config->set('default_setting_timezone', 'America/New_York');
+        $this->config->set_tz();
+        $this->assertEquals('America/New_York', date_default_timezone_get());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_shuffle_preserves_all_keys_in_different_order() {
+        $this->config->reload(array('aa' => 1, 'bb' => 2, 'cc' => 3, 'dd' => 4));
+        $before = array_keys($this->config->dump());
+        $this->config->shuffle();
+        $after = array_keys($this->config->dump());
+        $this->assertEqualsCanonicalizing($before, $after);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_reset_factory_retains_only_core_keys() {
+        $this->config->reload(array(
+            'version' => '1.0',
+            'feeds' => array(),
+            'imap_servers' => array(),
+            'smtp_servers' => array(),
+            'extra_key' => 'should_be_gone',
+        ));
+        $this->config->reset_factory();
+        $dump = $this->config->dump();
+        $this->assertArrayHasKey('version', $dump);
+        $this->assertArrayNotHasKey('extra_key', $dump);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_filter_servers_removes_entries_without_server_key() {
+        $this->config->reload(array(
+            'imap_servers' => array(
+                0 => array('server' => 'imap.test.com', 'user' => 'u', 'pass' => 'p', 'auth' => 'plain', 'object' => false),
+                1 => array('user' => 'u2', 'pass' => 'p2'),
+            ),
+            'smtp_servers' => array(),
+        ));
+        $this->config->filter_servers();
+        $dump = $this->config->dump();
+        $this->assertArrayNotHasKey(1, $dump['imap_servers']);
+        $this->assertArrayHasKey(0, $dump['imap_servers']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_filter_servers_preserves_password_for_xoauth2_servers() {
+        $this->config->reload(array(
+            'imap_servers' => array(
+                0 => array('server' => 'imap.test.com', 'user' => 'u', 'pass' => 'token123', 'auth' => 'xoauth2', 'object' => false),
+            ),
+            'smtp_servers' => array(),
+            'no_password_save_setting' => true,
+        ));
+        $this->config->filter_servers();
+        $dump = $this->config->dump();
+        $this->assertEquals('token123', $dump['imap_servers'][0]['pass']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_save_with_crypt_mode_writes_encrypted_data() {
+        $mock_config = new Hm_Mock_Config();
+        $mock_config->set('single_server_mode', true);
+        $config = new Hm_User_Config_File($mock_config);
+        $config->reload(array('secret_key' => 'secret_value'), 'testuser');
+        $config->save('testuser', 'testkey');
+        $path = APP_PATH . 'tests/phpunit/data/testuser.txt';
+        $this->assertTrue(is_readable($path));
+        $raw = file_get_contents($path);
+        $this->assertNotEquals('{"secret_key":"secret_value"}', $raw);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_load_with_crypt_mode_decrypts_data() {
+        $mock_config = new Hm_Mock_Config();
+        $mock_config->set('single_server_mode', true);
+        $config = new Hm_User_Config_File($mock_config);
+        $config->reload(array('crypt_test' => 'crypt_value'), 'testuser');
+        $config->save('testuser', 'testkey');
+        $config2 = new Hm_User_Config_File($mock_config);
+        $config2->load('testuser', 'testkey');
+        $this->assertEquals('crypt_value', $config2->get('crypt_test'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_restore_servers_restores_removed_password() {
+        $this->config->reload(array(
+            'imap_servers' => array(
+                0 => array('server' => 'imap.test.com', 'user' => 'u', 'pass' => 'secret', 'auth' => 'plain', 'object' => false),
+            ),
+            'smtp_servers' => array(),
+            'no_password_save_setting' => true,
+        ));
+        $removed = $this->config->filter_servers();
+        $this->config->restore_servers($removed);
+        $dump = $this->config->dump();
+        $this->assertEquals('secret', $dump['imap_servers'][0]['pass']);
+    }
 }

--- a/tests/phpunit/environment.php
+++ b/tests/phpunit/environment.php
@@ -41,4 +41,111 @@ class Hm_Test_Environment extends TestCase {
         $expected = array_merge($_ENV, $_SERVER);
         $this->assertEquals($expected, $env_vars);
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_env_function_returns_value_from_environment() {
+        putenv('CYPHT_TEST_VAR=hello_world');
+        $this->assertEquals('hello_world', env('CYPHT_TEST_VAR'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_env_function_returns_default_when_variable_not_set() {
+        $this->assertEquals('my_default', env('CYPHT_UNDEFINED_XYZ_12345', 'my_default'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_env_function_returns_null_default_when_not_set() {
+        $this->assertNull(env('CYPHT_UNDEFINED_XYZ_99999'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_config_array_converts_true_string_to_boolean() {
+        $tmp = tempnam(sys_get_temp_dir(), 'cypht_test_') . '.php';
+        file_put_contents($tmp, "<?php return array('key1' => 'true', 'key2' => 'false', 'key3' => 'value');");
+        $result = process_config_array($tmp);
+        unlink($tmp);
+        $this->assertTrue($result['key1']);
+        $this->assertFalse($result['key2']);
+        $this->assertEquals('value', $result['key3']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_config_array_returns_empty_array_for_non_array_return() {
+        $tmp = tempnam(sys_get_temp_dir(), 'cypht_test_') . '.php';
+        file_put_contents($tmp, "<?php return 'not_an_array';");
+        $result = process_config_array($tmp);
+        unlink($tmp);
+        $this->assertEquals(array(), $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_config_array_preserves_nested_arrays() {
+        $tmp = tempnam(sys_get_temp_dir(), 'cypht_test_') . '.php';
+        file_put_contents($tmp, "<?php return array('nested' => array('a' => 1, 'b' => 2));");
+        $result = process_config_array($tmp);
+        unlink($tmp);
+        $this->assertEquals(array('a' => 1, 'b' => 2), $result['nested']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_merge_config_files_merges_all_php_files_in_directory() {
+        $dir = sys_get_temp_dir() . '/cypht_test_' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/a.php', "<?php return array('key_a' => 'value_a');");
+        file_put_contents($dir . '/b.php', "<?php return array('key_b' => 'true');");
+        $result = merge_config_files($dir);
+        array_map('unlink', glob($dir . '/*.php'));
+        rmdir($dir);
+        $this->assertEquals('value_a', $result['key_a']);
+        $this->assertTrue($result['key_b']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_define_default_constants_defines_all_expected_constants() {
+        $mock_config = new Hm_Mock_Config();
+        $environment = Hm_Environment::getInstance();
+        $environment->define_default_constants($mock_config);
+        $this->assertTrue(defined('DEFAULT_SEARCH_SINCE'));
+        $this->assertTrue(defined('DEFAULT_UNREAD_PER_SOURCE'));
+        $this->assertTrue(defined('DEFAULT_LIST_STYLE'));
+        $this->assertTrue(defined('DEFAULT_ENABLE_SIEVE_FILTER'));
+        $this->assertTrue(defined('DEFAULT_THEME'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_define_default_constants_sets_numeric_defaults() {
+        $mock_config = new Hm_Mock_Config();
+        $environment = Hm_Environment::getInstance();
+        $environment->define_default_constants($mock_config);
+        $this->assertIsInt(DEFAULT_UNREAD_PER_SOURCE);
+        $this->assertIsInt(DEFAULT_FLAGGED_PER_SOURCE);
+        $this->assertIsInt(DEFAULT_IMAP_PER_PAGE);
+    }
 }

--- a/tests/phpunit/hm_cache.php
+++ b/tests/phpunit/hm_cache.php
@@ -131,4 +131,52 @@ class Hm_Test_Hm_Cache extends TestCase {
         $cache->del('foo');
         $this->assertFalse($cache->get('foo', false));
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_noop_cache_reconnect_returns_true() {
+        $noop = new Hm_Noop_Cache();
+        $this->assertTrue($noop->reconnect());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_noop_cache_set_returns_false() {
+        $noop = new Hm_Noop_Cache();
+        $this->assertFalse($noop->set('key', 'val', 600, ''));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_cache_reconnect_delegates_to_backend() {
+        $session = new Hm_Mock_Session();
+        $cache = new Hm_Cache($this->config, $session);
+        $this->assertTrue($cache->reconnect());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_cache_get_returns_default_for_noop_backend() {
+        $session = new Hm_Mock_Session();
+        $cache = new Hm_Cache($this->config, $session);
+        $this->assertEquals('my_default', $cache->get('nonexistent_key', 'my_default'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_cache_del_on_noop_backend_returns_true() {
+        $session = new Hm_Mock_Session();
+        $cache = new Hm_Cache($this->config, $session);
+        $this->assertTrue($cache->del('any_key'));
+    }
 }

--- a/tests/phpunit/lib/logging.php
+++ b/tests/phpunit/lib/logging.php
@@ -1,0 +1,146 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class Hm_Test_Logging extends TestCase {
+
+    public function setUp(): void {
+        require_once APP_PATH.'lib/logging.php';
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_instance_returns_singleton() {
+        $instance1 = Hm_Logger::getInstance();
+        $instance2 = Hm_Logger::getInstance();
+        $this->assertSame($instance1, $instance2);
+        $this->assertInstanceOf('Hm_Logger', $instance1);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_logger_returns_monolog_logger() {
+        $logger = Hm_Logger::getLogger();
+        $this->assertInstanceOf(\Monolog\Logger::class, $logger);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_error_static_method_does_not_throw() {
+        $this->expectNotToPerformAssertions();
+        Hm_Logger::error('Test error message', array('key' => 'value'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_warning_static_method_does_not_throw() {
+        $this->expectNotToPerformAssertions();
+        Hm_Logger::warning('Test warning');
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_info_static_method_does_not_throw() {
+        $this->expectNotToPerformAssertions();
+        Hm_Logger::info('Test info');
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_debug_static_method_does_not_throw() {
+        $this->expectNotToPerformAssertions();
+        Hm_Logger::debug('Test debug');
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_log_adds_type_to_context_when_missing() {
+        $test_handler = new \Monolog\Handler\TestHandler(\Monolog\Level::Debug);
+        Hm_Logger::getLogger()->pushHandler($test_handler);
+        Hm_Logger::getInstance()->log('Test message', 'warning', array());
+        $records = $test_handler->getRecords();
+        $this->assertNotEmpty($records);
+        $this->assertEquals('warning', $records[0]['context']['type']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_log_preserves_existing_type_in_context() {
+        $test_handler = new \Monolog\Handler\TestHandler(\Monolog\Level::Debug);
+        Hm_Logger::getLogger()->pushHandler($test_handler);
+        Hm_Logger::getInstance()->log('Msg', 'danger', array('type' => 'custom_type'));
+        $records = $test_handler->getRecords();
+        $this->assertEquals('custom_type', $records[0]['context']['type']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_error_logs_at_error_level() {
+        $test_handler = new \Monolog\Handler\TestHandler(\Monolog\Level::Debug);
+        Hm_Logger::getLogger()->pushHandler($test_handler);
+        Hm_Logger::error('An error');
+        $this->assertTrue($test_handler->hasErrorRecords());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_warning_logs_at_warning_level() {
+        $test_handler = new \Monolog\Handler\TestHandler(\Monolog\Level::Debug);
+        Hm_Logger::getLogger()->pushHandler($test_handler);
+        Hm_Logger::warning('A warning');
+        $this->assertTrue($test_handler->hasWarningRecords());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_info_logs_at_info_level() {
+        $test_handler = new \Monolog\Handler\TestHandler(\Monolog\Level::Debug);
+        Hm_Logger::getLogger()->pushHandler($test_handler);
+        Hm_Logger::info('An info');
+        $this->assertTrue($test_handler->hasInfoRecords());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_debug_logs_at_debug_level() {
+        $test_handler = new \Monolog\Handler\TestHandler(\Monolog\Level::Debug);
+        Hm_Logger::getLogger()->pushHandler($test_handler);
+        Hm_Logger::debug('A debug');
+        $this->assertTrue($test_handler->hasDebugRecords());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_log_with_unknown_type_maps_to_error_level() {
+        $test_handler = new \Monolog\Handler\TestHandler(\Monolog\Level::Debug);
+        Hm_Logger::getLogger()->pushHandler($test_handler);
+        Hm_Logger::getInstance()->log('Test unknown type', 'unknown_type', array());
+        $this->assertTrue($test_handler->hasErrorRecords());
+    }
+}

--- a/tests/phpunit/lib/output_debug.php
+++ b/tests/phpunit/lib/output_debug.php
@@ -1,0 +1,83 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class Hm_Test_Output_Debug extends TestCase {
+
+    public static function setUpBeforeClass(): void {
+        putenv('CYPHT_TEST_DEBUG_MODE=true');
+        $_ENV['CYPHT_TEST_DEBUG_MODE'] = 'true';
+    }
+
+    public static function tearDownAfterClass(): void {
+        putenv('CYPHT_TEST_DEBUG_MODE');
+        unset($_ENV['CYPHT_TEST_DEBUG_MODE']);
+    }
+
+    public function setUp(): void {
+        Hm_Debug::flush();
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_send_response_injects_debug_panel_when_body_tag_present_and_debug_messages_exist() {
+        Hm_Debug::add('Debug entry for panel', 'info');
+        $http = new Hm_Output_HTTP();
+        ob_start();
+        ob_start();
+        $http->send_response('<html><body>Page Content</body></html>');
+        $output = ob_get_clean();
+        $this->assertStringContainsString('cypht-debug-panel', $output);
+        $this->assertStringContainsString('Debug Panel', $output);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_send_response_skips_panel_when_no_debug_messages() {
+        $http = new Hm_Output_HTTP();
+        ob_start();
+        ob_start();
+        $http->send_response('<html><body>Page Content</body></html>');
+        $output = ob_get_clean();
+        $this->assertStringNotContainsString('cypht-debug-panel', $output);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_elog_logs_message_when_debug_mode_enabled() {
+        $result = elog('test log value');
+        $debug_msgs = Hm_Debug::get();
+        $found = false;
+        foreach ($debug_msgs as $msg) {
+            if (strpos($msg, 'ELOG called in') !== false) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_debug_panel_filters_messages_by_log_level() {
+        Hm_Debug::add('Low priority debug', 'debug');
+        Hm_Debug::add('High priority error', 'danger');
+        putenv('LOG_LEVEL=ERROR');
+        $http = new Hm_Output_HTTP();
+        ob_start();
+        ob_start();
+        $http->send_response('<html><body>Content</body></html>');
+        $output = ob_get_clean();
+        putenv('LOG_LEVEL=WARNING');
+        $this->assertStringContainsString('cypht-debug-panel', $output);
+        $this->assertStringContainsString('High priority error', $output);
+    }
+}

--- a/tests/phpunit/lib/repository.php
+++ b/tests/phpunit/lib/repository.php
@@ -255,4 +255,74 @@ class Hm_Test_Repository extends TestCase {
         $servers = $this->user_config->get('imap_servers', []);
         $this->assertArrayHasKey($existingId, $servers);
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_migrate_replaces_integer_feed_ids(): void {
+        $this->user_config->set('feeds', [
+            0 => ['url' => 'https://example.com/feed.rss'],
+            1 => ['url' => 'https://other.com/feed.rss'],
+        ]);
+
+        Hm_Repository_Wrapper::init($this->user_config, $this->session);
+
+        $feeds = $this->user_config->get('feeds', []);
+        foreach (array_keys($feeds) as $key) {
+            $this->assertFalse(is_numeric($key), "Feed key '$key' should not be numeric after migration");
+        }
+        $this->assertCount(2, $feeds);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_migrate_replaces_integer_special_imap_folder_ids(): void {
+        $this->user_config->set('imap_servers', [
+            0 => ['server' => 'imap.example.com', 'port' => 993],
+        ]);
+        $this->user_config->set('special_imap_folders', [
+            0 => ['trash' => 'Trash', 'sent' => 'Sent'],
+        ]);
+
+        Hm_Repository_Wrapper::init($this->user_config, $this->session);
+
+        $specials = $this->user_config->get('special_imap_folders', []);
+        foreach (array_keys($specials) as $key) {
+            $this->assertFalse(is_numeric($key), "Special folder key '$key' should not be numeric");
+        }
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_migrate_updates_custom_imap_source_pattern_keys(): void {
+        $this->user_config->set('imap_servers', [
+            0 => ['server' => 'imap.example.com', 'port' => 993],
+        ]);
+        $this->user_config->set('custom_imap_sources', [
+            'imap_0_inbox' => ['folder' => 'INBOX'],
+        ]);
+
+        Hm_Repository_Wrapper::init($this->user_config, $this->session);
+
+        $sources = $this->user_config->get('custom_imap_sources', []);
+        $this->assertArrayNotHasKey('imap_0_inbox', $sources);
+        $this->assertCount(1, $sources);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_save_persists_entities_to_user_config_and_session(): void {
+        $id = Hm_Repository_Wrapper::add(['name' => 'Persist Me'], false);
+        Hm_Repository_Wrapper::save();
+
+        $user_data = $this->session->get('user_data');
+        $this->assertIsArray($user_data);
+    }
 }

--- a/tests/phpunit/lib/version.php
+++ b/tests/phpunit/lib/version.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class Hm_Test_Version extends TestCase {
+
+    public function setUp(): void {
+        require_once APP_PATH.'lib/version.php';
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_cypht_version_constant_is_defined() {
+        $this->assertTrue(defined('CYPHT_VERSION'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_cypht_version_is_a_non_empty_string() {
+        $this->assertIsString(CYPHT_VERSION);
+        $this->assertNotEmpty(CYPHT_VERSION);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_cypht_version_matches_semver_format() {
+        $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+/', CYPHT_VERSION);
+    }
+}

--- a/tests/phpunit/mocks.php
+++ b/tests/phpunit/mocks.php
@@ -179,6 +179,18 @@ class Hm_Mock_Config {
             $this->data = $data;
         }
     }
+    public function reset_factory() {
+        $this->data = array(
+            'version' => $this->data['version'] ?? '',
+            'feeds' => $this->data['feeds'] ?? array(),
+            'imap_servers' => $this->data['imap_servers'] ?? array(),
+            'smtp_servers' => $this->data['smtp_servers'] ?? array(),
+        );
+    }
+    public function del($name) {
+        unset($this->data[$name]);
+        return true;
+    }
 }
 class Hm_Mock_Request {
     public $invalid_input_detected;

--- a/tests/phpunit/modules/core/functions.php
+++ b/tests/phpunit/modules/core/functions.php
@@ -209,4 +209,157 @@ class Hm_Test_Core_Functions extends TestCase {
     public function test_profiles_by_server_id() {
         $this->assertEquals(array(), profiles_by_smtp_id(array('smtp_id' => 0), 0));
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_validate_domain_full_accepts_valid_domains() {
+        $this->assertTrue(validate_domain_full('example.com'));
+        $this->assertTrue(validate_domain_full('sub.example.co.uk'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_validate_domain_full_accepts_ipv4_literal() {
+        $this->assertTrue(validate_domain_full('[192.168.1.1]'));
+        $this->assertFalse(validate_domain_full('[256.0.0.1]'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_validate_domain_full_accepts_ipv6_literal() {
+        $this->assertTrue(validate_domain_full('[IPv6:2001:db8::1]'));
+        $this->assertFalse(validate_domain_full('[IPv6:invalid::addr::]'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_validate_domain_full_rejects_hyphen_at_start_or_end_of_label() {
+        $this->assertFalse(validate_domain_full('-bad.example.com'));
+        $this->assertFalse(validate_domain_full('bad-.example.com'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_validate_domain_full_rejects_empty_and_too_long() {
+        $this->assertFalse(validate_domain_full(''));
+        $this->assertFalse(validate_domain_full(str_repeat('a', 256)));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_validate_local_full_accepts_valid_local_parts() {
+        $this->assertTrue(validate_local_full('user.name+tag'));
+        $this->assertTrue(validate_local_full('user123'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_validate_local_full_accepts_quoted_strings() {
+        $this->assertTrue(validate_local_full('"quoted string"'));
+        $this->assertFalse(validate_local_full('"bad"quote"'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_validate_local_full_rejects_dots_at_start_end_and_consecutive() {
+        $this->assertFalse(validate_local_full('.starts.with.dot'));
+        $this->assertFalse(validate_local_full('ends.with.dot.'));
+        $this->assertFalse(validate_local_full('double..dot'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_validate_local_full_rejects_empty_and_too_long() {
+        $this->assertFalse(validate_local_full(''));
+        $this->assertFalse(validate_local_full(str_repeat('a', 65)));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_check_file_upload_returns_false_when_key_missing() {
+        $request = new stdClass();
+        $request->files = array();
+        $this->assertFalse(check_file_upload($request, 'myfile'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_check_file_upload_returns_false_for_non_array_files() {
+        $request = new stdClass();
+        $request->files = 'not_an_array';
+        $this->assertFalse(check_file_upload($request, 'myfile'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_check_file_upload_returns_true_when_valid() {
+        $request = new stdClass();
+        $request->files = array('myfile' => array('tmp_name' => '/tmp/upload'));
+        $this->assertTrue(check_file_upload($request, 'myfile'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_default_sort_order_opts_returns_expected_keys() {
+        $opts = default_sort_order_opts();
+        $this->assertArrayHasKey('arrival', $opts);
+        $this->assertArrayHasKey('date', $opts);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_can_save_last_added_server_returns_true_when_no_duplicate() {
+        Hm_Server_Wrapper::add(array('user' => 'u1', 'pass' => 'p1', 'name' => 'srv1', 'server' => 'host1', 'port' => 993, 'tls' => 1, 'id' => 'x1'));
+        $this->assertTrue(can_save_last_added_server('Hm_Server_Wrapper', 'u1'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_can_save_last_added_server_returns_false_and_deletes_on_duplicate() {
+        Hm_Server_Wrapper::add(array('user' => 'dup', 'pass' => 'p', 'name' => 'same', 'server' => 'host.example.com', 'port' => 993, 'tls' => 1, 'id' => 's1'));
+        Hm_Server_Wrapper::add(array('user' => 'dup', 'pass' => 'p', 'name' => 'same', 'server' => 'host.example.com', 'port' => 993, 'tls' => 1, 'id' => 's2'));
+        $result = can_save_last_added_server('Hm_Server_Wrapper', 'dup');
+        $this->assertFalse($result);
+        $this->assertFalse(Hm_Server_Wrapper::dump('s2'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_nexter_formats_returns_array_of_format_options() {
+        $formats = nexter_formats();
+        $this->assertIsArray($formats);
+        $this->assertNotEmpty($formats);
+    }
 }

--- a/tests/phpunit/modules/core/handler_modules.php
+++ b/tests/phpunit/modules/core/handler_modules.php
@@ -548,4 +548,311 @@ class Hm_Test_Core_Handler_Modules extends TestCase {
 		$this->assertEquals('-1 week', $res->handler_response['search_since']);
 		$this->assertEquals('BODY', $res->handler_response['search_fld']);
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_default_sort_order_setting_outputs_arrival_by_default() {
+        $test = new Handler_Test('default_sort_order_setting', 'core');
+        $res = $test->run();
+        $this->assertEquals('arrival', $res->handler_response['default_sort_order']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_default_sort_order_setting_saves_valid_value() {
+        $test = new Handler_Test('process_default_sort_order_setting', 'core');
+        $test->post = array('save_settings' => 1, 'default_sort_order' => 'date');
+        $res = $test->run();
+        $this->assertEquals('date', $res->handler_response['new_user_settings']['default_sort_order_setting']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_ajax_save_search_all_folders_saves_valid_value() {
+        $test = new Handler_Test('ajax_save_search_all_folders', 'core');
+        $test->post = array('search_all_folders' => '1');
+        $res = $test->run();
+        $this->assertTrue($res->handler_response['search_all_folders_saved']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_ajax_save_search_all_folders_ignores_invalid_value() {
+        $test = new Handler_Test('ajax_save_search_all_folders', 'core');
+        $test->post = array('search_all_folders' => '5');
+        $res = $test->run();
+        $this->assertArrayNotHasKey('search_all_folders_saved', $res->handler_response);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_load_search_all_folders_setting_outputs_enabled_flag() {
+        $test = new Handler_Test('load_search_all_folders_setting', 'core');
+        $test->user_config = array('search_all_folders_setting' => 1);
+        $res = $test->run();
+        $this->assertTrue($res->handler_response['search_all_folders_enabled']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_snoozed_source_max_setting_saves_value() {
+        $test = new Handler_Test('process_snoozed_source_max_setting', 'core');
+        $test->post = array('save_settings' => 1, 'snoozed_per_source' => 15);
+        $res = $test->run();
+        $this->assertEquals(15, $res->handler_response['new_user_settings']['snoozed_per_source_setting']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_snoozed_since_setting_saves_value() {
+        $test = new Handler_Test('process_snoozed_since_setting', 'core');
+        $test->post = array('save_settings' => 1, 'snoozed_since' => '-1 week');
+        $res = $test->run();
+        $this->assertEquals('-1 week', $res->handler_response['new_user_settings']['snoozed_since_setting']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_enable_snooze_setting_saves_bool_value() {
+        $test = new Handler_Test('process_enable_snooze_setting', 'core');
+        $test->post = array('save_settings' => 1, 'enable_snooze' => 1);
+        $res = $test->run();
+        $this->assertArrayHasKey('enable_snooze_setting', $res->handler_response['new_user_settings']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_junk_source_max_setting_saves_value() {
+        $test = new Handler_Test('process_junk_source_max_setting', 'core');
+        $test->post = array('save_settings' => 1, 'junk_per_source' => 10);
+        $res = $test->run();
+        $this->assertEquals(10, $res->handler_response['new_user_settings']['junk_per_source_setting']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_junk_since_setting_saves_value() {
+        $test = new Handler_Test('process_junk_since_setting', 'core');
+        $test->post = array('save_settings' => 1, 'junk_since' => '-1 week');
+        $res = $test->run();
+        $this->assertEquals('-1 week', $res->handler_response['new_user_settings']['junk_since_setting']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_trash_source_max_setting_saves_value() {
+        $test = new Handler_Test('process_trash_source_max_setting', 'core');
+        $test->post = array('save_settings' => 1, 'trash_per_source' => 12);
+        $res = $test->run();
+        $this->assertEquals(12, $res->handler_response['new_user_settings']['trash_per_source_setting']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_trash_since_setting_saves_value() {
+        $test = new Handler_Test('process_trash_since_setting', 'core');
+        $test->post = array('save_settings' => 1, 'trash_since' => '-1 week');
+        $res = $test->run();
+        $this->assertEquals('-1 week', $res->handler_response['new_user_settings']['trash_since_setting']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_warn_for_unsaved_changes_saves_value() {
+        $test = new Handler_Test('process_warn_for_unsaved_changes_setting', 'core');
+        $test->post = array('save_settings' => 1, 'warn_for_unsaved_changes' => 1);
+        $res = $test->run();
+        $this->assertArrayHasKey('warn_for_unsaved_changes_setting', $res->handler_response['new_user_settings']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_delete_attachment_setting_saves_value() {
+        $test = new Handler_Test('process_delete_attachment_setting', 'core');
+        $test->post = array('save_settings' => 1, 'allow_delete_attachment' => 1);
+        $res = $test->run();
+        $this->assertArrayHasKey('allow_delete_attachment_setting', $res->handler_response['new_user_settings']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_save_hm_msgs_stores_messages_as_session_cookie() {
+        $parent = build_parent_mock();
+        $handler_mod = new Hm_Handler_Test($parent, 'home');
+        Hm_Msgs::flush();
+        Hm_Msgs::add('Test message for cookie', 'warning');
+        $handler_mod->save_hm_msgs();
+        $this->assertTrue($handler_mod->session->cookie_set);
+        $this->assertEmpty(Hm_Msgs::get());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_save_hm_msgs_does_nothing_when_no_messages() {
+        $parent = build_parent_mock();
+        $handler_mod = new Hm_Handler_Test($parent, 'home');
+        Hm_Msgs::flush();
+        $handler_mod->save_hm_msgs();
+        $this->assertFalse($handler_mod->session->cookie_set);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_login_outputs_redirect_url_when_configured() {
+        $test = new Handler_Test('login', 'core');
+        $test->config = array('redirect_after_login' => '?page=home');
+        $test->post = array('username' => 'testuser', 'password' => 'testpass');
+        $res = $test->run();
+        $this->assertEquals('?page=home', $res->handler_response['redirect_url']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_logout_handler_outputs_cancel_url_when_prompt_is_set() {
+        $test = new Handler_Test('logout', 'core');
+        $back_query = base64_encode(serialize(array('page' => 'home')));
+        $test->get = array('prompt' => '1', 'back_query' => $back_query);
+        $res = $test->run();
+        $this->assertNotEmpty($res->handler_response['cancel_logout_url']);
+        $this->assertStringContainsString('page=home', $res->handler_response['cancel_logout_url']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_logout_handler_outputs_cancel_url_without_back_query() {
+        $test = new Handler_Test('logout', 'core');
+        $test->get = array('prompt' => '1');
+        $res = $test->run();
+        $this->assertArrayHasKey('cancel_logout_url', $res->handler_response);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_message_list_type_clamps_negative_list_page_to_one() {
+        $test = new Handler_Test('message_list_type', 'core');
+        $test->get = array('list_path' => 'unread', 'list_page' => -5);
+        $res = $test->run();
+        $this->assertEquals(1, $res->handler_response['list_page']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_message_list_type_uses_news_style_from_user_config() {
+        $test = new Handler_Test('message_list_type', 'core');
+        $test->get = array('list_path' => 'unread');
+        $test->user_config = array('list_style_setting' => 'news_style');
+        $res = $test->run();
+        $this->assertEquals(1, $res->handler_response['news_list_style']);
+        $this->assertTrue($res->handler_response['no_message_list_headers']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_drafts_source_max_setting_saves_value() {
+        $test = new Handler_Test('process_drafts_source_max_setting', 'core');
+        $test->post = array('save_settings' => 1, 'drafts_per_source' => 10);
+        $res = $test->run();
+        $this->assertEquals(10, $res->handler_response['new_user_settings']['drafts_per_source_setting']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_process_drafts_since_setting_saves_value() {
+        $test = new Handler_Test('process_drafts_since_setting', 'core');
+        $test->post = array('save_settings' => 1, 'drafts_since' => '-1 week');
+        $res = $test->run();
+        $this->assertEquals('-1 week', $res->handler_response['new_user_settings']['drafts_since_setting']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_privacy_settings_processes_all_privacy_settings() {
+        $test = new Handler_Test('privacy_settings', 'core');
+        $test->post = array('save_settings' => 1, 'images_whitelist' => 'sender@example.com');
+        $res = $test->run();
+        $this->assertArrayHasKey('new_user_settings', $res->handler_response);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_version_upgrade_checker_uses_cached_version_from_session_without_http() {
+        $test = new Handler_Test('version_upgrade_checker', 'core');
+        $test->session = array('latest_version' => '99.0.0');
+        $res = $test->run();
+        $this->assertEquals('99.0.0', $res->handler_response['latest_version']);
+        $this->assertTrue($res->handler_response['need_upgrade']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_quick_servers_setup_returns_early_when_required_form_fields_missing() {
+        $test = new Handler_Test('quick_servers_setup', 'core');
+        $test->post = array();
+        $test->run();
+        $this->assertEquals(array(), Hm_Msgs::get());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_reset_factory_restores_defaults_and_adds_message() {
+        $test = new Handler_Test('reset_factory', 'core');
+        $test->post = array('reset_factory' => 1);
+        $test->run();
+        $this->assertEquals(array('Settings restored to default'), Hm_Msgs::get());
+        Hm_Msgs::flush();
+    }
 }

--- a/tests/phpunit/modules/core/mailbox.php
+++ b/tests/phpunit/modules/core/mailbox.php
@@ -29,6 +29,7 @@ class Hm_Test_Mailbox extends TestCase {
         require_once APP_PATH.'modules/imap/hm-ews.php';
         require_once APP_PATH.'modules/smtp/hm-smtp.php';
         require_once APP_PATH.'modules/core/hm-mailbox.php';
+        require_once APP_PATH.'modules/imap/functions.php';
         
         $this->mock_user_config = new Hm_Mock_Config();
         $this->mock_user_config->set('unsubscribed_folders', ['test_server_1' => ['Junk', 'Spam']]);
@@ -889,15 +890,421 @@ class Hm_Test_Mailbox extends TestCase {
     public function test_unsupported_send_message() {
         $mock_imap = $this->createMock(Hm_IMAP::class);
         $mock_imap->method('get_state')->willReturn('authenticated');
-        
+
         $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
-        
+
         $this->expectException(Error::class);
-        
+
         $mailbox->send_message(
             'test@example.com',
             ['recipient@example.com'],
             'Test message'
         );
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_state_returns_connection_state_for_imap() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->method('get_state')->willReturn('authenticated');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertEquals('authenticated', $mailbox->state());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_state_returns_null_for_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertNull($mailbox->state());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_folder_name_returns_folder_directly_for_imap() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->method('get_state')->willReturn('authenticated');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertEquals('INBOX', $mailbox->get_folder_name('INBOX'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_folder_name_uses_quick_lookup_for_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('get_folder_name_quick')->with('AQMs...')->willReturn('INBOX');
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertEquals('INBOX', $mailbox->get_folder_name('AQMs...'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_create_folder_returns_null_when_not_authed() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->method('get_state')->willReturn('disconnected');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertNull($mailbox->create_folder('NewFolder'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_create_folder_delegates_to_connection_for_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('authed')->willReturn(true);
+        $mock_ews->method('create_folder')->with('NewFolder', null)->willReturn('folder-id-123');
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertEquals('folder-id-123', $mailbox->create_folder('NewFolder'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_delete_folder_returns_null_when_not_authed() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->method('get_state')->willReturn('disconnected');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertNull($mailbox->delete_folder('OldFolder'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_delete_folder_delegates_to_connection_for_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('authed')->willReturn(true);
+        $mock_ews->method('delete_folder')->willReturn(true);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertTrue($mailbox->delete_folder('OldFolder'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_rename_folder_returns_null_when_not_authed() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->method('get_state')->willReturn('disconnected');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertNull($mailbox->rename_folder('OldFolder', 'NewName'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_rename_folder_delegates_to_ews_connection() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('authed')->willReturn(true);
+        $mock_ews->method('rename_folder')->willReturn(true);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertTrue($mailbox->rename_folder('AQMs...encoded', 'NewName'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_folders_returns_null_when_not_authed() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->method('get_state')->willReturn('disconnected');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertNull($mailbox->get_folders());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_folders_delegates_to_ews_connection() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('authed')->willReturn(true);
+        $mock_ews->method('get_folders')->willReturn(array('INBOX' => [], 'Sent' => []));
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $result = $mailbox->get_folders();
+        $this->assertArrayHasKey('INBOX', $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_subfolders_returns_null_when_not_authed() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->method('get_state')->willReturn('disconnected');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertNull($mailbox->get_subfolders('INBOX'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_subfolders_delegates_to_ews_connection() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('authed')->willReturn(true);
+        $mock_ews->method('get_folders')->willReturn(array('INBOX.Sub' => []));
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $result = $mailbox->get_subfolders('INBOX');
+        $this->assertArrayHasKey('INBOX.Sub', $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_folder_state_returns_imap_connection_property() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->folder_state = 'selected';
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertEquals('selected', $mailbox->get_folder_state());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_selected_folder_returns_imap_connection_property() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->selected_mailbox = array('name' => 'INBOX');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertEquals(array('name' => 'INBOX'), $mailbox->get_selected_folder());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_special_use_mailboxes_returns_null_when_not_authed() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->method('get_state')->willReturn('disconnected');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertNull($mailbox->get_special_use_mailboxes());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_special_use_mailboxes_delegates_to_ews_connection() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('authed')->willReturn(true);
+        $mock_ews->method('get_special_use_folders')->willReturn(array('Trash' => 'Trash', 'Sent' => 'Sent'));
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertArrayHasKey('Trash', $mailbox->get_special_use_mailboxes());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_quota_root_delegates_to_imap_connection() {
+        $mock_imap = $this->getMockBuilder(Hm_IMAP::class)
+            ->addMethods(['get_quota_root', 'get_quota'])
+            ->getMock();
+        $mock_imap->method('get_quota_root')->with('INBOX')->willReturn(array('usage' => 100, 'limit' => 1000));
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $result = $mailbox->get_quota('INBOX', true);
+        $this->assertEquals(100, $result['usage']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_quota_returns_empty_for_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertEquals(array(), $mailbox->get_quota('INBOX'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_debug_delegates_to_imap_connection() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->method('show_debug')->with(true, true, true)->willReturn(array('log entry'));
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertEquals(array('log entry'), $mailbox->get_debug());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_debug_returns_empty_for_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertEquals(array(), $mailbox->get_debug());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_use_cache_returns_connection_property_for_imap() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->use_cache = true;
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertTrue($mailbox->use_cache());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_use_cache_returns_false_for_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertFalse($mailbox->use_cache());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_dump_cache_delegates_to_imap_connection() {
+        $mock_imap = $this->getMockBuilder(Hm_IMAP::class)
+            ->addMethods(['dump_cache'])
+            ->getMock();
+        $mock_imap->method('dump_cache')->with('string')->willReturn('cache data');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertEquals('cache data', $mailbox->dump_cache());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_dump_cache_returns_null_for_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertNull($mailbox->dump_cache());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_state_delegates_to_imap_connection() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->method('get_state')->willReturn('selected');
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertEquals('selected', $mailbox->get_state());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_state_returns_authenticated_for_authed_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('authed')->willReturn(true);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertEquals('authenticated', $mailbox->get_state());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_capability_delegates_to_ews_connection() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('get_capability')->willReturn(array('EWS', 'IDLE'));
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertContains('IDLE', $mailbox->get_capability());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_set_read_only_sets_property_on_imap_connection() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->read_only = false;
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $mailbox->set_read_only(true);
+        $this->assertTrue($mock_imap->read_only);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_set_search_charset_sets_property_on_imap_connection() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mock_imap->search_charset = '';
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $mailbox->set_search_charset('UTF-8');
+        $this->assertEquals('UTF-8', $mock_imap->search_charset);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_message_list_delegates_to_ews_connection() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('authed')->willReturn(true);
+        $mock_ews->method('get_folder_status')->willReturn(array('id' => 'inbox-id', 'name' => 'INBOX', 'messages' => 10));
+        $mock_ews->method('get_message_list')->willReturn(array(1 => array('subject' => 'Test')));
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $result = $mailbox->get_message_list('INBOX', array(1));
+        $this->assertArrayHasKey(1, $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_is_archive_folder_returns_false_for_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertFalse($mailbox->is_archive_folder('archive', new Hm_Mock_Config(), 'INBOX'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_is_inplace_archive_enabled_delegates_to_ews_connection() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mock_ews->method('is_inplace_archive_enabled')->willReturn(true);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertTrue($mailbox->is_inplace_archive_enabled());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_is_inplace_archive_enabled_returns_null_for_imap() {
+        $mock_imap = $this->createMock(Hm_IMAP::class);
+        $mailbox = $this->createMailboxWithMockConnection('imap', $mock_imap);
+        $this->assertNull($mailbox->is_inplace_archive_enabled());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_prep_folder_name_returns_folder_decoded_for_ews() {
+        $mock_ews = $this->createMock(Hm_EWS::class);
+        $mailbox = $this->createMailboxWithMockConnection('ews', $mock_ews);
+        $this->assertEquals('simpletestfolder', $mailbox->prep_folder_name('simpletestfolder'));
     }
 }

--- a/tests/phpunit/modules/core/modules.php
+++ b/tests/phpunit/modules/core/modules.php
@@ -1,0 +1,55 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class Hm_Test_Core_Modules extends TestCase {
+
+    public function setUp(): void {
+        require_once APP_PATH.'modules/core/modules.php';
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_max_per_source_constant_is_defined_with_expected_value() {
+        $this->assertTrue(defined('MAX_PER_SOURCE'));
+        $this->assertEquals(1000, MAX_PER_SOURCE);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_default_per_source_constant_is_defined_with_expected_value() {
+        $this->assertTrue(defined('DEFAULT_PER_SOURCE'));
+        $this->assertEquals(20, DEFAULT_PER_SOURCE);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_default_since_constant_is_one_week() {
+        $this->assertTrue(defined('DEFAULT_SINCE'));
+        $this->assertEquals('-1 week', DEFAULT_SINCE);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_default_search_fld_is_text() {
+        $this->assertTrue(defined('DEFAULT_SEARCH_FLD'));
+        $this->assertEquals('TEXT', DEFAULT_SEARCH_FLD);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_default_max_google_contacts_number_is_defined() {
+        $this->assertTrue(defined('DEFAULT_MAX_GOOGLE_CONTACTS_NUMBER'));
+        $this->assertEquals(500, DEFAULT_MAX_GOOGLE_CONTACTS_NUMBER);
+    }
+}

--- a/tests/phpunit/modules/core/output_modules.php
+++ b/tests/phpunit/modules/core/output_modules.php
@@ -1105,4 +1105,481 @@ class Hm_Test_Core_Output_Modules extends TestCase {
         $res = $test->run();
         $this->assertEquals(array('</tbody></table></div></div>'), $res->output_response);
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_logout_outputs_confirmation_markup() {
+        $test = new Output_Test('logout', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('confirm-logout', $res->output_response[0]);
+        $this->assertStringContainsString('Yes, log me out', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_logout_hides_cancel_button_when_no_cancel_url() {
+        $test = new Output_Test('logout', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('style="display:none;"', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_logout_shows_cancel_link_when_url_provided() {
+        $test = new Output_Test('logout', 'core');
+        $test->handler_response = array('cancel_logout_url' => '?page=home');
+        $res = $test->run();
+        $this->assertStringContainsString('?page=home', $res->output_response[0]);
+        $this->assertStringContainsString('No, go back', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_msgs_outputs_system_messages_container_and_js_variable() {
+        $test = new Output_Test('msgs', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('sys_messages', $res->output_response[0]);
+        $this->assertStringContainsString('hm_msgs', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_default_sort_order_setting_outputs_select_with_arrival_and_date_options() {
+        $test = new Output_Test('default_sort_order_setting', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('default_sort_order', $res->output_response[0]);
+        $this->assertStringContainsString('value="arrival"', $res->output_response[0]);
+        $this->assertStringContainsString('value="date"', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_default_sort_order_setting_shows_reset_button_for_non_default_sort() {
+        $test = new Output_Test('default_sort_order_setting', 'core');
+        $test->handler_response = array('user_settings' => array('default_sort_order' => 'date'));
+        $res = $test->run();
+        $this->assertStringContainsString('reset_default_value_select', $res->output_response[0]);
+        $this->assertStringContainsString('selected="selected"', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_delete_attachment_setting_outputs_unchecked_checkbox_by_default() {
+        $test = new Output_Test('delete_attachment_setting', 'core');
+        $test->handler_response = array('user_settings' => array());
+        $res = $test->run();
+        $this->assertStringContainsString('allow_delete_attachment', $res->output_response[0]);
+        $this->assertStringContainsString('type="checkbox"', $res->output_response[0]);
+        $this->assertStringNotContainsString('checked="checked"', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_delete_attachment_setting_shows_checked_when_enabled_in_user_settings() {
+        $test = new Output_Test('delete_attachment_setting', 'core');
+        $test->handler_response = array('user_settings' => array('allow_delete_attachment' => true));
+        $res = $test->run();
+        $this->assertStringContainsString('checked="checked"', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_start_search_settings_outputs_search_input_and_no_results_message() {
+        $test = new Output_Test('start_search_settings', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('settingsSearch', $res->output_response[0]);
+        $this->assertStringContainsString('noSettingsFound', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_expand_search_banner_returns_empty_string_when_search_all_folders_disabled() {
+        $test = new Output_Test('expand_search_banner', 'core');
+        $res = $test->run();
+        $this->assertEmpty($res->output_response);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_expand_search_banner_shows_banner_when_search_all_folders_enabled() {
+        $test = new Output_Test('expand_search_banner', 'core');
+        $test->handler_response = array('search_all_folders_enabled' => true);
+        $res = $test->run();
+        $this->assertStringContainsString('expand-search-banner', $res->output_response[0]);
+        $this->assertStringContainsString('expand-search-btn', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_search_all_folders_setting_outputs_checkbox_with_experimental_badge() {
+        $test = new Output_Test('search_all_folders_setting', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('search_all_folders', $res->output_response[0]);
+        $this->assertStringContainsString('Experimental', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_search_move_copy_controls_concatenates_copy_and_move_buttons_to_output() {
+        $test = new Output_Test('search_move_copy_controls', 'core');
+        $res = $test->run();
+        $this->assertArrayHasKey('msg_controls_extra', $res->output_response);
+        $this->assertStringContainsString('imap_move', $res->output_response['msg_controls_extra']);
+        $this->assertStringContainsString('Copy', $res->output_response['msg_controls_extra']);
+        $this->assertStringContainsString('Move', $res->output_response['msg_controls_extra']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_start_trash_settings_outputs_trash_section_header_with_icon() {
+        $test = new Output_Test('start_trash_settings', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('trash_setting', $res->output_response[0]);
+        $this->assertStringContainsString('Trash', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_start_snoozed_settings_outputs_snoozed_section_header_with_icon() {
+        $test = new Output_Test('start_snoozed_settings', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('snoozed_setting', $res->output_response[0]);
+        $this->assertStringContainsString('Snoozed', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_snoozed_source_max_setting_outputs_input_for_per_source_count() {
+        $test = new Output_Test('snoozed_source_max_setting', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('snoozed_per_source', $res->output_response[0]);
+        $this->assertStringContainsString('Max messages per source', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_snoozed_since_setting_outputs_since_dropdown_for_snoozed() {
+        $test = new Output_Test('snoozed_since_setting', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('snoozed_since', $res->output_response[0]);
+        $this->assertStringContainsString('Show snoozed messages since', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_start_drafts_settings_outputs_drafts_section_header() {
+        $test = new Output_Test('start_drafts_settings', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('drafts_setting', $res->output_response[0]);
+        $this->assertStringContainsString('Drafts', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_warn_for_unsaved_changes_setting_outputs_unchecked_checkbox_by_default() {
+        $test = new Output_Test('warn_for_unsaved_changes_setting', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('warn_for_unsaved_changes', $res->output_response[0]);
+        $this->assertStringNotContainsString('checked="checked"', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_warn_for_unsaved_changes_setting_shows_checked_and_reset_when_enabled() {
+        $test = new Output_Test('warn_for_unsaved_changes_setting', 'core');
+        $test->handler_response = array('user_settings' => array('warn_for_unsaved_changes' => true));
+        $res = $test->run();
+        $this->assertStringContainsString('checked="checked"', $res->output_response[0]);
+        $this->assertStringContainsString('reset_default_value_checkbox', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_server_config_stepper_returns_empty_when_no_essential_modules_active() {
+        $test = new Output_Test('server_config_stepper', 'core');
+        $test->handler_response = array('router_module_list' => array());
+        $res = $test->run();
+        $this->assertArrayNotHasKey(0, $res->output_response);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_server_config_stepper_end_part_outputs_add_server_button() {
+        $test = new Output_Test('server_config_stepper_end_part', 'core');
+        $test->handler_response = array('router_module_list' => array());
+        $res = $test->run();
+        $this->assertStringContainsString('add_new_server_button', $res->output_response[0]);
+        $this->assertStringContainsString('Add a new server', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_server_config_stepper_accordion_end_part_outputs_closing_divs() {
+        $test = new Output_Test('server_config_stepper_accordion_end_part', 'core');
+        $res = $test->run();
+        $this->assertEquals(array('</div></div></div>'), $res->output_response);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_privacy_settings_outputs_whitelist_and_blacklist_fields() {
+        $test = new Output_Test('privacy_settings', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('images_whitelist', $res->output_response[0]);
+        $this->assertStringContainsString('images_blacklist', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_combined_message_list_sets_empty_formatted_list_when_no_data() {
+        $test = new Output_Test('combined_message_list', 'core');
+        $res = $test->run();
+        $this->assertEquals(array(), $res->output_response['formatted_message_list']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_version_upgrade_checker_returns_empty_when_upgrade_not_needed() {
+        $test = new Output_Test('version_upgrade_checker', 'core');
+        $res = $test->run();
+        $this->assertEmpty($res->output_response);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_version_upgrade_checker_shows_alert_when_new_version_available() {
+        $test = new Output_Test('version_upgrade_checker', 'core');
+        $test->handler_response = array('need_upgrade' => true, 'latest_version' => '99.0.0');
+        $res = $test->run();
+        $this->assertStringContainsString('99.0.0', $res->output_response[0]);
+        $this->assertStringContainsString('cypht-upgrade-alert', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_server_content_end_returns_closing_div() {
+        $test = new Output_Test('server_content_end', 'core');
+        $res = $test->run();
+        $this->assertEquals(array('</div>'), $res->output_response);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_js_search_data_outputs_hm_search_terms_js_function() {
+        $test = new Output_Test('js_search_data', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('hm_search_terms', $res->output_response[0]);
+        $this->assertStringContainsString('hm_run_search', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_js_search_data_includes_search_terms_value() {
+        $test = new Output_Test('js_search_data', 'core');
+        $test->handler_response = array('search_terms' => 'hello world', 'run_search' => 1);
+        $res = $test->run();
+        $this->assertStringContainsString('hello world', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_start_all_email_settings_returns_empty_when_no_email_modules() {
+        $test = new Output_Test('start_all_email_settings', 'core');
+        $test->handler_response = array('router_module_list' => array());
+        $res = $test->run();
+        $this->assertArrayNotHasKey(0, $res->output_response);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_start_all_email_settings_outputs_section_header_when_imap_active() {
+        $test = new Output_Test('start_all_email_settings', 'core');
+        $test->handler_response = array('router_module_list' => array('imap'));
+        $res = $test->run();
+        $this->assertStringContainsString('email_setting', $res->output_response[0]);
+        $this->assertStringContainsString('All Email', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_end_settings_form_outputs_save_and_restore_buttons() {
+        $test = new Output_Test('end_settings_form', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('save_settings', $res->output_response[0]);
+        $this->assertStringContainsString('reset_factory_button', $res->output_response[0]);
+        $this->assertStringContainsString('Restore Defaults', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_main_menu_end_outputs_closing_tags_in_html5_format() {
+        $test = new Output_Test('main_menu_end', 'core');
+        $res = $test->run();
+        $this->assertEquals(array('</ul></div>'), $res->output_response);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_no_folder_icon_setting_outputs_unchecked_checkbox_by_default() {
+        $test = new Output_Test('no_folder_icon_setting', 'core');
+        $test->handler_response = array('user_settings' => array());
+        $res = $test->run();
+        $this->assertStringContainsString('no_folder_icons', $res->output_response[0]);
+        $this->assertStringContainsString('type="checkbox"', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_list_style_setting_outputs_email_and_news_options() {
+        $test = new Output_Test('list_style_setting', 'core');
+        $test->handler_response = array('user_settings' => array());
+        $res = $test->run();
+        $this->assertStringContainsString('list_style', $res->output_response[0]);
+        $this->assertStringContainsString('email_style', $res->output_response[0]);
+        $this->assertStringContainsString('news_style', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_home_heading_outputs_home_title() {
+        $test = new Output_Test('home_heading', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('Home', $res->output_response[0]);
+        $this->assertStringContainsString('content_title', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_login_output_generates_standard_login_form_when_not_logged_in() {
+        $test = new Output_Test('login', 'core');
+        $res = $test->run();
+        $this->assertStringContainsString('username', $res->output_response[0]);
+        $this->assertStringContainsString('password', $res->output_response[0]);
+        $this->assertStringContainsString('Login', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_login_output_shows_logout_modal_when_logged_in() {
+        $test = new Output_Test('login', 'core');
+        $test->handler_response = array('router_login_state' => true, 'changed_settings' => array());
+        $res = $test->run();
+        $this->assertStringContainsString('confirmLogoutModal', $res->output_response[0]);
+        $this->assertStringContainsString('logout', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_login_output_includes_stay_logged_in_when_allowed() {
+        $test = new Output_Test('login', 'core');
+        $test->handler_response = array('allow_long_session' => true);
+        $res = $test->run();
+        $this->assertStringContainsString('stay_logged_in', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_header_css_includes_integrity_attribute_when_css_hash_defined() {
+        if (!defined('CSS_HASH')) {
+            define('CSS_HASH', 'sha256-test-hash=');
+        }
+        $test = new Output_Test('header_css', 'core');
+        $test->handler_response = array('router_module_list' => array());
+        $res = $test->run();
+        $this->assertStringContainsString('integrity="sha256-test-hash="', $res->output_response[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_no_folder_icon_setting_shows_reset_when_value_differs_from_default() {
+        $test = new Output_Test('no_folder_icon_setting', 'core');
+        $test->handler_response = array('user_settings' => array('no_folder_icons' => true));
+        $res = $test->run();
+        $this->assertStringContainsString('checked="checked"', $res->output_response[0]);
+        $this->assertStringContainsString('reset_default_value_checkbox', $res->output_response[0]);
+    }
 }

--- a/tests/phpunit/modules/sievefilters/functions.php
+++ b/tests/phpunit/modules/sievefilters/functions.php
@@ -2,6 +2,35 @@
 
 use PHPUnit\Framework\TestCase;
 
+class Hm_Test_Sieve_Failing_Factory {
+    public function init($user_config = null, $imap_account = null, $is_nux_supported = false) {
+        throw new Exception('Connection refused');
+    }
+}
+
+class Hm_Test_Failing_Sieve_Site_Config {
+    public function get($name) {
+        return 'Hm_Test_Sieve_Failing_Factory';
+    }
+    public function get_modules($include_setup = false) {
+        return array();
+    }
+}
+
+class Hm_Test_Mock_Sieve_Module {
+    public $config;
+    public $user_config;
+
+    public function __construct($site_config, $user_config) {
+        $this->config = $site_config;
+        $this->user_config = $user_config;
+    }
+
+    public function module_is_supported($name) {
+        return false;
+    }
+}
+
 /**
  * Helper class to manage mock scripts
  */
@@ -308,6 +337,289 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
         $this->assertStringContainsString('keep;', $mockScripts['main_script']);
         $this->assertStringContainsString('discard;', $mockScripts['main_script']);
         $this->assertStringNotContainsString('# CYPHT CONFIG HEADER', $mockScripts['main_script']);
+    }
+
+    private function makeMockSieveClient(array $extraMethods = []) {
+        $client = $this->createMock(PhpSieveManager\ManageSieve\Client::class);
+        $client->method('connect')->willReturn(true);
+        $client->method('listScripts')->willReturnCallback(function () {
+            return array_keys(MockSieveClientStorage::getScripts());
+        });
+        $client->method('getScript')->willReturnCallback(function ($name) {
+            return MockSieveClientStorage::getScripts()[$name] ?? '';
+        });
+        $client->method('close')->willReturn(true);
+        return $client;
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_split_script_lines_handles_crlf_line_endings() {
+        $script = "first line\r\nsecond line\r\nthird line";
+        $result = split_script_lines($script);
+        $this->assertCount(3, $result);
+        $this->assertEquals('first line', $result[0]);
+        $this->assertEquals('second line', $result[1]);
+        $this->assertEquals('third line', $result[2]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_sieve_client_factory_uses_class_from_site_config() {
+        $factory = get_sieve_client_factory(new Hm_Test_Mock_Sieve_Site_Config());
+        $this->assertInstanceOf('Hm_Test_Mock_Sieve_Client_Factory', $factory);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_initialize_sieve_client_factory_returns_null_and_adds_message_on_exception() {
+        require_once APP_PATH.'modules/sievefilters/hm-sieve.php';
+        $result = initialize_sieve_client_factory(
+            new Hm_Test_Failing_Sieve_Site_Config(),
+            new Hm_Mock_Config(),
+            array('sieve_config_host' => 'sieve.example.com')
+        );
+        $this->assertNull($result);
+        $messages = Hm_Msgs::get();
+        $this->assertNotEmpty($messages);
+        $this->assertStringContainsString('Connection refused', $messages[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_blocked_senders_array_returns_empty_when_no_blocked_senders_script() {
+        MockSieveClientStorage::setScripts(array('other_script' => 'discard;'));
+        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+            return $this->makeMockSieveClient();
+        });
+        $result = get_blocked_senders_array(
+            array('name' => 'Test', 'sieve_config_host' => 'tls://sieve.example.com:4190'),
+            new Hm_Test_Mock_Sieve_Site_Config(),
+            new Hm_Mock_Config()
+        );
+        $this->assertEquals(array(), $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_blocked_senders_array_returns_senders_and_prepends_wildcard_for_domain_entries() {
+        $senders = array('spam@example.com', '@baddomain.com');
+        MockSieveClientStorage::setScripts(array(
+            'blocked_senders' => implode("\n", array(
+                "# CYPHT CONFIG HEADER - DON'T REMOVE",
+                '# ' . base64_encode(json_encode($senders)),
+                '',
+                'discard; stop;',
+            )),
+        ));
+        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+            return $this->makeMockSieveClient();
+        });
+        $result = get_blocked_senders_array(
+            array('name' => 'Test', 'sieve_config_host' => 'tls://sieve.example.com:4190'),
+            new Hm_Test_Mock_Sieve_Site_Config(),
+            new Hm_Mock_Config()
+        );
+        $this->assertCount(2, $result);
+        $this->assertContains('spam@example.com', $result);
+        $this->assertContains('*@baddomain.com', $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_blocked_senders_array_returns_empty_and_adds_message_on_exception() {
+        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+            throw new Exception('Client connection failed');
+        });
+        $result = get_blocked_senders_array(
+            array('name' => 'Test', 'sieve_config_host' => 'tls://sieve.example.com:4190'),
+            new Hm_Test_Mock_Sieve_Site_Config(),
+            new Hm_Mock_Config()
+        );
+        $this->assertEquals(array(), $result);
+        $this->assertStringContainsString('Client connection failed', Hm_Msgs::get()[0]);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_blocked_senders_returns_empty_string_when_script_not_present() {
+        MockSieveClientStorage::setScripts(array());
+        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+            return $this->makeMockSieveClient();
+        });
+        $mod = new Hm_Output_Test(array(), array());
+        $result = get_blocked_senders(
+            array('name' => 'Test', 'sieve_config_host' => 'tls://sieve.example.com:4190', 'sieve_extensions' => array()),
+            'serverA', 'x-circle', 'globe',
+            new Hm_Test_Mock_Sieve_Site_Config(), new Hm_Mock_Config(), $mod
+        );
+        $this->assertEquals('', $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_blocked_senders_returns_html_rows_with_sender_and_unblock_button() {
+        $senders = array('spam@example.com');
+        $actions = array('spam@example.com' => array('action' => 'discard', 'reject_message' => ''));
+        MockSieveClientStorage::setScripts(array(
+            'blocked_senders' => implode("\n", array(
+                "# CYPHT CONFIG HEADER - DON'T REMOVE",
+                '# ' . base64_encode(json_encode($senders)),
+                '# ' . base64_encode(json_encode($actions)),
+                '',
+                'discard; stop;',
+            )),
+        ));
+        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+            return $this->makeMockSieveClient();
+        });
+        $mod = new Hm_Output_Test(array(), array());
+        $result = get_blocked_senders(
+            array('name' => 'Test', 'sieve_config_host' => 'tls://sieve.example.com:4190', 'sieve_extensions' => array()),
+            'serverA', 'x-circle', 'globe',
+            new Hm_Test_Mock_Sieve_Site_Config(), new Hm_Mock_Config(), $mod
+        );
+        $this->assertStringContainsString('spam@example.com', $result);
+        $this->assertStringContainsString('unblock_button', $result);
+        $this->assertStringContainsString('block_domain_button', $result);
+        $this->assertStringContainsString('Discard', $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_sieve_linked_mailbox_returns_folder_map_for_move_action_scripts() {
+        $actions = array(array('action' => 'move', 'value' => 'Archive'));
+        MockSieveClientStorage::setScripts(array(
+            'archive_filter-10-cyphtfilter' => implode("\n", array(
+                "# CYPHT CONFIG HEADER - DON'T REMOVE",
+                '# ' . base64_encode(json_encode(array(array('condition' => 'from', 'value' => 'test@example.com')))),
+                '# ' . base64_encode(json_encode($actions)),
+                '# ' . base64_encode('message_list'),
+                '',
+                'if anyof (header :contains "From" ["test@example.com"]) {',
+                '    # CYPHT GENERATED CONDITION',
+                '    fileinto "Archive";',
+                '}',
+            )),
+        ));
+        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+            return $this->makeMockSieveClient();
+        });
+        $user_config = new Hm_Mock_Config();
+        $module = new Hm_Test_Mock_Sieve_Module(new Hm_Test_Mock_Sieve_Site_Config(), $user_config);
+        $result = get_sieve_linked_mailbox(
+            array('name' => 'Primary Account', 'sieve_config_host' => 'tls://sieve.example.com:4190'),
+            $module
+        );
+        $this->assertArrayHasKey('archive_filter-10-cyphtfilter', $result);
+        $this->assertEquals('Archive', $result['archive_filter-10-cyphtfilter']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_is_mailbox_linked_with_filters_returns_false_when_no_sieve_config_on_account() {
+        $user_config = new Hm_Mock_Config();
+        $user_config->set('imap_servers', array(
+            'serverA' => array('name' => 'Test', 'server' => 'imap.example.com'),
+        ));
+        $module = new Hm_Test_Mock_Sieve_Module(new Hm_Test_Mock_Sieve_Site_Config(), $user_config);
+        $this->assertFalse(is_mailbox_linked_with_filters('Archive', 'serverA', $module));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_is_mailbox_linked_with_filters_returns_true_when_folder_is_linked() {
+        $actions = array(array('action' => 'move', 'value' => 'Archive'));
+        MockSieveClientStorage::setScripts(array(
+            'arch-10-cyphtfilter' => implode("\n", array(
+                "# CYPHT CONFIG HEADER - DON'T REMOVE",
+                '# ' . base64_encode(json_encode(array(array('condition' => 'from', 'value' => 'x@x.com')))),
+                '# ' . base64_encode(json_encode($actions)),
+                '# ' . base64_encode('message_list'),
+                '',
+                '# CYPHT GENERATED CONDITION',
+                'fileinto "Archive";',
+            )),
+        ));
+        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+            return $this->makeMockSieveClient();
+        });
+        $user_config = new Hm_Mock_Config();
+        $user_config->set('imap_servers', array(
+            'serverA' => array('name' => 'Test', 'sieve_config_host' => 'tls://sieve.example.com:4190'),
+        ));
+        $module = new Hm_Test_Mock_Sieve_Module(new Hm_Test_Mock_Sieve_Site_Config(), $user_config);
+        $this->assertTrue(is_mailbox_linked_with_filters('Archive', 'serverA', $module));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_block_filter_discard_action_generates_discard_script() {
+        $filter = \PhpSieveManager\Filters\FilterFactory::create('blocked_senders');
+        $result = block_filter($filter, new Hm_Mock_Config(), 'discard', 0, 'discard@example.com');
+        $this->assertEquals('discard', $result['action']);
+        $this->assertStringContainsString('discard@example.com', $filter->toScript());
+        $this->assertStringContainsString('discard;', $filter->toScript());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_block_filter_reject_default_uses_configured_message() {
+        $user_config = new Hm_Mock_Config();
+        $user_config->set('sieve_block_default_reject_message', array(0 => 'No thanks'));
+        $filter = \PhpSieveManager\Filters\FilterFactory::create('blocked_senders');
+        $result = block_filter($filter, $user_config, 'reject_default', 0, 'reject@example.com');
+        $this->assertEquals('reject_default', $result['action']);
+        $this->assertEquals('No thanks', $result['reject_message']);
+        $this->assertStringContainsString('reject', $filter->toScript());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_block_filter_blocked_action_moves_to_blocked_folder() {
+        $filter = \PhpSieveManager\Filters\FilterFactory::create('blocked_senders');
+        $result = block_filter($filter, new Hm_Mock_Config(), 'blocked', 0, 'junk@example.com');
+        $this->assertEquals('blocked', $result['action']);
+        $this->assertStringContainsString('fileinto "Blocked"', $filter->toScript());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_format_main_script_handles_script_with_no_require_statements() {
+        $result = format_main_script("keep;\ndiscard;");
+        $this->assertStringContainsString('keep;', $result);
+        $this->assertStringContainsString('discard;', $result);
+        $this->assertStringNotContainsString('require', $result);
     }
 
     /**

--- a/tests/phpunit/modules/sievefilters/handler_modules.php
+++ b/tests/phpunit/modules/sievefilters/handler_modules.php
@@ -97,6 +97,14 @@ class Hm_Test_Sieve_Client {
     public function getErrorMessage() {
         return '';
     }
+
+    public function getExtensions() {
+        return array('fileinto', 'reject');
+    }
+
+    public function getCapabilities() {
+        return array('fileinto', 'reject', 'vacation');
+    }
 }
 
 class Hm_Test_Sieve_Client_Factory {
@@ -555,6 +563,241 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
         $test->run();
 
         $this->assertEquals(array('Sieve: Test failure'), Hm_Msgs::get());
+    }
+
+    private function blockedSendersScript(array $senders, array $actions = []) {
+        $lines = array(
+            "# CYPHT CONFIG HEADER - DON'T REMOVE",
+            '# ' . base64_encode(json_encode($senders)),
+        );
+        if (!empty($actions)) {
+            $lines[] = '# ' . base64_encode(json_encode($actions));
+        }
+        $lines[] = '';
+        $lines[] = 'discard; stop;';
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_sieve_filters_enabled_outputs_user_config_value() {
+        $test = new Sieve_Handler_Test('sieve_filters_enabled', 'sievefilters');
+        $test->user_config = array('enable_sieve_filter_setting' => true);
+        $res = $test->run();
+        $this->assertTrue($res->handler_response['sieve_filters_enabled']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_sieve_block_change_behaviour_updates_user_config_and_adds_message() {
+        $test = new Sieve_Handler_Test('sieve_block_change_behaviour_script', 'sievefilters');
+        $test->post = array(
+            'imap_server_id' => 'serverA',
+            'selected_behaviour' => 'Reject',
+            'reject_message' => 'No spam allowed',
+        );
+        $test->user_config = array('enable_sieve_filter_setting' => true);
+        $test->run();
+        $this->assertEquals(array('Default behaviour changed'), Hm_Msgs::get());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_settings_load_imap_outputs_accounts_site_config_and_user_config() {
+        $test = new Sieve_Handler_Test('settings_load_imap', 'sievefilters');
+        $test->user_config = array('imap_servers' => $this->imapServersConfig());
+        $res = $test->run();
+        $this->assertEquals($this->imapServersConfig(), $res->handler_response['imap_accounts']);
+        $this->assertNotNull($res->handler_response['site_config']);
+        $this->assertNotNull($res->handler_response['user_config']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_load_behaviour_outputs_empty_arrays_when_not_configured() {
+        $test = new Sieve_Handler_Test('load_behaviour', 'sievefilters');
+        $test->user_config = array('enable_sieve_filter_setting' => true);
+        $res = $test->run();
+        $this->assertEquals(array(), $res->handler_response['sieve_block_default_behaviour']);
+        $this->assertEquals(array(), $res->handler_response['sieve_block_default_reject_message']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_load_behaviour_outputs_configured_values() {
+        $test = new Sieve_Handler_Test('load_behaviour', 'sievefilters');
+        $test->user_config = array(
+            'enable_sieve_filter_setting' => true,
+            'sieve_block_default_behaviour' => array('serverA' => 'Reject'),
+            'sieve_block_default_reject_message' => array('serverA' => 'Blocked'),
+        );
+        $res = $test->run();
+        $this->assertEquals(array('serverA' => 'Reject'), $res->handler_response['sieve_block_default_behaviour']);
+        $this->assertEquals(array('serverA' => 'Blocked'), $res->handler_response['sieve_block_default_reject_message']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_sieve_unblock_sender_removes_sender_and_adds_message() {
+        Hm_Test_Sieve_Client::$scripts = array(
+            'main_script' => 'require ["include"];',
+            'blocked_senders' => $this->blockedSendersScript(array('spam@example.com')),
+        );
+        $test = new Sieve_Handler_Test('sieve_unblock_sender', 'sievefilters');
+        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->post = array('imap_server_id' => 'serverA', 'sender' => 'spam@example.com');
+        $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
+        $test->run();
+        $this->assertEquals(array('Sender Unblocked'), Hm_Msgs::get());
+        $this->assertEquals('', Hm_Test_Sieve_Client::$scripts['blocked_senders']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_sieve_block_domain_blocks_wildcard_domain_and_sets_reload_page() {
+        Hm_Test_Sieve_Client::$scripts = array('main_script' => 'require ["include"];');
+        $test = new Sieve_Handler_Test('sieve_block_domain_script', 'sievefilters');
+        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->post = array('imap_server_id' => 'serverA', 'sender' => 'spam@example.com');
+        $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
+        $res = $test->run();
+        $this->assertTrue($res->handler_response['reload_page']);
+        $this->assertArrayHasKey('blocked_senders', Hm_Test_Sieve_Client::$scripts);
+        $this->assertStringContainsString('@example.com', Hm_Test_Sieve_Client::$scripts['blocked_senders']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_sieve_block_unblock_script_blocks_new_sender_with_discard_action() {
+        Hm_Test_Sieve_Client::$scripts = array();
+        $test = new Sieve_Handler_Test('sieve_block_unblock_script', 'sievefilters');
+        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->post = array(
+            'imap_server_id' => 'serverA',
+            'block_action' => 'discard',
+            'scope' => 'sender',
+            'sender' => 'spammer@example.com',
+            'reject_message' => '',
+        );
+        $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
+        $test->run();
+        $this->assertEquals(array('Sender Blocked'), Hm_Msgs::get());
+        $this->assertArrayHasKey('blocked_senders', Hm_Test_Sieve_Client::$scripts);
+        $this->assertStringContainsString('spammer@example.com', Hm_Test_Sieve_Client::$scripts['blocked_senders']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_sieve_block_unblock_script_unblocks_existing_sender() {
+        $senders = array('existing@example.com');
+        $actions = array('existing@example.com' => array('action' => 'discard', 'reject_message' => ''));
+        Hm_Test_Sieve_Client::$scripts = array(
+            'blocked_senders' => $this->blockedSendersScript($senders, $actions),
+        );
+        $test = new Sieve_Handler_Test('sieve_block_unblock_script', 'sievefilters');
+        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->post = array(
+            'imap_server_id' => 'serverA',
+            'block_action' => 'discard',
+            'scope' => 'sender',
+            'sender' => 'existing@example.com',
+            'reject_message' => '',
+        );
+        $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
+        $test->run();
+        $this->assertEquals(array('Sender Unblocked'), Hm_Msgs::get());
+        $this->assertEquals('', Hm_Test_Sieve_Client::$scripts['blocked_senders']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_list_block_sieve_script_outputs_json_of_blocked_senders() {
+        Hm_Test_Sieve_Client::$scripts = array(
+            'blocked_senders' => $this->blockedSendersScript(array('blocked@example.com')),
+        );
+        Hm_IMAP_List::init(new Hm_Mock_Config(), new Hm_Mock_Session());
+        Hm_IMAP_List::add(array(
+            'name' => 'Primary Account',
+            'server' => 'imap.example.com',
+            'user' => 'user@example.com',
+            'pass' => 'secret',
+            'sieve_config_host' => 'tls://sieve.example.com:4190',
+            'id' => 0,
+        ));
+        $test = new Sieve_Handler_Test('list_block_sieve_script', 'sievefilters');
+        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->post = array('imap_server_id' => 0);
+        $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
+        $res = $test->run();
+        $this->assertEquals(json_encode(array('blocked@example.com')), $res->handler_response['ajax_list_block_sieve']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_load_account_sieve_filters_outputs_mailbox_with_extensions() {
+        Hm_Test_Sieve_Client::$scripts = array();
+        $test = new Sieve_Handler_Test('load_account_sieve_filters', 'sievefilters');
+        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->post = array('imap_server_id' => 'serverA');
+        $test->input = array('imap_accounts' => $this->imapServersConfig());
+        $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
+        $res = $test->run();
+        $this->assertArrayHasKey('mailbox', $res->handler_response);
+        $this->assertEquals(array('fileinto', 'reject'), $res->handler_response['mailbox']['sieve_extensions']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_sieve_toggle_script_state_enables_disabled_script() {
+        Hm_Test_Sieve_Client::$scripts = array(
+            'main_script' => 'require ["include"];',
+            'sdisabled_manual_script-15-cypht' => "require [\"fileinto\"];\nkeep;",
+        );
+        Hm_IMAP_List::init(new Hm_Mock_Config(), new Hm_Mock_Session());
+        Hm_IMAP_List::add(array(
+            'name' => 'Primary Account',
+            'server' => 'imap.example.com',
+            'user' => 'user@example.com',
+            'pass' => 'secret',
+            'sieve_config_host' => 'tls://sieve.example.com:4190',
+            'id' => 0,
+        ));
+        $test = new Sieve_Handler_Test('sieve_toggle_script_state', 'sievefilters');
+        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->post = array(
+            'imap_account' => 0,
+            'script_state' => 1,
+            'sieve_script_name' => 'sdisabled_manual_script-15-cypht',
+        );
+        $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
+        $res = $test->run();
+        $this->assertTrue($res->handler_response['success']);
+        $this->assertArrayHasKey('senabled_sdisabled_manual_script-15-cypht', Hm_Test_Sieve_Client::$scripts);
+        $this->assertEquals(array('Script enabled'), Hm_Msgs::get());
     }
 
     /**

--- a/tests/phpunit/mta_sts.php
+++ b/tests/phpunit/mta_sts.php
@@ -156,6 +156,121 @@ class Hm_Test_MTA_STS extends TestCase {
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
+    public function test_parse_policy_id_extracts_id_from_valid_dns_record() {
+        $mta_sts = new Hm_MTA_STS();
+        $this->assertEquals('20190429T010101', $mta_sts->parse_policy_id('v=STSv1; id=20190429T010101;'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_parse_policy_id_returns_false_when_no_id_present() {
+        $mta_sts = new Hm_MTA_STS();
+        $this->assertFalse($mta_sts->parse_policy_id('v=STSv1; no-id-here'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_parse_policy_id_trims_whitespace_from_extracted_id() {
+        $mta_sts = new Hm_MTA_STS();
+        $this->assertEquals('abc123', $mta_sts->parse_policy_id('v=STSv1; id=  abc123  '));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_check_domain_returns_error_when_no_domain_set() {
+        $mta_sts = new Hm_MTA_STS();
+        $result = $mta_sts->check_domain();
+        $this->assertFalse($result['enabled']);
+        $this->assertNull($result['policy']);
+        $this->assertEquals('No domain specified', $result['error']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_check_tls_rpt_returns_error_when_no_domain_set() {
+        $mta_sts = new Hm_MTA_STS();
+        $result = $mta_sts->check_tls_rpt();
+        $this->assertFalse($result['enabled']);
+        $this->assertNull($result['rua']);
+        $this->assertEquals('No domain specified', $result['error']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_check_domain_caches_no_dns_record_result() {
+        $mta = new Hm_Testable_MTA_STS_No_DNS('nodomain.example');
+        $result = $mta->check_domain();
+        $this->assertFalse($result['enabled']);
+        $this->assertEquals('No MTA-STS DNS record found', $result['error']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_parse_policy_returns_false_for_missing_version() {
+        $mta_sts = new Hm_MTA_STS();
+        $this->assertFalse($mta_sts->parse_policy("version: STSv2\nmode: enforce\nmx: mx.example.com\nmax_age: 86400\n"));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_parse_policy_handles_comments_and_empty_lines() {
+        $mta_sts = new Hm_MTA_STS();
+        $content = "# comment\nversion: STSv1\n\nmode: testing\nmx: mx.example.com\nmax_age: 3600\n";
+        $result = $mta_sts->parse_policy($content);
+        $this->assertEquals('testing', $result['mode']);
+        $this->assertEquals(3600, $result['max_age']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_clear_cache_removes_cached_results() {
+        $mta = new Hm_Testable_MTA_STS('example.com');
+        $mta->check_domain();
+        $mta->clear_cache();
+        $mta->check_domain();
+        $this->assertEquals(2, Hm_Testable_MTA_STS::$dns_lookups);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_status_class_returns_disabled_for_unknown_mode() {
+        $mta_sts = new Hm_MTA_STS();
+        $result = array('enabled' => true, 'policy' => array('mode' => 'unknown_mode'));
+        $this->assertEquals('mta-sts-disabled', $mta_sts->get_status_class($result));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_status_message_returns_unknown_mode_message() {
+        $mta_sts = new Hm_MTA_STS();
+        $result = array('enabled' => true, 'policy' => array('mode' => 'unknown_xyz'));
+        $this->assertEquals('MTA-STS policy published (unknown mode)', $mta_sts->get_status_message($result));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
     public function test_check_domain_uses_shared_cache() {
         $first = new Hm_Testable_MTA_STS('example.com');
         $second = new Hm_Testable_MTA_STS('example.com');
@@ -180,5 +295,25 @@ class Hm_Testable_MTA_STS extends Hm_MTA_STS {
 
     protected function fetch_policy() {
         return $this->parse_policy("version: STSv1\nmode: enforce\nmx: mail.example.com\nmax_age: 86400\n");
+    }
+}
+
+class Hm_Testable_MTA_STS_TLS extends Hm_MTA_STS {
+    public function check_tls_rpt() {
+        if (empty($this->domain)) {
+            return array('enabled' => false, 'rua' => null, 'error' => 'No domain specified');
+        }
+        return array(
+            'enabled' => true,
+            'rua' => 'mailto:reports@example.com',
+            'error' => null,
+            'dns_record' => 'v=TLSRPTv1; rua=mailto:reports@example.com'
+        );
+    }
+}
+
+class Hm_Testable_MTA_STS_No_DNS extends Hm_MTA_STS {
+    protected function get_mta_sts_dns_record() {
+        return false;
     }
 }

--- a/tests/phpunit/output.php
+++ b/tests/phpunit/output.php
@@ -10,6 +10,8 @@ class Hm_Test_Output extends TestCase {
     public $http;
     public function setUp(): void {
         $this->http = new Hm_Output_HTTP();
+        Hm_Msgs::flush();
+        Hm_Debug::flush();
     }
     /**
      * @preserveGlobalState disabled
@@ -31,5 +33,139 @@ class Hm_Test_Output extends TestCase {
     }
     public function tearDown(): void {
         unset($this->http);
+        Hm_Msgs::flush();
+        Hm_Debug::flush();
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_msgs_add_deduplicates_messages() {
+        Hm_Msgs::add('duplicate message');
+        Hm_Msgs::add('duplicate message');
+        $this->assertCount(1, Hm_Msgs::get());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_msgs_add_stores_type_with_message() {
+        Hm_Msgs::add('test warning', 'warning');
+        $raw = Hm_Msgs::getRaw();
+        $this->assertEquals('warning', $raw[0]['type']);
+        $this->assertEquals('test warning', $raw[0]['text']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_msgs_get_returns_text_only() {
+        Hm_Msgs::add('msg one');
+        Hm_Msgs::add('msg two');
+        $texts = Hm_Msgs::get();
+        $this->assertEquals(array('msg one', 'msg two'), $texts);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_msgs_flush_clears_all_messages() {
+        Hm_Msgs::add('will be flushed');
+        Hm_Msgs::flush();
+        $this->assertEmpty(Hm_Msgs::get());
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_list_str_with_array_returns_print_r_output() {
+        $result = Hm_Msgs::str(array('a' => 1));
+        $this->assertStringContainsString('Array', $result);
+        $this->assertStringContainsString('[a]', $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_list_str_with_object_returns_print_r_output() {
+        $obj = new stdClass();
+        $obj->key = 'value';
+        $result = Hm_Msgs::str($obj);
+        $this->assertStringContainsString('stdClass', $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_list_str_with_return_type_true_includes_type_prefix() {
+        $result = Hm_Msgs::str(42);
+        $this->assertEquals('integer: 42', $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_list_str_with_return_type_false_returns_string_only() {
+        $result = Hm_Msgs::str(42, false);
+        $this->assertEquals('42', $result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_msgs_show_returns_true_when_hm_logger_exists() {
+        // Hm_Logger is loaded by the bootstrap environment
+        if (!class_exists('Hm_Logger', false)) {
+            $this->markTestSkipped('Hm_Logger not loaded');
+        }
+        Hm_Msgs::add('test message');
+        $result = Hm_Msgs::show();
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_debug_add_stores_message() {
+        Hm_Debug::add('debug entry', 'info');
+        $raw = Hm_Debug::getRaw();
+        $this->assertNotEmpty($raw);
+        $this->assertEquals('debug entry', $raw[0]['text']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_hm_debug_load_page_stats_adds_system_info() {
+        Hm_Debug::load_page_stats();
+        $texts = Hm_Debug::get();
+        $this->assertTrue(count($texts) >= 5);
+        $found_php = false;
+        foreach ($texts as $text) {
+            if (strpos($text, 'PHP version') !== false) {
+                $found_php = true;
+                break;
+            }
+        }
+        $this->assertTrue($found_php);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_elog_returns_null_when_debug_mode_is_false() {
+        $this->assertNull(elog('test value'));
     }
 }

--- a/tests/phpunit/phpunit.xml
+++ b/tests/phpunit/phpunit.xml
@@ -134,11 +134,15 @@
       <file>./lib/api_curl.php</file>
       <file>./lib/js_libs.php</file>
       <file>./lib/repository.php</file>
+      <file>./lib/version.php</file>
+      <file>./lib/logging.php</file>
+      <file>./lib/output_debug.php</file>
     </testsuite>
     <!--<testsuite name="modules_imap">
             <file>./modules/imap/hm-imap.php</file>
         </testsuite>-->
     <testsuite name="modules_core">
+      <file>./modules/core/modules.php</file>
       <file>./modules/core/functions.php</file>
       <file>./modules/core/message_functions.php</file>
       <file>./modules/core/message_list_functions.php</file>
@@ -163,6 +167,9 @@
     </testsuite>
     <testsuite name="modules_ldap_contacts">
       <file>./modules/ldap_contacts/ldap_contacts.php</file>
+    </testsuite>
+    <testsuite name="mta_sts">
+      <file>./mta_sts.php</file>
     </testsuite>
   </testsuites>
   <source>

--- a/tests/phpunit/servers.php
+++ b/tests/phpunit/servers.php
@@ -122,4 +122,57 @@ class Hm_Test_Servers extends TestCase {
         Hm_Server_Wrapper::clean_up($this->id);
         Hm_Server_Wrapper::clean_up();
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_for_mailbox_returns_server_with_password_and_username_fields() {
+        $result = Hm_Server_Wrapper::getForMailbox($this->id);
+        $this->assertIsArray($result);
+        $this->assertEquals('testpass', $result['password']);
+        $this->assertEquals('testuser', $result['username']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_for_mailbox_returns_false_for_unknown_id() {
+        $this->assertFalse(Hm_Server_Wrapper::getForMailbox('nonexistent'));
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_dump_for_mailbox_single_server_includes_password_and_username() {
+        $result = Hm_Server_Wrapper::dumpForMailbox($this->id);
+        $this->assertIsArray($result);
+        $this->assertEquals('testpass', $result['password']);
+        $this->assertEquals('testuser', $result['username']);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_dump_for_mailbox_all_servers_includes_password_and_username_in_each() {
+        $result = Hm_Server_Wrapper::dumpForMailbox();
+        $this->assertIsArray($result);
+        foreach ($result as $server) {
+            $this->assertArrayHasKey('password', $server);
+            $this->assertArrayHasKey('username', $server);
+        }
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_fetch_with_empty_server_name_matches_by_username_only() {
+        $result = Hm_Server_Wrapper::fetch('testuser', '');
+        $this->assertIsArray($result);
+        $this->assertGreaterThan(0, count($result));
+    }
 }

--- a/tests/phpunit/session.php
+++ b/tests/phpunit/session.php
@@ -266,4 +266,58 @@ class Hm_Test_PHP_Session extends TestCase {
         $this->assertEquals(array(), $_SESSION);
         $session->destroy($request);
     }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_set_session_params_with_real_cookie_domain() {
+        $this->config->set('cookie_domain', 'example.com');
+        $session = new Hm_PHP_Session($this->config, 'Hm_Auth_DB');
+        $request = new Hm_Mock_Request('HTTP');
+        $result = $session->set_session_params($request);
+        $this->assertEquals('example.com', $result[2]);
+        $session->destroy($request);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_restore_long_session_sets_lifetime_and_refreshes_cookie() {
+        $session = new Hm_PHP_Session($this->config, 'Hm_Auth_DB');
+        $request = new Hm_Mock_Request('HTTP');
+        $request->server['HTTP_HOST'] = 'test';
+        $session->start($request);
+        $session->set('long_session_enabled', true);
+        $session->set('long_session_lifetime', 3600);
+        $reflection = new ReflectionClass($session);
+        $method = $reflection->getMethod('restore_long_session');
+        $method->setAccessible(true);
+        $method->invoke($session, $request);
+        $prop = $reflection->getProperty('lifetime');
+        $prop->setAccessible(true);
+        $this->assertEquals(3600, $prop->getValue($session));
+        $session->destroy($request);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_restore_long_session_does_nothing_when_not_enabled() {
+        $session = new Hm_PHP_Session($this->config, 'Hm_Auth_DB');
+        $request = new Hm_Mock_Request('HTTP');
+        $request->server['HTTP_HOST'] = 'test';
+        $session->start($request);
+        $session->set('long_session_enabled', false);
+        $reflection = new ReflectionClass($session);
+        $method = $reflection->getMethod('restore_long_session');
+        $method->setAccessible(true);
+        $method->invoke($session, $request);
+        $prop = $reflection->getProperty('lifetime');
+        $prop->setAccessible(true);
+        $this->assertEquals(0, $prop->getValue($session));
+        $session->destroy($request);
+    }
 }


### PR DESCRIPTION
The marginal gains slow down significantly after ~83% because the remaining uncovered lines require external infrastructure that is not available in the test environment:

- **Hm_Memcached** (151 uncovered lines): requires a running Memcached server
- **Hm_Auth_IMAP / Hm_Auth_LDAP** (0% coverage): require real IMAP/LDAP servers
- **Hm_DB_Session / Hm_Auth_DB / Hm_User_Config_DB**: require a real database
- **Hm_MTA_STS** DNS/HTTP methods: require live network access
- **Hm_Logger::configureHandlers**: private method, initialised before tests can set env vars

Reaching 90%+ would require either dedicated test infrastructure (DB, Redis, IMAP) or refactoring those classes to make their external connections injectable and mockable via PHPUnit's `createMock()`.

<table>
<tr>
<td align="center"><strong>Before: 77.32%</strong></td>
<td align="center"><strong>After: 83%+</strong></td>
</tr>
<tr>
<td><img width="735" alt="Before" src="https://github.com/user-attachments/assets/7b31d108-431f-46c5-be9a-6508815ea142" /></td>
<td><img width="956" alt="After" src="https://github.com/user-attachments/assets/59a95f3b-0a61-467f-bf4e-bf28ca8c56fd" /></td>
</tr>
<tr>
<td><img width="1917" alt="lib/ detail" src="https://github.com/user-attachments/assets/83c8588a-6739-4e8a-8035-e6aafd006ad0" /></td>
<td><img width="1897" alt="modules/core/ detail" src="https://github.com/user-attachments/assets/adfc78c2-dc0e-4cf8-9b11-5ade13b8bba0" /></td>
</tr>
</table>



