### PR TITLE
fix(module/imap): send IMAP ID when X-CM-EXT-1 is advertised

### DIFF
--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -341,6 +341,9 @@ if (!class_exists('Hm_IMAP')) {
                 $this->debug[] = 'Logged in successfully as ' . $username;
                 $this->get_capability();
                 $this->enable();
+                if ($this->is_supported('X-CM-EXT-1')) {
+                    $this->id();
+                }
             } else {
                 $this->debug[] = 'Log in for ' . $username . ' FAILED';
             }
@@ -2329,7 +2332,7 @@ if (!class_exists('Hm_IMAP')) {
          */
         public function id() {
             $server_id = array();
-            if ($this->is_supported('ID')) {
+            if ($this->is_supported('ID') || $this->is_supported('X-CM-EXT-1')) {
                 $params = array(
                     'name' => $this->app_name,
                     'version' => $this->app_version,


### PR DESCRIPTION
## Pull request

This fixes the 163.com / NetEase IMAP case from #2028. The server accepts login and `STATUS INBOX`, but rejects `SELECT INBOX` with `NO SELECT Unsafe Login` unless the client sends IMAP `ID` first.

Cypht already has an `id()` helper. This PR makes the IMAP client use it after login when the server advertises `X-CM-EXT-1`, and lets `id()` run for that capability as well as the standard `ID` capability.

## Testing

- `git diff --check`
- `php -l modules/imap/hm-imap.php` with PHP 8.2

I also tried running the IMAP PHPUnit file locally, but it stopped before the test assertions because the current test bootstrap loaded the same helper files twice in that mode. I left the test harness alone.

## Issue

Fixes #2028
