### PR TITLE
fix(backend): remove redundant post-package-install script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,6 @@
     },
     "scripts": {
         "post-update-cmd": "composer suggest",
-        "post-package-install": "composer suggest",
         "post-install-cmd": "composer suggest"
     }
 }


### PR DESCRIPTION
Unlike post-install-cmd/post-update-cmd (which fire only once, at the very end), post-package-install is a Composer event that fires once per installed package

Related issue: https://github.com/cypht-org/cypht/issues/1991