### PR TITLE
fix(backend): allowed memory size of 134217728 bytes exhausted (tried to allocate 53145280 bytes)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,6 +56,7 @@ xdebug.client_host=host.docker.internal" > /usr/local/etc/php/conf.d/xdebug.ini
 
 RUN printf "post_max_size = 60M \n\
 upload_max_filesize = 50M \n\
+memory_limit = 256M \n\
 open_basedir = /var/lib/hm3/:/usr/local/share/cypht/:/tmp:/usr/local/bin:/tmp/composer_cache:/tmp/composer_home:/etc" > /usr/local/etc/php/conf.d/cypht.ini
 
 # Composer

--- a/lib/crypt.php
+++ b/lib/crypt.php
@@ -293,3 +293,181 @@ class Hm_Crypt_Base {
         }
     }
 }
+
+/**
+ * Streaming, chunked authenticated encryption for payloads that must not be
+ * fully buffered in memory (e.g. large mail attachments). This is a separate
+ * format from Hm_Crypt::ciphertext()/plaintext() (not used for sessions or
+ * passwords) and always uses OpenSSL, independent of the LIBSODIUM extension.
+ *
+ * File format:
+ *   [16 bytes salt]
+ *   repeated: [4 bytes BE ciphertext length][ciphertext][1 byte final-flag][32 bytes HMAC-SHA256 tag]
+ *   tag = HMAC-SHA256(chunk_index(4 bytes BE) . final-flag(1 byte) . ciphertext, hmac_key)
+ *
+ * Each chunk is individually authenticated so a reader can verify and reject
+ * tampered data before ever handing out its plaintext, and the final-flag
+ * lets a reader detect a truncated stream instead of silently accepting a
+ * short read as a complete one.
+ *
+ * @package framework
+ * @subpackage crypt
+ */
+class Hm_Crypt_Stream_Writer {
+
+    const CHUNK_SIZE = 1048576;
+    const PBKDF2_ROUNDS = 100;
+    const PBKDF2_ALGO = 'sha512';
+
+    private $fp;
+    private $crypt_key;
+    private $hmac_key;
+    private $chunk_index = 0;
+    private $buffer = '';
+    private $closed = false;
+
+    /**
+     * @param string $path destination file path
+     * @param string $key encryption key
+     */
+    public function __construct($path, $key) {
+        $this->fp = fopen($path, 'wb');
+        if (!$this->fp) {
+            throw new Exception(sprintf('Unable to open %s for writing', $path));
+        }
+        $salt = Hm_Crypt_Base::random(16);
+        $this->crypt_key = Hm_Crypt_Base::pbkdf2($key, $salt.'enc', 32, self::PBKDF2_ROUNDS, self::PBKDF2_ALGO);
+        $this->hmac_key = Hm_Crypt_Base::pbkdf2($key, $salt.'mac', 32, self::PBKDF2_ROUNDS, self::PBKDF2_ALGO);
+        fwrite($this->fp, $salt);
+    }
+
+    /**
+     * Encrypt and write a chunk of plaintext once enough has been buffered
+     * @param string $data plaintext to append to the stream
+     * @return void
+     */
+    public function write($data) {
+        $this->buffer .= $data;
+        while (strlen($this->buffer) >= self::CHUNK_SIZE) {
+            $this->write_chunk(substr($this->buffer, 0, self::CHUNK_SIZE), false);
+            $this->buffer = substr($this->buffer, self::CHUNK_SIZE);
+        }
+    }
+
+    /**
+     * Flush any buffered plaintext as the final, authenticated chunk and
+     * close the destination file
+     * @return void
+     */
+    public function close() {
+        if ($this->closed) {
+            return;
+        }
+        $this->write_chunk($this->buffer, true);
+        $this->buffer = '';
+        fclose($this->fp);
+        $this->closed = true;
+    }
+
+    private function write_chunk($data, $final) {
+        $iv = substr(hash_hmac('sha256', pack('N', $this->chunk_index), $this->crypt_key, true), 0, 16);
+        $ciphertext = openssl_encrypt($data, 'aes-256-cbc', $this->crypt_key, OPENSSL_RAW_DATA, $iv);
+        $flag = $final ? "\x01" : "\x00";
+        $tag = hash_hmac('sha256', pack('N', $this->chunk_index).$flag.$ciphertext, $this->hmac_key, true);
+        fwrite($this->fp, pack('N', strlen($ciphertext)).$ciphertext.$flag.$tag);
+        $this->chunk_index++;
+    }
+}
+
+/**
+ * Reader counterpart to Hm_Crypt_Stream_Writer. Verifies each chunk's
+ * authentication tag before returning its plaintext, so tampered or
+ * truncated data is rejected without ever handing out unauthenticated bytes.
+ * @package framework
+ * @subpackage crypt
+ */
+class Hm_Crypt_Stream_Reader {
+
+    private $fp;
+    private $crypt_key;
+    private $hmac_key;
+    private $chunk_index = 0;
+    private $finished = false;
+
+    /**
+     * @param string $path source file path, as written by Hm_Crypt_Stream_Writer
+     * @param string $key encryption key
+     */
+    public function __construct($path, $key) {
+        $this->fp = fopen($path, 'rb');
+        if (!$this->fp) {
+            throw new Exception(sprintf('Unable to open %s for reading', $path));
+        }
+        $salt = $this->read_exact(16);
+        if ($salt === false) {
+            throw new Exception('Truncated stream: missing salt');
+        }
+        $this->crypt_key = Hm_Crypt_Base::pbkdf2($key, $salt.'enc', 32, Hm_Crypt_Stream_Writer::PBKDF2_ROUNDS, Hm_Crypt_Stream_Writer::PBKDF2_ALGO);
+        $this->hmac_key = Hm_Crypt_Base::pbkdf2($key, $salt.'mac', 32, Hm_Crypt_Stream_Writer::PBKDF2_ROUNDS, Hm_Crypt_Stream_Writer::PBKDF2_ALGO);
+    }
+
+    /**
+     * Read, verify, and decrypt the next chunk
+     * @return string|false decrypted plaintext, or false once the
+     *                       authenticated end of the stream has been reached
+     */
+    public function read() {
+        if ($this->finished) {
+            return false;
+        }
+        $len_bytes = $this->read_exact(4);
+        if ($len_bytes === false) {
+            throw new Exception('Truncated stream: missing chunk header');
+        }
+        $len = unpack('N', $len_bytes)[1];
+        $ciphertext = $this->read_exact($len);
+        $flag = $this->read_exact(1);
+        $tag = $this->read_exact(32);
+        if ($ciphertext === false || $flag === false || $tag === false) {
+            throw new Exception('Truncated stream: incomplete chunk');
+        }
+        $expected_tag = hash_hmac('sha256', pack('N', $this->chunk_index).$flag.$ciphertext, $this->hmac_key, true);
+        if (!Hm_Crypt_Base::hash_compare($expected_tag, $tag)) {
+            throw new Exception('Stream authentication failed: data may have been tampered with');
+        }
+        $iv = substr(hash_hmac('sha256', pack('N', $this->chunk_index), $this->crypt_key, true), 0, 16);
+        $plaintext = openssl_decrypt($ciphertext, 'aes-256-cbc', $this->crypt_key, OPENSSL_RAW_DATA, $iv);
+        $this->chunk_index++;
+        if ($flag === "\x01") {
+            $this->finished = true;
+        }
+        return $plaintext;
+    }
+
+    /**
+     * @return void
+     */
+    public function close() {
+        if (is_resource($this->fp)) {
+            fclose($this->fp);
+        }
+    }
+
+    private function read_exact($size) {
+        if ($size === 0) {
+            return '';
+        }
+        $data = '';
+        while (strlen($data) < $size) {
+            if (feof($this->fp)) {
+                return false;
+            }
+            $chunk = fread($this->fp, $size - strlen($data));
+            if ($chunk === false || $chunk === '') {
+                return false;
+            }
+            $data .= $chunk;
+        }
+        return $data;
+    }
+}

--- a/lib/crypt.php
+++ b/lib/crypt.php
@@ -325,20 +325,68 @@ class Hm_Crypt_Stream_Writer {
     private $chunk_index = 0;
     private $buffer = '';
     private $closed = false;
+    private $salt;
 
     /**
      * @param string $path destination file path
      * @param string $key encryption key
+     * @param string|null $salt reuse a previously generated salt (see
+     *                           get_salt()) instead of generating a new one -
+     *                           needed to resume writing the same encrypted
+     *                           stream from a later, separate process/request
+     * @param int $start_index chunk index to continue counting from, when
+     *                         resuming a stream started by an earlier writer
+     * @param bool $append open the destination file for appending instead of
+     *                     truncating it, and skip writing the salt header
+     *                     again - set this together with $salt/$start_index
+     *                     when resuming
      */
-    public function __construct($path, $key) {
-        $this->fp = fopen($path, 'wb');
+    public function __construct($path, $key, $salt = null, $start_index = 0, $append = false) {
+        $this->fp = fopen($path, $append ? 'ab' : 'wb');
         if (!$this->fp) {
             throw new Exception(sprintf('Unable to open %s for writing', $path));
         }
-        $salt = Hm_Crypt_Base::random(16);
-        $this->crypt_key = Hm_Crypt_Base::pbkdf2($key, $salt.'enc', 32, self::PBKDF2_ROUNDS, self::PBKDF2_ALGO);
-        $this->hmac_key = Hm_Crypt_Base::pbkdf2($key, $salt.'mac', 32, self::PBKDF2_ROUNDS, self::PBKDF2_ALGO);
-        fwrite($this->fp, $salt);
+        $this->salt = $salt !== null ? $salt : Hm_Crypt_Base::random(16);
+        $this->crypt_key = Hm_Crypt_Base::pbkdf2($key, $this->salt.'enc', 32, self::PBKDF2_ROUNDS, self::PBKDF2_ALGO);
+        $this->hmac_key = Hm_Crypt_Base::pbkdf2($key, $this->salt.'mac', 32, self::PBKDF2_ROUNDS, self::PBKDF2_ALGO);
+        $this->chunk_index = $start_index;
+        if (! $append) {
+            fwrite($this->fp, $this->salt);
+        }
+    }
+
+    /**
+     * The salt this writer generated (or was given), needed by a later
+     * writer to resume this same stream
+     * @return string
+     */
+    public function get_salt() {
+        return $this->salt;
+    }
+
+    /**
+     * The chunk index the next write will use, needed by a later writer to
+     * resume this same stream
+     * @return int
+     */
+    public function get_next_chunk_index() {
+        return $this->chunk_index;
+    }
+
+    /**
+     * Encrypt and write exactly one chunk immediately (no buffering), then
+     * release the file handle. For a writer used once per incoming piece of
+     * data across separate requests/processes (e.g. one HTTP request per
+     * upload chunk), where each caller must flush and hand off rather than
+     * hold the handle open.
+     * @param string $data plaintext chunk
+     * @param bool $final whether this is the last chunk of the stream
+     * @return void
+     */
+    public function write_chunk_now($data, $final) {
+        $this->write_chunk($data, $final);
+        fclose($this->fp);
+        $this->closed = true;
     }
 
     /**

--- a/modules/core/hm-mailbox.php
+++ b/modules/core/hm-mailbox.php
@@ -689,6 +689,9 @@ class Hm_Mailbox {
                 $from_params = '';
                 $recipients_params = '';
             }
+            if ($message instanceof Hm_MIME_Msg) {
+                return $this->connection->send_mime_message($from, $recipients, $message, $from_params, $recipients_params);
+            }
             return $this->connection->send_message($from, $recipients, $message, $from_params, $recipients_params);
         } else {
             return $this->connection->send_message($from, $recipients, $message, $delivery_receipt);

--- a/modules/core/hm-mailbox.php
+++ b/modules/core/hm-mailbox.php
@@ -477,6 +477,64 @@ class Hm_Mailbox {
         }
     }
 
+    /**
+     * Stream a message part (or, with $part_id = 0, the whole raw message)
+     * straight from the IMAP server into an encrypted local file, without
+     * ever buffering the full part in memory. Mirrors stream_message_part()
+     * above but writes to a Hm_Crypt_Stream_Writer instead of echoing to
+     * the HTTP response, so it can be used for attachment forwarding.
+     * @param string $folder IMAP folder
+     * @param int $msg_id IMAP message UID
+     * @param string $part_id IMAP part number, or 0 for the whole message
+     * @param string $dest_path destination file path
+     * @param string $key encryption key for the destination file
+     * @return int|false decoded byte count written, or false on failure
+     */
+    public function stream_message_part_to_file($folder, $msg_id, $part_id, $dest_path, $key) {
+        if (! $this->select_folder($folder)) {
+            return false;
+        }
+        if (! $this->is_imap()) {
+            return false;
+        }
+        $encoding = false;
+        $is_text = false;
+        $msg_struct = $this->connection->get_message_structure($msg_id);
+        $struct = $this->connection->search_bodystructure($msg_struct, array('imap_part_number' => $part_id));
+        if (! empty($struct)) {
+            $part_struct = array_shift($struct);
+            if (array_key_exists('encoding', $part_struct)) {
+                $encoding = trim(mb_strtolower($part_struct['encoding']));
+            }
+            $is_text = ($part_struct['type'] == 'text');
+        }
+        $stream_size = $this->connection->start_message_stream($msg_id, $part_id);
+        if (! ($stream_size > 0)) {
+            return false;
+        }
+        $writer = new Hm_Crypt_Stream_Writer($dest_path, $key);
+        $decoded_size = 0;
+        $output_line = '';
+        while ($line = $this->connection->read_stream_line()) {
+            if ($encoding == 'quoted-printable') {
+                $line = quoted_printable_decode($line);
+            }
+            elseif ($encoding == 'base64') {
+                $line = base64_decode($line);
+            }
+            $decoded_size += strlen($output_line);
+            $writer->write($output_line);
+            $output_line = $line;
+        }
+        if ($is_text) {
+            $output_line = preg_replace("/\)(\r\n)$/m", '$1', $output_line);
+        }
+        $decoded_size += strlen($output_line);
+        $writer->write($output_line);
+        $writer->close();
+        return $decoded_size;
+    }
+
     public function remove_attachment($folder, $msg_id, $part_id) {
         if (! $this->select_folder($folder)) {
             return;

--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -627,17 +627,17 @@ function get_imap_size($vals) {
     }
     $size = intval($vals['size']);
     switch (true) {
-        case $size > 1000:
-            $size = $size/1000;
-            $label = 'KB';
+        case $size > 1000000000:
+            $size = $size/1000000000;
+            $label = 'GB';
             break;
         case $size > 1000000:
             $size = $size/1000000;
             $label = 'MB';
             break;
-        case $size > 1000000000:
-            $size = $size/1000000000;
-            $label = 'GB';
+        case $size > 1000:
+            $size = $size/1000;
+            $label = 'KB';
             break;
         default:
             $label = 'B';
@@ -715,36 +715,117 @@ function format_attachment($struct,  $output_mod, $part, $dl_args, $at_args) {
     return $res;
 }
 
+if (!hm_exists('get_attachment_tone')) {
+function get_attachment_tone($ext) {
+    $map = array(
+        'pdf' => 'pdf',
+        'doc' => 'doc', 'docx' => 'doc',
+        'xls' => 'xls', 'xlsx' => 'xls', 'csv' => 'xls',
+        'ppt' => 'ppt', 'pptx' => 'ppt',
+        'zip' => 'zip', 'rar' => 'zip', '7z' => 'zip',
+        'txt' => 'txt',
+    );
+    return $map[$ext] ?? 'default';
+}}
+
+if (!hm_exists('get_attachment_icon_class')) {
+function get_attachment_icon_class($ext) {
+    $map = array(
+        'pdf' => 'bi-file-earmark-pdf-fill',
+        'doc' => 'bi-file-earmark-word-fill', 'docx' => 'bi-file-earmark-word-fill',
+        'xls' => 'bi-file-earmark-excel-fill', 'xlsx' => 'bi-file-earmark-excel-fill',
+        'ppt' => 'bi-file-earmark-ppt-fill', 'pptx' => 'bi-file-earmark-ppt-fill',
+        'zip' => 'bi-file-earmark-zip-fill', 'rar' => 'bi-file-earmark-zip-fill', '7z' => 'bi-file-earmark-zip-fill',
+        'txt' => 'bi-file-earmark-text-fill',
+        'csv' => 'bi-file-earmark-spreadsheet-fill',
+    );
+    return 'bi '.($map[$ext] ?? 'bi-file-earmark-fill');
+}}
+
+if (!hm_exists('format_attachment_card')) {
+function format_attachment_card($id, $vals, $output_mod, $dl_link, $show_link) {
+    $name = get_part_desc($vals, $id, false);
+    $href = '?'.$dl_link.'&amp;imap_msg_part='.$output_mod->html_safe($id);
+    $download_btn = '<span class="attachment_card_download"><i class="bi bi-download"></i></span>';
+    if ($vals['type'] === 'image') {
+        $src = '?'.$show_link.'&amp;imap_msg_part='.$output_mod->html_safe($id);
+        $thumb = '<div class="attachment_card_thumb is_image">'.
+            '<img src="'.$src.'" loading="lazy" alt="">'.$download_btn.'</div>';
+    }
+    else {
+        $ext = mb_strtolower(pathinfo($name, PATHINFO_EXTENSION));
+        $tone = get_attachment_tone($ext);
+        $thumb = '<div class="attachment_card_thumb is_icon attachment_tone_'.$tone.'">'.
+            '<span class="attachment_card_icon '.get_attachment_icon_class($ext).'"></span>'.
+            '<span class="attachment_card_ext">'.$output_mod->html_safe($ext ?: '?').'</span>'.
+            $download_btn.'</div>';
+    }
+    return '<div class="col-6 col-md-3 col-lg-2">'.
+        '<a class="attachment_card" href="'.$href.'" data-src="'.$href.'" title="'.$output_mod->html_safe($name).'">'.
+            $thumb.
+            '<div class="attachment_card_meta">'.
+                '<div class="attachment_card_name">'.$output_mod->html_safe($name).'</div>'.
+                '<div class="attachment_card_size">'.$output_mod->html_safe(get_imap_size($vals)).'</div>'.
+            '</div>'.
+        '</a>'.
+        '</div>';
+}}
+
 /**
- * Format the attached images section
+ * Collect downloadable attachments and embedded images from a message
+ * structure
+ * @subpackage imap/functions
+ * @param array $struct message structure
+ * @return array list of [id, vals]
+ */
+if (!hm_exists('collect_attachment_parts')) {
+function collect_attachment_parts($struct) {
+    $found = array();
+    foreach ($struct as $id => $vals) {
+        if (is_array($vals) && (($vals['type'] ?? '') === 'image' || isset($vals['file_attributes']['attachment']))) {
+            $found[] = array($id, $vals);
+        }
+        if (isset($vals['subs'])) {
+            $found = array_merge($found, collect_attachment_parts($vals['subs']));
+        }
+    }
+    return $found;
+}}
+
+/**
+ * Card grid for downloadable attachments and embedded images, rendered
+ * above the technical message part table
  * @subpackage imap/functions
  * @param array $struct message structure
  * @param object $output_mod Hm_Output_Module
  * @param string $dl_link base arguments for a download link
+ * @param string $show_link base arguments for an inline display link
  * @return string
  */
-if (!hm_exists('format_attached_image_section')) {
-function format_attached_image_section($struct, $output_mod, $dl_link) {
-    $res = '';
-    $isThereAnyImg = false;
-    foreach ($struct as $id => $vals) {
-        if ($vals['type'] === 'image') {
-            $res .= '<div class="col-6 col-md-3">
-                        <img class="attached_image img-fluid" 
-                             src="?' . $dl_link . '&amp;imap_msg_part=' . $output_mod->html_safe($id) . '" >
-                     </div>';
-            $isThereAnyImg = true;
-        }
-        if (isset($vals['subs'])) {
-            $res .= format_attached_image_section($vals['subs'], $output_mod, $dl_link);
-        }
+if (!hm_exists('format_attached_files_section')) {
+function format_attached_files_section($struct, $output_mod, $dl_link, $show_link) {
+    $parts = collect_attachment_parts($struct);
+    if (! $parts) {
+        return '';
     }
-
-    if ($isThereAnyImg) {
-        $res = '<div class="container-fluid"><div class="row text-center attached_image_box">' . $res . '</div></div>';
+    $total_size = 0;
+    $cards = '';
+    foreach ($parts as $part) {
+        list($id, $vals) = $part;
+        $total_size += intval($vals['size'] ?? 0);
+        $cards .= format_attachment_card($id, $vals, $output_mod, $dl_link, $show_link);
     }
-
-    return $res;
+    $count = count($parts);
+    $heading = '<div class="attached_files_heading">'.
+        '<span class="attached_files_label"><i class="bi bi-paperclip"></i> '.
+            sprintf($output_mod->trans($count == 1 ? '%d attachment' : '%d attachments'), $count).
+            ' <span class="attached_files_total">&middot; '.$output_mod->html_safe(get_imap_size(array('size' => $total_size))).'</span>'.
+        '</span>';
+    if ($count > 1) {
+        $heading .= '<a href="#" class="attached_files_download_all"><i class="bi bi-download"></i> '.$output_mod->trans('Download all').'</a>';
+    }
+    $heading .= '</div>';
+    return '<div class="attached_files_box">'.$heading.'<div class="row attached_files_grid">'.$cards.'</div></div>';
 }}
 
 /**

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -336,28 +336,36 @@ class Hm_Handler_imap_save_sent extends Hm_Handler_Module {
         $imap_id = $this->get('save_sent_server');
         $mime = $this->get('save_sent_msg');
 
-        if ($imap_id === false) {
-            return;
-        }
-        $msg = $mime->get_mime_msg();
-        $msg = str_replace("\r\n", "\n", $msg);
-        $msg = str_replace("\n", "\r\n", $msg);
-        $msg = rtrim($msg)."\r\n";
-        $imap_details = Hm_IMAP_List::dump($imap_id);
-        $mailbox = Hm_IMAP_List::get_connected_mailbox($imap_id, $this->cache);
-        if ($mailbox && $mailbox->authed()) {
-            list($uid, $sent_folder) = save_sent_msg($this, $imap_id, $mailbox, $imap_details, $msg, $mime->get_headers()['Message-Id']);
-            if ($uid) {
-                $this->out('sent_msg_uid', $uid);
-                $this->out('sent_imap_id', $imap_id);
+        if ($imap_id !== false) {
+            $msg = $mime->get_mime_msg();
+            $msg = str_replace("\r\n", "\n", $msg);
+            $msg = str_replace("\n", "\r\n", $msg);
+            $msg = rtrim($msg)."\r\n";
+            $imap_details = Hm_IMAP_List::dump($imap_id);
+            $mailbox = Hm_IMAP_List::get_connected_mailbox($imap_id, $this->cache);
+            if ($mailbox && $mailbox->authed()) {
+                list($uid, $sent_folder) = save_sent_msg($this, $imap_id, $mailbox, $imap_details, $msg, $mime->get_headers()['Message-Id']);
+                if ($uid) {
+                    $this->out('sent_msg_uid', $uid);
+                    $this->out('sent_imap_id', $imap_id);
 
-                if ($this->user_config->get('review_sent_email_setting', false)) {
-                    $this->out('redirect_url', $this->build_page_url('message', array(
-                        'uid' => $uid,
-                        'list_path' => 'imap_'.$imap_id.'_'.bin2hex($sent_folder),
-                    )));
+                    if ($this->user_config->get('review_sent_email_setting', false)) {
+                        $this->out('redirect_url', $this->build_page_url('message', array(
+                            'uid' => $uid,
+                            'list_path' => 'imap_'.$imap_id.'_'.bin2hex($sent_folder),
+                        )));
+                    }
                 }
             }
+        }
+
+        /* attachment files on disk are kept around until this point so
+         * $mime->get_mime_msg() above can still re-read their content for
+         * the sent-folder copy; safe to clean them up now */
+        $draft_id = $this->get('compose_draft_id', 0);
+        delete_uploaded_files($this->session, $draft_id);
+        if ($draft_id > 0) {
+            delete_uploaded_files($this->session, 0);
         }
     }
 }

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -359,9 +359,6 @@ class Hm_Handler_imap_save_sent extends Hm_Handler_Module {
             }
         }
 
-        /* attachment files on disk are kept around until this point so
-         * $mime->get_mime_msg() above can still re-read their content for
-         * the sent-folder copy; safe to clean them up now */
         $draft_id = $this->get('compose_draft_id', 0);
         delete_uploaded_files($this->session, $draft_id);
         if ($draft_id > 0) {

--- a/modules/imap/js_modules/utils/attachements.js
+++ b/modules/imap/js_modules/utils/attachements.js
@@ -1,41 +1,56 @@
-function handleAttachementDownload() {
-    $('.download_link a').on("click", async function(e) {
-        e.preventDefault();
-        const loaderInstance = showLoaderToast("Downloading attachment...");
-        const href = $(this).data('src');
-        try {
-            const res = await fetch(href);
+async function downloadAttachment(href, showToast = true) {
+    const loaderInstance = showToast ? showLoaderToast("Downloading attachment...") : false;
+    try {
+        const res = await fetch(href);
 
-            if (!res.ok) {
-                throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-            }
+        if (!res.ok) {
+            throw new Error(`Download failed: ${res.status} ${res.statusText}`);
+        }
 
-            // Extract filename from Content-Disposition header if present
-            const disposition = res.headers.get('Content-Disposition') || '';
-            const filenameMatch = disposition.match(
-                /filename\*?=(?:UTF-8'')?"?([^;\r\n"]+)"/i
-            );
-            const filename = filenameMatch?.[1] || 'attachment';
-            const blob = await res.blob();
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = filename;
-            a.click();  
+        // Extract filename from Content-Disposition header if present
+        const disposition = res.headers.get('Content-Disposition') || '';
+        const filenameMatch = disposition.match(
+            /filename\*?=(?:UTF-8'')?"?([^;\r\n"]+)"/i
+        );
+        const filename = filenameMatch?.[1] || 'attachment';
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
 
-            /**
-             * We delay revocation of the blob URL to ensure the browser’s download
-             * mechanism has had time to consume it. Immediate revocation in some
-             * browsers (notably Safari/WebKit) can abort or corrupt the download.
-             */
-            const tm = setTimeout(() => {
-                URL.revokeObjectURL(url);
-                clearTimeout(tm);
-            }, 1000);
-        } catch (error) {
-            Hm_Notices.show(error.message, 'danger');
-        } finally {
+        /**
+         * We delay revocation of the blob URL to ensure the browser’s download
+         * mechanism has had time to consume it. Immediate revocation in some
+         * browsers (notably Safari/WebKit) can abort or corrupt the download.
+         */
+        const tm = setTimeout(() => {
+            URL.revokeObjectURL(url);
+            clearTimeout(tm);
+        }, 1000);
+    } catch (error) {
+        Hm_Notices.show(error.message, 'danger');
+    } finally {
+        if (loaderInstance) {
             loaderInstance.hide();
         }
+    }
+}
+
+function handleAttachementDownload() {
+    $('.download_link a, .attachment_card').on("click", function(e) {
+        e.preventDefault();
+        downloadAttachment($(this).data('src'));
+    });
+
+    $('.attached_files_download_all').on("click", async function(e) {
+        e.preventDefault();
+        const cards = $(this).closest('.attached_files_box').find('.attachment_card');
+        const loaderInstance = showLoaderToast("Downloading attachments...");
+        for (const card of cards) {
+            await downloadAttachment($(card).data('src'), false);
+        }
+        loaderInstance.hide();
     });
 }

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -210,7 +210,12 @@ class Hm_Output_filter_message_struct extends Hm_Output_Module {
             $showMsgArgs = $this->get('msg_show_args', '');
             $res .=  format_msg_part_section($this->get('msg_struct'), $this, $part, $args, $att_args);
             $res .= '</table>';
-            $res .= format_attached_image_section($this->get('msg_struct'), $this, $showMsgArgs);
+            $res = '<div class="msg_parts_toggle">'.
+                '<button type="button" class="btn btn-link p-0" data-bs-toggle="collapse" data-bs-target="#msg_parts_details" aria-expanded="false" aria-controls="msg_parts_details">'.
+                    '<i class="bi bi-chevron-down"></i> '.$this->trans('View technical details').
+                '</button></div>'.
+                '<div class="collapse" id="msg_parts_details">'.$res.'</div>';
+            $res = format_attached_files_section($this->get('msg_struct'), $this, $args, $showMsgArgs).$res;
             $this->out('msg_parts', $res);
         }
     }

--- a/modules/imap/site.css
+++ b/modules/imap/site.css
@@ -474,14 +474,208 @@
   padding-left: 20px;
 }
 
-.attached_image {
-  margin-right: 20px;
-  margin-bottom: 20px;
-  height: 200px;
+.msg_parts_toggle {
+  padding: 0.75rem 0;
 }
-.attached_image_box {
-  border-top: solid 1px #ddd;
-  padding-top: 1rem;
+.msg_parts_toggle button {
+  font-size: 0.78rem;
+  color: var(--bs-secondary-color, #777);
+  text-decoration: none;
+}
+.msg_parts_toggle button:hover {
+  color: var(--bs-body-color, #333);
+}
+.msg_parts_toggle .bi-chevron-down {
+  display: inline-block;
+  transition: transform 150ms ease;
+}
+.msg_parts_toggle button[aria-expanded="true"] .bi-chevron-down {
+  transform: rotate(180deg);
+}
+
+:root {
+  --attachment_tone_pdf: #d64545;    --attachment_tint_pdf: #d6454514;
+  --attachment_tone_doc: #3161d1;    --attachment_tint_doc: #3161d114;
+  --attachment_tone_xls: #1c8a5e;    --attachment_tint_xls: #1c8a5e14;
+  --attachment_tone_ppt: #d1762f;    --attachment_tint_ppt: #d1762f14;
+  --attachment_tone_zip: #8438c9;    --attachment_tint_zip: #8438c914;
+  --attachment_tone_txt: var(--bs-secondary-color, #777); --attachment_tint_txt: var(--bs-secondary-bg, #f3f4f6);
+  --attachment_tone_default: var(--bs-secondary-color, #777); --attachment_tint_default: var(--bs-secondary-bg, #f3f4f6);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --attachment_tone_pdf: #ef6a6a;
+    --attachment_tone_doc: #6c9bff;
+    --attachment_tone_xls: #4fca97;
+    --attachment_tone_ppt: #e8974f;
+    --attachment_tone_zip: #b98af5;
+  }
+}
+
+.attached_files_box {
+  padding-bottom: 1.25rem;
+  margin-bottom: 1rem;
+  border-bottom: solid 1px var(--bs-border-color, #ddd);
+}
+.attached_files_heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+.attached_files_label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--bs-secondary-color, #666);
+}
+.attached_files_total {
+  font-weight: 400;
+}
+.attached_files_download_all {
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.attached_files_grid {
+  --bs-gutter-y: 0.85rem;
+}
+
+.attachment_card {
+  display: flex;
+  flex-direction: column;
+  border: solid 1px var(--bs-border-color, #ddd);
+  border-radius: 12px;
+  background: var(--bs-body-bg, #fff);
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+  cursor: pointer;
+  transition: box-shadow 200ms ease, transform 200ms ease, border-color 200ms ease;
+}
+.attachment_card:hover,
+.attachment_card:focus-visible {
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.14), 0 3px 8px rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  transform: translateY(-3px);
+  color: inherit;
+  outline: none;
+}
+.attachment_card:focus-visible {
+  outline: 2px solid var(--bs-primary, #3161d1);
+  outline-offset: 2px;
+}
+
+.attachment_card_thumb {
+  position: relative;
+  height: 88px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.attachment_card_thumb.is_icon {
+  background: var(--attachment_tint_default);
+}
+.attachment_card_thumb.is_icon.attachment_tone_pdf { background: var(--attachment_tint_pdf); }
+.attachment_card_thumb.is_icon.attachment_tone_doc { background: var(--attachment_tint_doc); }
+.attachment_card_thumb.is_icon.attachment_tone_xls { background: var(--attachment_tint_xls); }
+.attachment_card_thumb.is_icon.attachment_tone_ppt { background: var(--attachment_tint_ppt); }
+.attachment_card_thumb.is_icon.attachment_tone_zip { background: var(--attachment_tint_zip); }
+.attachment_card_thumb.is_icon.attachment_tone_txt { background: var(--attachment_tint_txt); }
+
+.attachment_card_icon {
+  font-size: 2rem;
+  color: var(--attachment_tone_default);
+}
+.attachment_tone_pdf .attachment_card_icon,
+.attachment_tone_pdf .attachment_card_ext { color: var(--attachment_tone_pdf); }
+.attachment_tone_doc .attachment_card_icon,
+.attachment_tone_doc .attachment_card_ext { color: var(--attachment_tone_doc); }
+.attachment_tone_xls .attachment_card_icon,
+.attachment_tone_xls .attachment_card_ext { color: var(--attachment_tone_xls); }
+.attachment_tone_ppt .attachment_card_icon,
+.attachment_tone_ppt .attachment_card_ext { color: var(--attachment_tone_ppt); }
+.attachment_tone_zip .attachment_card_icon,
+.attachment_tone_zip .attachment_card_ext { color: var(--attachment_tone_zip); }
+.attachment_tone_txt .attachment_card_icon,
+.attachment_tone_txt .attachment_card_ext { color: var(--attachment_tone_txt); }
+
+.attachment_card_ext {
+  position: absolute;
+  left: 8px;
+  bottom: 8px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+.attachment_card_thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.attachment_card_thumb.is_image::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0) 65%);
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.attachment_card_download {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+.attachment_card_download i {
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--bs-body-bg, #fff);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  font-size: 0.85rem;
+}
+.attachment_card_thumb.is_image .attachment_card_download i {
+  background: rgba(255, 255, 255, 0.92);
+  color: #1c1b29;
+}
+@media (hover: hover) {
+  .attachment_card:hover .attachment_card_download,
+  .attachment_card:focus-visible .attachment_card_download {
+    opacity: 1;
+  }
+  .attachment_card:hover .attachment_card_thumb.is_image::after,
+  .attachment_card:focus-visible .attachment_card_thumb.is_image::after {
+    opacity: 1;
+  }
+}
+@media (hover: none) {
+  .attachment_card_download { opacity: 1; }
+  .attachment_card_thumb.is_image::after { opacity: 1; background: linear-gradient(to top, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0) 70%); }
+}
+
+.attachment_card_meta {
+  padding: 0.55rem 0.65rem 0.65rem;
+}
+.attachment_card_name {
+  font-size: 0.8rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.attachment_card_size {
+  font-size: 0.72rem;
+  color: var(--bs-secondary-color, #777);
+  margin-top: 0.1rem;
 }
 /* .list_meta { float: none; margin-left: 37%; } */
 

--- a/modules/smtp/hm-mime-message.php
+++ b/modules/smtp/hm-mime-message.php
@@ -19,6 +19,7 @@ class Hm_MIME_Msg {
     private $text_body = '';
     private $html = false;
     private $final_msg = '';
+    private $body_msg = '';
 
     /* build mime message data */
     function __construct($to, $subject, $body, $from, $html=false, $cc='', $bcc='', $in_reply_to_id='', $from_name='', $reply_to='', $delivery_receipt='', $schedule='', $profile_id = '') {
@@ -75,11 +76,32 @@ class Hm_MIME_Msg {
         $this->attachments = $files;
     }
 
+    /**
+     * Fully read and decrypt an attachment file written by
+     * Hm_Crypt_Stream_Writer (used by attachment_dir files)
+     * @param string $path attachment file path
+     * @return string|false decrypted content, or false on failure
+     */
+    private static function read_attachment_file($path) {
+        try {
+            $reader = new Hm_Crypt_Stream_Reader($path, Hm_Request_Key::generate());
+            $content = '';
+            while (($chunk = $reader->read()) !== false) {
+                $content .= $chunk;
+            }
+            $reader->close();
+            return $content;
+        }
+        catch (Exception $e) {
+            return false;
+        }
+    }
+
     function process_attachments() {
         $res = '';
         $closing = false;
         foreach ($this->attachments as $file) {
-            $content = Hm_Crypt::plaintext(@file_get_contents($file['filename']), Hm_Request_Key::generate());
+            $content = self::read_attachment_file($file['filename']);
             if ($content) {
                 $closing = true;
                 if (array_key_exists('no_encoding', $file) || (array_key_exists('type', $file) && $file['type'] == 'message/rfc822')) {
@@ -129,6 +151,73 @@ class Hm_MIME_Msg {
         }
         $this->final_msg = $res;
         return $headers.$res;
+    }
+
+    /**
+     * Like get_mime_msg(), but excludes attachment bodies so a caller can
+     * stream them separately instead of holding them fully in memory. See
+     * get_attachment_parts()/get_closing_boundary().
+     * @return string headers and non-attachment body
+     */
+    function get_headers_and_body() {
+        if (! $this->body_msg) {
+            if (!empty($this->body)) {
+                $this->prep_message_body();
+            }
+            $res = '';
+            if ($this->html) {
+                $res .= $this->text_body;
+            }
+            $res .= "\r\n".$this->body;
+            $this->body_msg = $res;
+        }
+        $headers = '';
+        foreach ($this->headers as $name => $val) {
+            if (!trim($val)) {
+                continue;
+            }
+            $headers .= sprintf("%s: %s\r\n", $name, rtrim($this->prep_fld($val, $name)));
+        }
+        return $headers.$this->body_msg;
+    }
+
+    /**
+     * Per-attachment MIME part headers and source file paths, for a caller
+     * to stream the file content directly rather than through
+     * process_attachments()/get_mime_msg(). Attachments whose file is
+     * missing or unreadable are silently omitted, matching
+     * process_attachments()'s existing behavior.
+     * @return array list of ['header' => string, 'filename' => string, 'base64' => bool]
+     */
+    function get_attachment_parts() {
+        $parts = array();
+        foreach ($this->attachments as $file) {
+            if (! is_readable($file['filename'])) {
+                continue;
+            }
+            if (array_key_exists('no_encoding', $file) || (array_key_exists('type', $file) && $file['type'] == 'message/rfc822')) {
+                $header = sprintf("\r\n--%s\r\nContent-Type: %s; name=\"%s\"\r\nContent-Description: %s\r\n".
+                    "Content-Disposition: attachment; filename=\"%s\"\r\nContent-Transfer-Encoding: 7bit\r\n\r\n",
+                    $this->boundary, $file['type'], $file['name'], $file['name'], $file['name']);
+                $base64 = false;
+            }
+            else {
+                $header = sprintf("\r\n--%s\r\nContent-Type: %s; name=\"%s\"\r\nContent-Description: %s\r\n".
+                    "Content-Disposition: attachment; filename=\"%s\"\r\nContent-Transfer-Encoding: base64\r\n\r\n",
+                    $this->boundary, $file['type'], $file['name'], $file['name'], $file['name']);
+                $base64 = true;
+            }
+            $parts[] = array('header' => $header, 'filename' => $file['filename'], 'base64' => $base64);
+        }
+        return $parts;
+    }
+
+    /**
+     * Closing MIME boundary, sent after the last attachment part
+     * @return string
+     */
+    function get_closing_boundary() {
+        return sprintf("\r\n--%s--\r\n", $this->boundary);
     }
 
     function set_auto_bcc($addr) {

--- a/modules/smtp/hm-mime-message.php
+++ b/modules/smtp/hm-mime-message.php
@@ -20,6 +20,7 @@ class Hm_MIME_Msg {
     private $html = false;
     private $final_msg = '';
     private $body_msg = '';
+    private $body_prepared = false;
 
     /* build mime message data */
     function __construct($to, $subject, $body, $from, $html=false, $cc='', $bcc='', $in_reply_to_id='', $from_name='', $reply_to='', $delivery_receipt='', $schedule='', $profile_id = '') {
@@ -126,8 +127,9 @@ class Hm_MIME_Msg {
 
     /* output mime message */
     function get_mime_msg() {
-        if (!empty($this->body)) {
+        if (!empty($this->body) && !$this->body_prepared) {
             $this->prep_message_body();
+            $this->body_prepared = true;
         }
         $res = '';
         $headers = '';
@@ -161,8 +163,9 @@ class Hm_MIME_Msg {
      */
     function get_headers_and_body() {
         if (! $this->body_msg) {
-            if (!empty($this->body)) {
+            if (!empty($this->body) && !$this->body_prepared) {
                 $this->prep_message_body();
+                $this->body_prepared = true;
             }
             $res = '';
             if ($this->html) {

--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -739,8 +739,6 @@ class Hm_SMTP {
             while ($chunk !== false) {
                 if ($part['base64']) {
                     $buffer .= $chunk;
-                    /* flush in multiples of 57 raw bytes, so output lines
-                     * land on clean 76-char base64 boundaries */
                     $usable = strlen($buffer) - (strlen($buffer) % 57);
                     if ($usable > 0) {
                         $this->write_raw(chunk_split(base64_encode(substr($buffer, 0, $usable))));
@@ -757,8 +755,6 @@ class Hm_SMTP {
             }
         }
         catch (Exception $e) {
-            /* tampered/truncated mid-stream: nothing more can safely be
-             * sent for this attachment */
             $reader->close();
             return true;
         }

--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -584,19 +584,24 @@ class Hm_SMTP {
         return openssl_encrypt($challenge, 'DES-ECB', $key, OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
     }
 
-    /* Send a message */
-    function send_message($from, $recipients, $message, $from_params = '', $recipients_params = '') {
+    /**
+     * Run the MAIL FROM / RCPT TO / DATA negotiation shared by
+     * send_message() and send_mime_message()
+     * @param string $from sender address
+     * @param mixed $recipients recipient address or array of addresses
+     * @param string $from_params extra MAIL FROM parameters
+     * @param string $recipients_params extra RCPT TO parameters
+     * @return bool|string true once the server is ready for the message body,
+     *                      or a user-facing error string on failure
+     */
+    private function smtp_start_data($from, $recipients, $from_params = '', $recipients_params = '') {
         $this->clean($from);
-        if ($from_params) {
-            $from_params = ' ' . $from_params;
-        }
         $from_params = $from_params ? ' ' . $from_params : '';
         $command = 'MAIL FROM:<'.$from.'>' . $from_params;
         $this->send_command($command);
         $res = $this->get_response();
         $bail = false;
-        $result = "Sorry, we couldn't send your message through the SMTP server right now. Please check your connection and try again.";
-        if(is_array($recipients)) {
+        if (is_array($recipients)) {
             if ($recipients_params) {
                 $recipients_params = ' ' . $recipients_params;
             }
@@ -620,37 +625,145 @@ class Hm_SMTP {
                 $bail = true;
             }
         }
-        if (!$bail) {
-            $command = 'DATA';
-            $this->send_command($command);
-            $res = $this->get_response();
-            if ($this->compare_response($res, '354') != 0) {
-                // Log technical details for debugging
-                error_log("SMTP DATA command failed. Expected 354, got: " . print_r($res, true));
-                $result = "Sorry, we couldn't send your message right now. The SMTP server didn't accept the message for delivery (DATA command failed). Please try again later.";
-            }
-            else {
-                $this->send_command($message);
-                /* TODO: process attachments */
-                $command = $this->crlf.'.';
-                $this->send_command($command);
-                $res = $this->get_response();
-                if ($this->compare_response($res, '250') == 0) {
-                    $result = false;
-                }
-                else {
-                    // Log technical details for debugging
-                    error_log("SMTP message delivery failed. Expected 250, got: " . print_r($res, true));
-                    $result = "Your message could not be sent. The SMTP server did not confirm delivery. Please try again later.";
-                }
-            }
-        }
-        else {
+        if ($bail) {
             // Log technical details for debugging
             error_log("SMTP RCPT command failed for one or more recipients");
-            $result = "There was an error sending your message. One or more of the recipient addresses may be invalid (RCPT command failed). Please check the email addresses and try again.";
+            return "There was an error sending your message. One or more of the recipient addresses may be invalid (RCPT command failed). Please check the email addresses and try again.";
         }
-        return $result;
+        $command = 'DATA';
+        $this->send_command($command);
+        $res = $this->get_response();
+        if ($this->compare_response($res, '354') != 0) {
+            // Log technical details for debugging
+            error_log("SMTP DATA command failed. Expected 354, got: " . print_r($res, true));
+            return "Sorry, we couldn't send your message right now. The SMTP server didn't accept the message for delivery (DATA command failed). Please try again later.";
+        }
+        return true;
+    }
+
+    /**
+     * Send the closing "." after the message body has been written and
+     * check the server's final response
+     * @return bool|string false on success, or a user-facing error string
+     */
+    private function smtp_finish_data() {
+        $command = $this->crlf.'.';
+        $this->send_command($command);
+        $res = $this->get_response();
+        if ($this->compare_response($res, '250') == 0) {
+            return false;
+        }
+        // Log technical details for debugging
+        error_log("SMTP message delivery failed. Expected 250, got: " . print_r($res, true));
+        return "Your message could not be sent. The SMTP server did not confirm delivery. Please try again later.";
+    }
+
+    /**
+     * Write raw bytes straight to the socket, with no added CRLF (unlike
+     * send_command()) so callers can write a message piecemeal
+     * @param string $data
+     * @return void
+     */
+    private function write_raw($data) {
+        if (is_resource($this->handle)) {
+            fputs($this->handle, $data);
+        }
+    }
+
+    /* Send a message */
+    function send_message($from, $recipients, $message, $from_params = '', $recipients_params = '') {
+        $ready = $this->smtp_start_data($from, $recipients, $from_params, $recipients_params);
+        if ($ready !== true) {
+            return $ready;
+        }
+        $this->send_command($message);
+        return $this->smtp_finish_data();
+    }
+
+    /**
+     * Send a message built from a Hm_MIME_Msg, streaming each attachment's
+     * file content directly to the socket (decrypting and base64-encoding
+     * it in bounded-size chunks) instead of ever holding a whole attachment
+     * in memory.
+     * @param string $from sender address
+     * @param mixed $recipients recipient address or array of addresses
+     * @param Hm_MIME_Msg $mime message to send
+     * @param string $from_params extra MAIL FROM parameters
+     * @param string $recipients_params extra RCPT TO parameters
+     * @return bool|string false on success, or a user-facing error string
+     */
+    function send_mime_message($from, $recipients, $mime, $from_params = '', $recipients_params = '') {
+        $ready = $this->smtp_start_data($from, $recipients, $from_params, $recipients_params);
+        if ($ready !== true) {
+            return $ready;
+        }
+        $this->write_raw($mime->get_headers_and_body());
+        $sent_any = false;
+        foreach ($mime->get_attachment_parts() as $part) {
+            if ($this->stream_attachment_part($part)) {
+                $sent_any = true;
+            }
+        }
+        if ($sent_any) {
+            $this->write_raw($mime->get_closing_boundary());
+        }
+        return $this->smtp_finish_data();
+    }
+
+    /**
+     * Stream one attachment's decrypted content directly to the socket. A
+     * missing file, or a decryption/authentication failure, causes this
+     * attachment to be silently skipped (matching the previous
+     * Hm_MIME_Msg::process_attachments() behavior) rather than aborting the
+     * whole send.
+     * @param array $part one entry from Hm_MIME_Msg::get_attachment_parts()
+     * @return bool true if the attachment was written
+     */
+    private function stream_attachment_part($part) {
+        try {
+            $reader = new Hm_Crypt_Stream_Reader($part['filename'], Hm_Request_Key::generate());
+        }
+        catch (Exception $e) {
+            return false;
+        }
+        try {
+            $chunk = $reader->read();
+        }
+        catch (Exception $e) {
+            $reader->close();
+            return false;
+        }
+        $this->write_raw($part['header']);
+        $buffer = '';
+        try {
+            while ($chunk !== false) {
+                if ($part['base64']) {
+                    $buffer .= $chunk;
+                    /* flush in multiples of 57 raw bytes, so output lines
+                     * land on clean 76-char base64 boundaries */
+                    $usable = strlen($buffer) - (strlen($buffer) % 57);
+                    if ($usable > 0) {
+                        $this->write_raw(chunk_split(base64_encode(substr($buffer, 0, $usable))));
+                        $buffer = substr($buffer, $usable);
+                    }
+                }
+                else {
+                    $this->write_raw($chunk);
+                }
+                $chunk = $reader->read();
+            }
+            if ($part['base64'] && $buffer !== '') {
+                $this->write_raw(chunk_split(base64_encode($buffer)));
+            }
+        }
+        catch (Exception $e) {
+            /* tampered/truncated mid-stream: nothing more can safely be
+             * sent for this attachment */
+            $reader->close();
+            return true;
+        }
+        $reader->close();
+        return true;
     }
 
     function supports_dsn() {

--- a/modules/smtp/js_modules/route_handlers.js
+++ b/modules/smtp/js_modules/route_handlers.js
@@ -153,6 +153,17 @@ function applySmtpComposePageHandlers(routeParams) {
                         }
                     });
                 } else {
+                    // sending large attachments can take a while (the
+                    // browser does a real full-page form submit here, not
+                    // an AJAX call) - show visible feedback so it doesn't
+                    // look like the click did nothing
+                    const sendBtn = document.querySelector('.smtp_send_placeholder');
+                    if (sendBtn) {
+                        sendBtn.disabled = true;
+                        sendBtn.dataset.originalText = sendBtn.textContent;
+                        sendBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>' + hm_trans('Sending...');
+                    }
+                    showLoaderToast(hm_trans('Sending message...'));
                     document.getElementsByClassName("smtp_send")[0].click();
                 }
             } else {

--- a/modules/smtp/js_modules/route_handlers.js
+++ b/modules/smtp/js_modules/route_handlers.js
@@ -153,10 +153,6 @@ function applySmtpComposePageHandlers(routeParams) {
                         }
                     });
                 } else {
-                    // sending large attachments can take a while (the
-                    // browser does a real full-page form submit here, not
-                    // an AJAX call) - show visible feedback so it doesn't
-                    // look like the click did nothing
                     const sendBtn = document.querySelector('.smtp_send_placeholder');
                     if (sendBtn) {
                         sendBtn.disabled = true;

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -753,7 +753,6 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
 
         /* add attachments */
         $mime->add_attachments($uploaded_files);
-        $res = $mime->process_attachments();
 
         /* get smtp recipients */
         $recipients = $mime->get_recipient_addresses();
@@ -764,7 +763,7 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
         }
 
         /* send the message */
-        $err_msg = $mailbox->send_message($from, $recipients, $mime->get_mime_msg(), $this->user_config->get('enable_compose_delivery_receipt_setting', false) && !empty($this->request->post['compose_delivery_receipt']));
+        $err_msg = $mailbox->send_message($from, $recipients, $mime, $this->user_config->get('enable_compose_delivery_receipt_setting', false) && !empty($this->request->post['compose_delivery_receipt']));
         if ($err_msg) {
             Hm_Msgs::add(sprintf("%s", $err_msg), 'danger');
             repopulate_compose_form($draft, $this);
@@ -775,7 +774,7 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
         $auto_bcc = $this->user_config->get('smtp_auto_bcc_setting', DEFAULT_SMTP_AUTO_BCC);
         if ($auto_bcc) {
             $mime->set_auto_bcc($from);
-            $bcc_err_msg = $mailbox->send_message($from, array($from), $mime->get_mime_msg());
+            $bcc_err_msg = $mailbox->send_message($from, array($from), $mime);
         }
 
         /* check for associated IMAP server to save a copy */
@@ -1994,8 +1993,24 @@ if (!hm_exists('createFileFromChunks')) {
                     fwrite($fp, file_get_contents($temp_dir.'/'.$fileName.'.part'.$i));
                 }
                 fclose($fp);
-                $hashed_content = Hm_Crypt::ciphertext(file_get_contents($temp_dir.'/../'.$fileName), Hm_Request_Key::generate());
-                file_put_contents($temp_dir.'/../'.$fileName, $hashed_content);
+
+                // re-encrypt the reassembled file in place, streaming it
+                // through fixed-size chunks so large uploads don't need to
+                // be fully buffered in memory
+                $plain_path = $temp_dir.'/../'.$fileName;
+                $encrypted_path = $plain_path.'.enc';
+                $writer = new Hm_Crypt_Stream_Writer($encrypted_path, Hm_Request_Key::generate());
+                $src = fopen($plain_path, 'rb');
+                while (! feof($src)) {
+                    $chunk = fread($src, 1048576);
+                    if ($chunk === false || $chunk === '') {
+                        break;
+                    }
+                    $writer->write($chunk);
+                }
+                fclose($src);
+                $writer->close();
+                rename($encrypted_path, $plain_path);
             } else {
                 return false;
             }
@@ -2128,7 +2143,6 @@ function save_imap_draft($atts, $id, $session, $mod, $mod_cache, $uploaded_files
     }
 
     $mime = prepare_draft_mime($atts, $uploaded_files, $from, $name, $profile['id'], $body_type_for_mime);
-    $res = $mime->process_attachments();
 
     if (! empty($atts['schedule']) && empty($mime->get_recipient_addresses())) {
         Hm_Msgs::add("ERRNo valid recipients found");

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -303,10 +303,16 @@ class Hm_Handler_upload_chunk extends Hm_Handler_Module {
                 Hm_Msgs::add('Error saving (move_uploaded_file) chunk '.$this->request->get['resumableChunkNumber'].' for file '.$this->request->get['resumableFilename'], 'danger');
             } else {
                 // check if all the parts present, and create the final destination file
-                $result = createFileFromChunks($temp_dir, $this->request->get['resumableFilename'],
-                                $this->request->get['resumableChunkSize'],
-                                $this->request->get['resumableTotalSize'],
-                                $this->request->get['resumableTotalChunks']);
+                try {
+                    $result = createFileFromChunks($temp_dir, $this->request->get['resumableFilename'],
+                                    $this->request->get['resumableChunkSize'],
+                                    $this->request->get['resumableTotalSize'],
+                                    $this->request->get['resumableTotalChunks']);
+                }
+                catch (Exception $e) {
+                    Hm_Debug::add(sprintf('Error finalizing uploaded file %s: %s', $this->request->get['resumableFilename'], $e->getMessage()));
+                    Hm_Msgs::add('Error processing uploaded file '.$this->request->get['resumableFilename'], 'danger');
+                }
             }
         }
     }
@@ -819,10 +825,21 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
             $specials = get_special_folders($this, $imap_server);
             delete_draft($form['draft_id'], $this->cache, $imap_server, $specials['draft']);
         }
-        
-        delete_uploaded_files($this->session, $form['draft_id']);
-        if ($form['draft_id'] > 0) {
-            delete_uploaded_files($this->session, 0);
+
+        /* Attachment files on disk are only cleaned up once nothing else
+         * needs to read them. When a sent-folder copy is being saved,
+         * Hm_Handler_imap_save_sent (modules/imap/handler_modules.php),
+         * which runs later, still needs to re-read attachment content via
+         * $mime->get_mime_msg() - it performs the cleanup itself in that
+         * case instead of here. */
+        if ($imap_server === false) {
+            delete_uploaded_files($this->session, $form['draft_id']);
+            if ($form['draft_id'] > 0) {
+                delete_uploaded_files($this->session, 0);
+            }
+        }
+        else {
+            $this->out('compose_draft_id', $form['draft_id'], false);
         }
     }
 }
@@ -1975,55 +1992,85 @@ if (!hm_exists('rrmdir')) {
  */
 if (!hm_exists('createFileFromChunks')) {
     function createFileFromChunks($temp_dir, $fileName, $chunkSize, $totalSize,$total_files) {
-        // count all the parts of this file
-        // $fileName = Hm_Crypt::ciphertext($fileName, Hm_Request_Key::generate());
-        $total_files_on_server_size = 0;
-        $temp_total = 0;
-        foreach(scandir($temp_dir) as $file) {
-            $temp_total = $total_files_on_server_size;
-            $tempfilesize = filesize($temp_dir.'/'.$file);
-            $total_files_on_server_size = $temp_total + $tempfilesize;
+        if (! is_dir($temp_dir)) {
+            // already finalized by a concurrent request for another chunk
+            // of the same upload (resumable.js uploads several chunks in
+            // parallel)
+            return true;
         }
-        // check that all the parts are present
-        // If the Size of all the chunks on the server is equal to the size of the file uploaded.
-        if ($total_files_on_server_size >= $totalSize) {
-        // create the final destination file
-            if (($fp = fopen($temp_dir.'/../'.$fileName, 'w')) !== false) {
-                for ($i=1; $i<=$total_files; $i++) {
-                    fwrite($fp, file_get_contents($temp_dir.'/'.$fileName.'.part'.$i));
-                }
-                fclose($fp);
 
-                // re-encrypt the reassembled file in place, streaming it
-                // through fixed-size chunks so large uploads don't need to
-                // be fully buffered in memory
-                $plain_path = $temp_dir.'/../'.$fileName;
-                $encrypted_path = $plain_path.'.enc';
-                $writer = new Hm_Crypt_Stream_Writer($encrypted_path, Hm_Request_Key::generate());
-                $src = fopen($plain_path, 'rb');
-                while (! feof($src)) {
-                    $chunk = fread($src, 1048576);
-                    if ($chunk === false || $chunk === '') {
-                        break;
+        // serialize finalization across those concurrent requests, so only
+        // one of them reassembles/encrypts the file - without this, two
+        // requests could both see "all chunks present" and race on writing/
+        // renaming the same files, at best wasting work and at worst
+        // hitting a mid-write file-not-found error
+        $lock_path = rtrim($temp_dir, '/\\').'.lock';
+        $lock_fp = @fopen($lock_path, 'c');
+        if (! $lock_fp || ! flock($lock_fp, LOCK_EX)) {
+            if ($lock_fp) {
+                fclose($lock_fp);
+            }
+            return true;
+        }
+
+        $result = true;
+        if (is_dir($temp_dir)) {
+            // count all the parts of this file
+            $total_files_on_server_size = 0;
+            foreach (scandir($temp_dir) as $file) {
+                if ($file === '.' || $file === '..') {
+                    continue;
+                }
+                $total_files_on_server_size += filesize($temp_dir.'/'.$file);
+            }
+            // check that all the parts are present
+            // If the Size of all the chunks on the server is equal to the size of the file uploaded.
+            if ($total_files_on_server_size >= $totalSize) {
+                // create the final destination file
+                if (($fp = fopen($temp_dir.'/../'.$fileName, 'w')) !== false) {
+                    for ($i=1; $i<=$total_files; $i++) {
+                        fwrite($fp, file_get_contents($temp_dir.'/'.$fileName.'.part'.$i));
                     }
-                    $writer->write($chunk);
-                }
-                fclose($src);
-                $writer->close();
-                rename($encrypted_path, $plain_path);
-            } else {
-                return false;
-            }
+                    fclose($fp);
 
-            // rename the temporary directory (to avoid access from other
-            // concurrent chunks uploads) and than delete it
-            if (rename($temp_dir, $temp_dir.'_UNUSED')) {
-                rrmdir($temp_dir.'_UNUSED');
-            } else {
-                rrmdir($temp_dir);
+                    // re-encrypt the reassembled file in place, streaming it
+                    // through fixed-size chunks so large uploads don't need to
+                    // be fully buffered in memory
+                    $plain_path = $temp_dir.'/../'.$fileName;
+                    $encrypted_path = $plain_path.'.enc';
+                    $writer = new Hm_Crypt_Stream_Writer($encrypted_path, Hm_Request_Key::generate());
+                    $src = fopen($plain_path, 'rb');
+                    while (! feof($src)) {
+                        $chunk = fread($src, 1048576);
+                        if ($chunk === false || $chunk === '') {
+                            break;
+                        }
+                        $writer->write($chunk);
+                    }
+                    fclose($src);
+                    $writer->close();
+                    rename($encrypted_path, $plain_path);
+                } else {
+                    $result = false;
+                }
+
+                if ($result) {
+                    // rename the temporary directory (to avoid access from other
+                    // concurrent chunks uploads) and than delete it
+                    if (rename($temp_dir, $temp_dir.'_UNUSED')) {
+                        rrmdir($temp_dir.'_UNUSED');
+                    } else {
+                        rrmdir($temp_dir);
+                    }
+                }
             }
         }
-        return true;
+
+        flock($lock_fp, LOCK_UN);
+        fclose($lock_fp);
+        @unlink($lock_path);
+
+        return $result;
     }
 }
 

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -77,8 +77,7 @@ class Hm_Handler_load_smtp_is_imap_draft extends Hm_Handler_Module {
                             $new_attachment['size'] = $sub['size'];
                             $new_attachment['type'] = $sub['type'];
                             $file_path = $this->config->get('attachment_dir').DIRECTORY_SEPARATOR.$new_attachment['name'];
-                            $content = Hm_Crypt::ciphertext($mailbox->get_message_content(hex2bin($path[2]), $this->request->get['uid'], $ind), Hm_Request_Key::generate());
-                            file_put_contents($file_path, $content);
+                            $mailbox->stream_message_part_to_file(hex2bin($path[2]), $this->request->get['uid'], $ind, $file_path, Hm_Request_Key::generate());
                             $new_attachment['tmp_name'] = $file_path;
                             $new_attachment['filename'] = $file_path;
                             $attached_files[$this->request->get['uid']][] = $new_attachment;
@@ -135,8 +134,6 @@ class Hm_Handler_load_smtp_is_imap_forward_as_attachment extends Hm_Handler_Modu
                 if (!array_key_exists('From', $msg_header) || count($msg_header) == 0) {
                     return;
                 }
-                $content = $mailbox->get_message_content(hex2bin($path[2]), $this->request->get['uid']);
-
                 # Attachment Download
                 $attached_files = [];
                 $this->session->set('uploaded_files', array());
@@ -148,16 +145,15 @@ class Hm_Handler_load_smtp_is_imap_forward_as_attachment extends Hm_Handler_Modu
                 $basename = str_replace(',', '', $msg_header['Subject']);
                 $name = $basename. '.eml';
                 $file_path = $file_dir . $name;
+                $size = $mailbox->stream_message_part_to_file(hex2bin($path[2]), $this->request->get['uid'], 0, $file_path, Hm_Request_Key::generate());
                 $attached_files[$this->request->get['uid']][] = array(
                     'name' => $name,
                     'type' => 'message/rfc822',
-                    'size' => strlen($content),
+                    'size' => $size,
                     'tmp_name' => $file_path,
                     'filename' => $file_path,
                     'basename' => $basename
                 );
-                $content = Hm_Crypt::ciphertext($content, Hm_Request_Key::generate());
-                file_put_contents($file_path, $content);
                 $this->session->set('uploaded_files', $attached_files);
                 $this->out('as_attr', true);
             }
@@ -199,8 +195,7 @@ class Hm_Handler_load_smtp_is_imap_forward extends Hm_Handler_Module
                             $new_attachment['size'] = $sub['size'];
                             $new_attachment['type'] = $sub['type'] . "/" . $sub['subtype'];
                             $file_path = $file_dir . $new_attachment['name'];
-                            $content = Hm_Crypt::ciphertext($mailbox->get_message_content(hex2bin($path[2]), $this->request->get['uid'], $ind), Hm_Request_Key::generate());
-                            file_put_contents($file_path, $content);
+                            $mailbox->stream_message_part_to_file(hex2bin($path[2]), $this->request->get['uid'], $ind, $file_path, Hm_Request_Key::generate());
                             $new_attachment['tmp_name'] = $file_path;
                             $new_attachment['filename'] = $file_path;
                             $attached_files[$this->request->get['uid']][] = $new_attachment;

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -826,12 +826,6 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
             delete_draft($form['draft_id'], $this->cache, $imap_server, $specials['draft']);
         }
 
-        /* Attachment files on disk are only cleaned up once nothing else
-         * needs to read them. When a sent-folder copy is being saved,
-         * Hm_Handler_imap_save_sent (modules/imap/handler_modules.php),
-         * which runs later, still needs to re-read attachment content via
-         * $mime->get_mime_msg() - it performs the cleanup itself in that
-         * case instead of here. */
         if ($imap_server === false) {
             delete_uploaded_files($this->session, $form['draft_id']);
             if ($form['draft_id'] > 0) {
@@ -1993,17 +1987,9 @@ if (!hm_exists('rrmdir')) {
 if (!hm_exists('createFileFromChunks')) {
     function createFileFromChunks($temp_dir, $fileName, $chunkSize, $totalSize,$total_files) {
         if (! is_dir($temp_dir)) {
-            // already finalized by a concurrent request for another chunk
-            // of the same upload (resumable.js uploads several chunks in
-            // parallel)
             return true;
         }
 
-        // serialize finalization across those concurrent requests, so only
-        // one of them reassembles/encrypts the file - without this, two
-        // requests could both see "all chunks present" and race on writing/
-        // renaming the same files, at best wasting work and at worst
-        // hitting a mid-write file-not-found error
         $lock_path = rtrim($temp_dir, '/\\').'.lock';
         $lock_fp = @fopen($lock_path, 'c');
         if (! $lock_fp || ! flock($lock_fp, LOCK_EX)) {
@@ -2033,9 +2019,6 @@ if (!hm_exists('createFileFromChunks')) {
                     }
                     fclose($fp);
 
-                    // re-encrypt the reassembled file in place, streaming it
-                    // through fixed-size chunks so large uploads don't need to
-                    // be fully buffered in memory
                     $plain_path = $temp_dir.'/../'.$fileName;
                     $encrypted_path = $plain_path.'.enc';
                     $writer = new Hm_Crypt_Stream_Writer($encrypted_path, Hm_Request_Key::generate());

--- a/modules/smtp/site.css
+++ b/modules/smtp/site.css
@@ -31,9 +31,14 @@
 .editor-statusbar { border-top: none !important; }
 .editor-toolbar:before, .editor-toolbar:after { background: none !important; }
 .meter { height: 5px; position: relative; background: #ede8e6; overflow: hidden;}
-.meter span {display: block; height: 100%; }
-.progress {background-color: #4323f5; animation: progressBar 1s ease-in-out; animation-fill-mode:both; }
-@keyframes progressBar { 0% { width: 0; } 100% { width: 100%; }}
+.meter span {display: block; height: 100%; transition: width 0.2s linear; }
+.progress {background-color: #4323f5; }
+.progress.processing {
+    background-image: repeating-linear-gradient(45deg, #4323f5, #4323f5 10px, #6a52f7 10px, #6a52f7 20px);
+    background-size: 28px 28px;
+    animation: progressStripes 1s linear infinite;
+}
+@keyframes progressStripes { 0% { background-position: 0 0; } 100% { background-position: 28px 0; } }
 .compose_container { min-height: calc(3.5rem + calc(var(--bs-border-width) * 2)); padding-left: 3px !important;}
 .bubbles { display: inline-block; background-color: #fff; cursor: pointer; padding: 5px; }
 .bubble { font-size: .9rem; border: 1px solid #ddd; border-radius: 4px; padding: 7px 14px; display: inline-block; margin: 0px 5px 5px 0px; }

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -287,6 +287,13 @@ var init_resumable_upload = function () {
         target:'?page=compose&hm_ajax_hook=ajax_upload_chunk&draft_smtp=' + $(".compose_server").val(),
         testTarget:'?page=compose&hm_ajax_hook=ajax_get_test_chunk&draft_smtp=' + $(".compose_server").val(),
         testMethod: 'POST',
+        // PHP's default session handler locks the session file for the
+        // duration of each request; several chunk-upload requests in
+        // flight at once queue up behind that lock (and behind each
+        // other) rather than actually running in parallel, which can be
+        // slow enough to make a request time out and look like a lost
+        // session. Uploading one chunk at a time avoids that contention.
+        simultaneousUploads: 1,
         headers: {
             'X-Requested-with': 'xmlhttprequest'
         }

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -325,17 +325,24 @@ var init_resumable_upload = function () {
     r.on('fileProgress', function(file) {
         var progress = Math.floor(file.progress() * 100);
         $('#progress-' + file.uniqueIdentifier).css('width', progress+'%');
+        // all bytes have reached the server, but it may still be busy
+        // reassembling/encrypting a large file before confirming success -
+        // switch to an indeterminate animation so the user sees it's still
+        // being processed rather than a bar stuck at 100%
+        if (progress >= 100) {
+            $('#progress-bar-' + file.uniqueIdentifier).addClass('processing');
+        }
     });
     r.on('fileSuccess', function(file) {
         $('.remove_attachment').css('display', '');
         $('.pause_upload').css('display', 'none');
         $('.resume_upload').css('display', 'none');
         $('#tr-'+file.uniqueIdentifier).append('<td style="display:none"><input name="uploaded_files[]" type="text" value="'+file.fileName+'" /></td>');
-        $('#progress-bar-' + file.uniqueIdentifier).css('background-color', 'green');
+        $('#progress-bar-' + file.uniqueIdentifier).removeClass('processing').css('background-color', 'green');
         $('#progress-' + file.uniqueIdentifier).parent().css('opacity', '0');
     });
     r.on('fileError', function(file, message) {
-        $('#progress-bar-' + file.uniqueIdentifier).css('background-color', 'red');
+        $('#progress-bar-' + file.uniqueIdentifier).removeClass('processing').css('background-color', 'red');
     });
     r.on('pause', function() {
         $('.remove_attachment').css('display', 'none');

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -287,12 +287,6 @@ var init_resumable_upload = function () {
         target:'?page=compose&hm_ajax_hook=ajax_upload_chunk&draft_smtp=' + $(".compose_server").val(),
         testTarget:'?page=compose&hm_ajax_hook=ajax_get_test_chunk&draft_smtp=' + $(".compose_server").val(),
         testMethod: 'POST',
-        // PHP's default session handler locks the session file for the
-        // duration of each request; several chunk-upload requests in
-        // flight at once queue up behind that lock (and behind each
-        // other) rather than actually running in parallel, which can be
-        // slow enough to make a request time out and look like a lost
-        // session. Uploading one chunk at a time avoids that contention.
         simultaneousUploads: 1,
         headers: {
             'X-Requested-with': 'xmlhttprequest'

--- a/tests/phpunit/crypt_stream.php
+++ b/tests/phpunit/crypt_stream.php
@@ -96,6 +96,35 @@ class Hm_Test_Crypt_Stream extends TestCase {
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
+    public function test_resumable_writer_across_separate_instances() {
+        $data1 = random_bytes(1000);
+        $data2 = random_bytes(1500);
+        $data3 = random_bytes(37);
+
+        // simulate one HTTP request per chunk: each chunk gets its own
+        // Hm_Crypt_Stream_Writer instance, resuming from where the last
+        // one left off
+        $writer1 = new Hm_Crypt_Stream_Writer($this->path, 'testkey');
+        $salt = $writer1->get_salt();
+        $writer1->write_chunk_now($data1, false);
+        $next = $writer1->get_next_chunk_index();
+
+        $writer2 = new Hm_Crypt_Stream_Writer($this->path, 'testkey', $salt, $next, true);
+        $writer2->write_chunk_now($data2, false);
+        $next = $writer2->get_next_chunk_index();
+
+        $writer3 = new Hm_Crypt_Stream_Writer($this->path, 'testkey', $salt, $next, true);
+        $writer3->write_chunk_now($data3, true);
+
+        $reader = new Hm_Crypt_Stream_Reader($this->path, 'testkey');
+        $this->assertEquals($data1.$data2.$data3, $this->read_all($reader));
+        $reader->close();
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
     public function test_wrong_key_fails() {
         $writer = new Hm_Crypt_Stream_Writer($this->path, 'testkey');
         $writer->write('secret data');

--- a/tests/phpunit/crypt_stream.php
+++ b/tests/phpunit/crypt_stream.php
@@ -1,0 +1,147 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * tests for Hm_Crypt_Stream_Writer / Hm_Crypt_Stream_Reader
+ */
+class Hm_Test_Crypt_Stream extends TestCase {
+
+    private $path;
+
+    public function setUp(): void {
+        $this->path = sys_get_temp_dir().'/hm_crypt_stream_test_'.bin2hex(random_bytes(8));
+    }
+
+    public function tearDown(): void {
+        if (file_exists($this->path)) {
+            unlink($this->path);
+        }
+    }
+
+    private function read_all(Hm_Crypt_Stream_Reader $reader) {
+        $out = '';
+        while (($chunk = $reader->read()) !== false) {
+            $out .= $chunk;
+        }
+        return $out;
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_round_trip_empty() {
+        $writer = new Hm_Crypt_Stream_Writer($this->path, 'testkey');
+        $writer->write('');
+        $writer->close();
+
+        $reader = new Hm_Crypt_Stream_Reader($this->path, 'testkey');
+        $this->assertEquals('', $this->read_all($reader));
+        $reader->close();
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_round_trip_single_byte() {
+        $writer = new Hm_Crypt_Stream_Writer($this->path, 'testkey');
+        $writer->write('a');
+        $writer->close();
+
+        $reader = new Hm_Crypt_Stream_Reader($this->path, 'testkey');
+        $this->assertEquals('a', $this->read_all($reader));
+        $reader->close();
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_round_trip_exact_chunk_multiple() {
+        $data = str_repeat('x', Hm_Crypt_Stream_Writer::CHUNK_SIZE * 2);
+        $writer = new Hm_Crypt_Stream_Writer($this->path, 'testkey');
+        $writer->write($data);
+        $writer->close();
+
+        $reader = new Hm_Crypt_Stream_Reader($this->path, 'testkey');
+        $this->assertEquals($data, $this->read_all($reader));
+        $reader->close();
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_round_trip_random_multi_chunk() {
+        $data = random_bytes((int) (Hm_Crypt_Stream_Writer::CHUNK_SIZE * 2.5) + 137);
+        $writer = new Hm_Crypt_Stream_Writer($this->path, 'testkey');
+        /* feed it in small, uneven pieces to exercise the internal buffer */
+        $offset = 0;
+        $len = strlen($data);
+        while ($offset < $len) {
+            $piece = substr($data, $offset, 777);
+            $writer->write($piece);
+            $offset += strlen($piece);
+        }
+        $writer->close();
+
+        $reader = new Hm_Crypt_Stream_Reader($this->path, 'testkey');
+        $this->assertEquals($data, $this->read_all($reader));
+        $reader->close();
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_wrong_key_fails() {
+        $writer = new Hm_Crypt_Stream_Writer($this->path, 'testkey');
+        $writer->write('secret data');
+        $writer->close();
+
+        $reader = new Hm_Crypt_Stream_Reader($this->path, 'wrongkey');
+        $this->expectException(Exception::class);
+        $this->read_all($reader);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_tampered_ciphertext_fails() {
+        $writer = new Hm_Crypt_Stream_Writer($this->path, 'testkey');
+        $writer->write('secret data');
+        $writer->close();
+
+        $contents = file_get_contents($this->path);
+        /* flip a byte well past the salt, inside the first chunk's ciphertext */
+        $contents[20] = chr(ord($contents[20]) ^ 0xFF);
+        file_put_contents($this->path, $contents);
+
+        $reader = new Hm_Crypt_Stream_Reader($this->path, 'testkey');
+        $this->expectException(Exception::class);
+        $this->read_all($reader);
+    }
+
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_truncated_stream_fails() {
+        $data = str_repeat('y', Hm_Crypt_Stream_Writer::CHUNK_SIZE + 10);
+        $writer = new Hm_Crypt_Stream_Writer($this->path, 'testkey');
+        $writer->write($data);
+        $writer->close();
+
+        /* drop the final chunk (which carries the final-flag) */
+        $contents = file_get_contents($this->path);
+        $truncated = substr($contents, 0, 16 + 4 + Hm_Crypt_Stream_Writer::CHUNK_SIZE + 1 + 32);
+        file_put_contents($this->path, $truncated);
+
+        $reader = new Hm_Crypt_Stream_Reader($this->path, 'testkey');
+        $this->expectException(Exception::class);
+        $this->read_all($reader);
+    }
+}

--- a/tests/phpunit/phpunit.xml
+++ b/tests/phpunit/phpunit.xml
@@ -37,6 +37,9 @@
     <testsuite name="crypt_base">
       <file>./crypt_base.php</file>
     </testsuite>
+    <testsuite name="crypt_stream">
+      <file>./crypt_stream.php</file>
+    </testsuite>
     <testsuite name="request_key">
       <file>./request_key.php</file>
     </testsuite>


### PR DESCRIPTION
`base64_encode($salt.$mac.$ciphertext)` in `lib/crypt_sodium.php` was the visible crash site, but the real problem was upstream: IMAP fetch → local encrypt → decrypt → SMTP send; every stage buffered the entire attachment in memory, with no streaming anywhere. For a 50MB PDF that could easily require 150-200MB of peak memory against the default 128M limit. The crash wasn't just "this send fails" per the original report, it required a server restart.

This PR replaces the one-shot encrypt/decrypt with chunked (1MB) authenticated streaming end-to-end, bringing peak memory down from O(file size) to O(chunk size).

There is no way to send a message; I get a 500 error. Even the redirection to the compose page when clicking on FORWARD sometimes doesn’t work, and sometimes it does, but it takes too long, sometimes several minutes.

Error:
```
[23-Jul-2025 23:45:32 Africa/Cairo] PHP Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 53145280 bytes) in /cypht/lib/crypt_sodium.php on line 58
```

Still running more manual tests (forward, auto-BCC, Draft, etc...)