### PR TITLE
fix(unit): fix PHPUnit warnings and PHP 8.4 deprecations in test suite

### DIFF
--- a/lib/environment.php
+++ b/lib/environment.php
@@ -38,59 +38,65 @@ class Hm_Environment {
     }
 
     public function define_default_constants($config) {
-        define('DEFAULT_SEARCH_SINCE', $config->get('default_setting_search_since', '-1 week'));
-        define('DEFAULT_UNREAD_SINCE', $config->get('default_setting_unread_since', '-1 week'));
-        define('DEFAULT_UNREAD_PER_SOURCE', $config->get('default_setting_unread_per_source', 20));
-        define('DEFAULT_FLAGGED_SINCE', $config->get('default_setting_flagged_since', '-1 week'));
-        define('DEFAULT_FLAGGED_PER_SOURCE', $config->get('default_setting_flagged_per_source', 20));
-        define('DEFAULT_SEARCH_ALL_FOLDERS', $config->get('default_setting_search_all_folders', false));
-        define('DEFAULT_ALL_SINCE', $config->get('default_setting_all_since', '-1 week'));
-        define('DEFAULT_ALL_PER_SOURCE', $config->get('default_setting_all_per_source', 20));
-        define('DEFAULT_ALL_EMAIL_SINCE', $config->get('default_setting_all_email_since', '-1 week'));
-        define('DEFAULT_ALL_EMAIL_PER_SOURCE', $config->get('default_setting_all_email_per_source', 20));
-        define('DEFAULT_FEED_SINCE', $config->get('default_setting_feed_since', '-1 week'));
-        define('DEFAULT_FEED_LIMIT', $config->get('default_setting_feed_limit', 20));
-        define('DEFAULT_SENT_SINCE', $config->get('default_setting_sent_since', '-1 week'));
-        define('DEFAULT_SENT_PER_SOURCE', $config->get('default_setting_sent_per_source', 20));
-        define('DEFAULT_UNREAD_EXCLUDE_FEEDS', $config->get('default_setting_unread_exclude_feeds', false));
-        define('DEFAULT_LIST_STYLE', $config->get('default_setting_list_style', 'email_style'));
-        define('DEFAULT_IMAP_PER_PAGE', $config->get('default_setting_imap_per_page', 20));
-        define('DEFAULT_JUNK_SINCE', $config->get('default_setting_junk_since', '-1 week'));
-        define('DEFAULT_JUNK_PER_SOURCE', $config->get('default_setting_junk_per_source', 20));
-        define('DEFAULT_SNOOZED_SINCE', $config->get('default_setting_snoozed_since', '-1 week'));
-        define('DEFAULT_SNOOZED_PER_SOURCE', $config->get('default_setting_snoozed_per_source', 20));
-        define('DEFAULT_ENABLE_SNOOZE', $config->get('default_setting_enable_snooze', true));
-        define('DEFAULT_TAGS_SINCE', $config->get('default_setting_tags_since', '-1 week'));
-        define('DEFAULT_TAGS_PER_SOURCE', $config->get('default_setting_tags_per_source', 20));
-        define('DEFAULT_TRASH_SINCE', $config->get('default_setting_trash_since', '-1 week'));
-        define('DEFAULT_TRASH_PER_SOURCE', $config->get('default_setting_trash_per_source', 20));
-        define('DEFAULT_DRAFT_SINCE', $config->get('default_setting_draft_since', '-1 week'));
-        define('DEFAULT_DRAFT_PER_SOURCE', $config->get('default_setting_draft_per_source', 20));
-        define('DEFAULT_SIMPLE_MSG_PARTS', $config->get('default_setting_simple_msg_parts', false));
-        define('DEFAULT_MSG_PART_ICONS', $config->get('default_setting_msg_part_icons', true));
-        define('DEFAULT_PAGINATION_LINKS', $config->get('default_setting_pagination_links', true));
-        define('DEFAULT_REVIEW_SENT_EMAIL', $config->get('default_setting_review_sent_email', true));
-        define('DEFAULT_TEXT_ONLY', $config->get('default_setting_text_only', false));
-        define('DEFAULT_NO_PASSWORD_SAVE', $config->get('default_setting_no_password_save', false));
-        define('DEFAULT_SHOW_LIST_ICONS', $config->get('default_setting_show_list_icons', true));
-        define('DEFAULT_START_PAGE', $config->get('default_setting_start_page', "none"));
-        define('DEFAULT_DISABLE_DELETE_PROMPT', $config->get('default_setting_disable_delete_prompt', false));
-        define('DEFAULT_NO_FOLDER_ICONS', $config->get('default_setting_no_folder_icons', false));
-        define('DEFAULT_SETTING_LANGUAGE', $config->get('default_setting_language', 'en'));
-        define('DEFAULT_SMTP_COMPOSE_TYPE', $config->get('default_setting_smtp_compose_type', 0));
-        define('DEFAULT_SMTP_AUTO_BCC', $config->get('default_setting_smtp_auto_bcc', false));
-        define('DEFAULT_THEME', $config->get('default_setting_theme', 'default'));
-        define('DEFAULT_UNREAD_EXCLUDE_WORDPRESS', $config->get('default_setting_unread_exclude_wordpress', false));
-        define('DEFAULT_WORDPRESS_SINCE', $config->get('default_setting_wordpress_since', '-1 week'));
-        define('DEFAULT_UNREAD_EXCLUDE_GITHUB', $config->get('default_setting_unread_exclude_github', false));
-        define('DEFAULT_GITHUB_PER_SOURCE', $config->get('default_setting_github_limit', 20));
-        define('DEFAULT_GITHUB_SINCE', $config->get('default_setting_github_since', '-1 week'));
-        define('DEFAULT_INLINE_MESSAGE', $config->get('default_setting_inline_message', false));
-        define('DEFAULT_INLINE_MESSAGE_STYLE', $config->get('default_setting_inline_message_style', 'right'));
-        define('DEFAULT_ENABLE_KEYBOARD_SHORTCUTS', $config->get('default_setting_enable_keyboard_shortcuts', false));
-        define('DEFAULT_ENABLE_SIEVE_FILTER', $config->get('default_setting_enable_sieve_filter', false));
-        define('DEFAULT_ENABLE_COLLECT_ADDRESS_ON_SEND', $config->get('default_setting_enable_collect_address_on_send', false));
-        define('DEFAULT_SETTING_ENABLE_EXCLUDE_AUTO_BCC', $config->get('default_setting_enable_exclude_auto_bcc', true));
+        $this->define_constant('DEFAULT_SEARCH_SINCE', $config->get('default_setting_search_since', '-1 week'));
+        $this->define_constant('DEFAULT_UNREAD_SINCE', $config->get('default_setting_unread_since', '-1 week'));
+        $this->define_constant('DEFAULT_UNREAD_PER_SOURCE', $config->get('default_setting_unread_per_source', 20));
+        $this->define_constant('DEFAULT_FLAGGED_SINCE', $config->get('default_setting_flagged_since', '-1 week'));
+        $this->define_constant('DEFAULT_FLAGGED_PER_SOURCE', $config->get('default_setting_flagged_per_source', 20));
+        $this->define_constant('DEFAULT_SEARCH_ALL_FOLDERS', $config->get('default_setting_search_all_folders', false));
+        $this->define_constant('DEFAULT_ALL_SINCE', $config->get('default_setting_all_since', '-1 week'));
+        $this->define_constant('DEFAULT_ALL_PER_SOURCE', $config->get('default_setting_all_per_source', 20));
+        $this->define_constant('DEFAULT_ALL_EMAIL_SINCE', $config->get('default_setting_all_email_since', '-1 week'));
+        $this->define_constant('DEFAULT_ALL_EMAIL_PER_SOURCE', $config->get('default_setting_all_email_per_source', 20));
+        $this->define_constant('DEFAULT_FEED_SINCE', $config->get('default_setting_feed_since', '-1 week'));
+        $this->define_constant('DEFAULT_FEED_LIMIT', $config->get('default_setting_feed_limit', 20));
+        $this->define_constant('DEFAULT_SENT_SINCE', $config->get('default_setting_sent_since', '-1 week'));
+        $this->define_constant('DEFAULT_SENT_PER_SOURCE', $config->get('default_setting_sent_per_source', 20));
+        $this->define_constant('DEFAULT_UNREAD_EXCLUDE_FEEDS', $config->get('default_setting_unread_exclude_feeds', false));
+        $this->define_constant('DEFAULT_LIST_STYLE', $config->get('default_setting_list_style', 'email_style'));
+        $this->define_constant('DEFAULT_IMAP_PER_PAGE', $config->get('default_setting_imap_per_page', 20));
+        $this->define_constant('DEFAULT_JUNK_SINCE', $config->get('default_setting_junk_since', '-1 week'));
+        $this->define_constant('DEFAULT_JUNK_PER_SOURCE', $config->get('default_setting_junk_per_source', 20));
+        $this->define_constant('DEFAULT_SNOOZED_SINCE', $config->get('default_setting_snoozed_since', '-1 week'));
+        $this->define_constant('DEFAULT_SNOOZED_PER_SOURCE', $config->get('default_setting_snoozed_per_source', 20));
+        $this->define_constant('DEFAULT_ENABLE_SNOOZE', $config->get('default_setting_enable_snooze', true));
+        $this->define_constant('DEFAULT_TAGS_SINCE', $config->get('default_setting_tags_since', '-1 week'));
+        $this->define_constant('DEFAULT_TAGS_PER_SOURCE', $config->get('default_setting_tags_per_source', 20));
+        $this->define_constant('DEFAULT_TRASH_SINCE', $config->get('default_setting_trash_since', '-1 week'));
+        $this->define_constant('DEFAULT_TRASH_PER_SOURCE', $config->get('default_setting_trash_per_source', 20));
+        $this->define_constant('DEFAULT_DRAFT_SINCE', $config->get('default_setting_draft_since', '-1 week'));
+        $this->define_constant('DEFAULT_DRAFT_PER_SOURCE', $config->get('default_setting_draft_per_source', 20));
+        $this->define_constant('DEFAULT_SIMPLE_MSG_PARTS', $config->get('default_setting_simple_msg_parts', false));
+        $this->define_constant('DEFAULT_MSG_PART_ICONS', $config->get('default_setting_msg_part_icons', true));
+        $this->define_constant('DEFAULT_PAGINATION_LINKS', $config->get('default_setting_pagination_links', true));
+        $this->define_constant('DEFAULT_REVIEW_SENT_EMAIL', $config->get('default_setting_review_sent_email', true));
+        $this->define_constant('DEFAULT_TEXT_ONLY', $config->get('default_setting_text_only', false));
+        $this->define_constant('DEFAULT_NO_PASSWORD_SAVE', $config->get('default_setting_no_password_save', false));
+        $this->define_constant('DEFAULT_SHOW_LIST_ICONS', $config->get('default_setting_show_list_icons', true));
+        $this->define_constant('DEFAULT_START_PAGE', $config->get('default_setting_start_page', "none"));
+        $this->define_constant('DEFAULT_DISABLE_DELETE_PROMPT', $config->get('default_setting_disable_delete_prompt', false));
+        $this->define_constant('DEFAULT_NO_FOLDER_ICONS', $config->get('default_setting_no_folder_icons', false));
+        $this->define_constant('DEFAULT_SETTING_LANGUAGE', $config->get('default_setting_language', 'en'));
+        $this->define_constant('DEFAULT_SMTP_COMPOSE_TYPE', $config->get('default_setting_smtp_compose_type', 0));
+        $this->define_constant('DEFAULT_SMTP_AUTO_BCC', $config->get('default_setting_smtp_auto_bcc', false));
+        $this->define_constant('DEFAULT_THEME', $config->get('default_setting_theme', 'default'));
+        $this->define_constant('DEFAULT_UNREAD_EXCLUDE_WORDPRESS', $config->get('default_setting_unread_exclude_wordpress', false));
+        $this->define_constant('DEFAULT_WORDPRESS_SINCE', $config->get('default_setting_wordpress_since', '-1 week'));
+        $this->define_constant('DEFAULT_UNREAD_EXCLUDE_GITHUB', $config->get('default_setting_unread_exclude_github', false));
+        $this->define_constant('DEFAULT_GITHUB_PER_SOURCE', $config->get('default_setting_github_limit', 20));
+        $this->define_constant('DEFAULT_GITHUB_SINCE', $config->get('default_setting_github_since', '-1 week'));
+        $this->define_constant('DEFAULT_INLINE_MESSAGE', $config->get('default_setting_inline_message', false));
+        $this->define_constant('DEFAULT_INLINE_MESSAGE_STYLE', $config->get('default_setting_inline_message_style', 'right'));
+        $this->define_constant('DEFAULT_ENABLE_KEYBOARD_SHORTCUTS', $config->get('default_setting_enable_keyboard_shortcuts', false));
+        $this->define_constant('DEFAULT_ENABLE_SIEVE_FILTER', $config->get('default_setting_enable_sieve_filter', false));
+        $this->define_constant('DEFAULT_ENABLE_COLLECT_ADDRESS_ON_SEND', $config->get('default_setting_enable_collect_address_on_send', false));
+        $this->define_constant('DEFAULT_SETTING_ENABLE_EXCLUDE_AUTO_BCC', $config->get('default_setting_enable_exclude_auto_bcc', true));
+    }
+
+    private function define_constant($name, $value) {
+        if (!defined($name)) {
+            define($name, $value);
+        }
     }
 
     /**

--- a/lib/format.php
+++ b/lib/format.php
@@ -110,7 +110,10 @@ class Hm_Format_HTML5 extends HM_Format {
         if (array_key_exists('router_module_list', $output)) {
             unset($output['router_module_list']);
         }
-        return implode('', $output);
+        if (array_is_list($output)) {
+            return implode('', $output);
+        }
+        return implode('', array_filter($output, 'is_string'));
     }
 }
 

--- a/lib/scram.php
+++ b/lib/scram.php
@@ -49,7 +49,7 @@ public function generateClientProof($username, $password, $salt, $clientNonce, $
     return $clientProof;
 }
 
-public function authenticateScram($scramAlgorithm, $username, $password, $getServerResponse, $sendCommand, $protocol = 'imap', callable $nonce_generator = null) {
+public function authenticateScram($scramAlgorithm, $username, $password, $getServerResponse, $sendCommand, $protocol = 'imap', ?callable $nonce_generator = null) {
     $algorithm = $this->getHashAlgorithm($scramAlgorithm);
     $nonce_generator = $nonce_generator ?? static fn() => base64_encode(random_bytes(32));
 

--- a/tests/phpunit/stubs.php
+++ b/tests/phpunit/stubs.php
@@ -96,6 +96,11 @@ if (!defined("IMAP_TEST")) {
         static public $allow_connection = true;
         static public $allow_auth = true;
         private $connected = false;
+        public $read_only = false;
+        public $search_charset = '';
+        public $use_cache = true;
+        public $selected_mailbox = false;
+        public $folder_state = false;
         public function get_state() { if (self::$allow_auth) { return $this->connected ? 'authenticated' : false; } return 'connected'; }
         public function connect() { if (self::$allow_connection) { $this->connected = true; return true; } return false; }
         public function show_debug() {}


### PR DESCRIPTION
<details>
    <summary>Issues</summary>
    8 tests triggered 54 PHP warnings:

1) /var/www/html/cyphtsecurity/lib/environment.php:41
Constant DEFAULT_SEARCH_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

2) /var/www/html/cyphtsecurity/lib/environment.php:42
Constant DEFAULT_UNREAD_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

3) /var/www/html/cyphtsecurity/lib/environment.php:43
Constant DEFAULT_UNREAD_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

4) /var/www/html/cyphtsecurity/lib/environment.php:44
Constant DEFAULT_FLAGGED_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

5) /var/www/html/cyphtsecurity/lib/environment.php:45
Constant DEFAULT_FLAGGED_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

6) /var/www/html/cyphtsecurity/lib/environment.php:46
Constant DEFAULT_SEARCH_ALL_FOLDERS already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

7) /var/www/html/cyphtsecurity/lib/environment.php:47
Constant DEFAULT_ALL_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

8) /var/www/html/cyphtsecurity/lib/environment.php:48
Constant DEFAULT_ALL_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

9) /var/www/html/cyphtsecurity/lib/environment.php:49
Constant DEFAULT_ALL_EMAIL_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

10) /var/www/html/cyphtsecurity/lib/environment.php:50
Constant DEFAULT_ALL_EMAIL_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

11) /var/www/html/cyphtsecurity/lib/environment.php:51
Constant DEFAULT_FEED_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

12) /var/www/html/cyphtsecurity/lib/environment.php:52
Constant DEFAULT_FEED_LIMIT already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

13) /var/www/html/cyphtsecurity/lib/environment.php:53
Constant DEFAULT_SENT_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

14) /var/www/html/cyphtsecurity/lib/environment.php:54
Constant DEFAULT_SENT_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

15) /var/www/html/cyphtsecurity/lib/environment.php:55
Constant DEFAULT_UNREAD_EXCLUDE_FEEDS already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

16) /var/www/html/cyphtsecurity/lib/environment.php:56
Constant DEFAULT_LIST_STYLE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

17) /var/www/html/cyphtsecurity/lib/environment.php:57
Constant DEFAULT_IMAP_PER_PAGE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

18) /var/www/html/cyphtsecurity/lib/environment.php:58
Constant DEFAULT_JUNK_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

19) /var/www/html/cyphtsecurity/lib/environment.php:59
Constant DEFAULT_JUNK_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

20) /var/www/html/cyphtsecurity/lib/environment.php:60
Constant DEFAULT_SNOOZED_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

21) /var/www/html/cyphtsecurity/lib/environment.php:61
Constant DEFAULT_SNOOZED_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

22) /var/www/html/cyphtsecurity/lib/environment.php:62
Constant DEFAULT_ENABLE_SNOOZE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

23) /var/www/html/cyphtsecurity/lib/environment.php:63
Constant DEFAULT_TAGS_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

24) /var/www/html/cyphtsecurity/lib/environment.php:64
Constant DEFAULT_TAGS_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

25) /var/www/html/cyphtsecurity/lib/environment.php:65
Constant DEFAULT_TRASH_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

26) /var/www/html/cyphtsecurity/lib/environment.php:66
Constant DEFAULT_TRASH_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

27) /var/www/html/cyphtsecurity/lib/environment.php:67
Constant DEFAULT_DRAFT_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

28) /var/www/html/cyphtsecurity/lib/environment.php:68
Constant DEFAULT_DRAFT_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

29) /var/www/html/cyphtsecurity/lib/environment.php:69
Constant DEFAULT_SIMPLE_MSG_PARTS already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

30) /var/www/html/cyphtsecurity/lib/environment.php:70
Constant DEFAULT_MSG_PART_ICONS already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

31) /var/www/html/cyphtsecurity/lib/environment.php:71
Constant DEFAULT_PAGINATION_LINKS already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

32) /var/www/html/cyphtsecurity/lib/environment.php:72
Constant DEFAULT_REVIEW_SENT_EMAIL already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

33) /var/www/html/cyphtsecurity/lib/environment.php:73
Constant DEFAULT_TEXT_ONLY already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

34) /var/www/html/cyphtsecurity/lib/environment.php:74
Constant DEFAULT_NO_PASSWORD_SAVE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

35) /var/www/html/cyphtsecurity/lib/environment.php:75
Constant DEFAULT_SHOW_LIST_ICONS already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

36) /var/www/html/cyphtsecurity/lib/environment.php:76
Constant DEFAULT_START_PAGE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

37) /var/www/html/cyphtsecurity/lib/environment.php:77
Constant DEFAULT_DISABLE_DELETE_PROMPT already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

38) /var/www/html/cyphtsecurity/lib/environment.php:78
Constant DEFAULT_NO_FOLDER_ICONS already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

39) /var/www/html/cyphtsecurity/lib/environment.php:79
Constant DEFAULT_SETTING_LANGUAGE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

40) /var/www/html/cyphtsecurity/lib/environment.php:80
Constant DEFAULT_SMTP_COMPOSE_TYPE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

41) /var/www/html/cyphtsecurity/lib/environment.php:81
Constant DEFAULT_SMTP_AUTO_BCC already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

42) /var/www/html/cyphtsecurity/lib/environment.php:82
Constant DEFAULT_THEME already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

43) /var/www/html/cyphtsecurity/lib/environment.php:83
Constant DEFAULT_UNREAD_EXCLUDE_WORDPRESS already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

44) /var/www/html/cyphtsecurity/lib/environment.php:84
Constant DEFAULT_WORDPRESS_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

45) /var/www/html/cyphtsecurity/lib/environment.php:85
Constant DEFAULT_UNREAD_EXCLUDE_GITHUB already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

46) /var/www/html/cyphtsecurity/lib/environment.php:86
Constant DEFAULT_GITHUB_PER_SOURCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

47) /var/www/html/cyphtsecurity/lib/environment.php:87
Constant DEFAULT_GITHUB_SINCE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

48) /var/www/html/cyphtsecurity/lib/environment.php:88
Constant DEFAULT_INLINE_MESSAGE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

49) /var/www/html/cyphtsecurity/lib/environment.php:89
Constant DEFAULT_INLINE_MESSAGE_STYLE already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

50) /var/www/html/cyphtsecurity/lib/environment.php:90
Constant DEFAULT_ENABLE_KEYBOARD_SHORTCUTS already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

51) /var/www/html/cyphtsecurity/lib/environment.php:91
Constant DEFAULT_ENABLE_SIEVE_FILTER already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

52) /var/www/html/cyphtsecurity/lib/environment.php:92
Constant DEFAULT_ENABLE_COLLECT_ADDRESS_ON_SEND already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

53) /var/www/html/cyphtsecurity/lib/environment.php:93
Constant DEFAULT_SETTING_ENABLE_EXCLUDE_AUTO_BCC already defined

Triggered by:

* Hm_Test_Environment::test_define_default_constants_defines_all_expected_constants
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:128

* Hm_Test_Environment::test_define_default_constants_sets_numeric_defaults
  /var/www/html/cyphtsecurity/tests/phpunit/environment.php:143

54) /var/www/html/cyphtsecurity/lib/format.php:113
Array to string conversion

Triggered by:

* Hm_Test_Dispatch::test_check_for_redirect
  /var/www/html/cyphtsecurity/tests/phpunit/dispatch.php:92

* Hm_Test_Dispatch::test_get_page
  /var/www/html/cyphtsecurity/tests/phpunit/dispatch.php:53

* Hm_Test_Dispatch::test_init_with_site_lib
  /var/www/html/cyphtsecurity/tests/phpunit/dispatch.php:28

* Hm_Test_Dispatch::test_process_request
  /var/www/html/cyphtsecurity/tests/phpunit/dispatch.php:41

* Hm_Test_Dispatch::test_validate_ajax_request
  /var/www/html/cyphtsecurity/tests/phpunit/dispatch.php:127

* Hm_Test_Dispatch::test_validate_request_uri
  /var/www/html/cyphtsecurity/tests/phpunit/dispatch.php:75

--

9 tests triggered 9 PHP deprecations:

1) /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:396
Creation of dynamic property MockObject_Hm_IMAP_3f113874::$selected_mailbox is deprecated

Triggered by:

* Hm_Test_Mailbox::test_search_functionality
  /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:392

2) /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:424
Creation of dynamic property MockObject_Hm_IMAP_d85714ea::$selected_mailbox is deprecated

Triggered by:

* Hm_Test_Mailbox::test_search_without_sort_support
  /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:417

3) /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:456
Creation of dynamic property MockObject_Hm_IMAP_56a48a7f::$selected_mailbox is deprecated

Triggered by:

* Hm_Test_Mailbox::test_search_without_sorting
  /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:449

4) /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:479
Creation of dynamic property MockObject_Hm_IMAP_a6df69f5::$selected_mailbox is deprecated

Triggered by:

* Hm_Test_Mailbox::test_search_folder_selection_fails
  /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:475

5) /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:1071
Creation of dynamic property MockObject_Hm_IMAP_0fc336b0::$folder_state is deprecated

Triggered by:

* Hm_Test_Mailbox::test_get_folder_state_returns_imap_connection_property
  /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:1069

6) /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:1082
Creation of dynamic property MockObject_Hm_IMAP_c1e8672a::$selected_mailbox is deprecated

Triggered by:

* Hm_Test_Mailbox::test_get_selected_folder_returns_imap_connection_property
  /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:1080

7) /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:1161
Creation of dynamic property MockObject_Hm_IMAP_43fe95b2::$use_cache is deprecated

Triggered by:

* Hm_Test_Mailbox::test_use_cache_returns_connection_property_for_imap
  /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:1159

8) /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:1238
Creation of dynamic property MockObject_Hm_IMAP_f4c366d5::$read_only is deprecated

Triggered by:

* Hm_Test_Mailbox::test_set_read_only_sets_property_on_imap_connection
  /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:1236

9) /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:1250
Creation of dynamic property MockObject_Hm_IMAP_be540151::$search_charset is deprecated

Triggered by:

* Hm_Test_Mailbox::test_set_search_charset_sets_property_on_imap_connection
  /var/www/html/cyphtsecurity/tests/phpunit/modules/core/mailbox.php:1248

OK, but there were issues!
Tests: 857, Assertions: 1731, Warnings: 54, Deprecations: 9, Skipped: 15.
</details>