### PR TITLE
fix(frontend): invalidate message page cache after rebuild

### DIFF
--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -598,9 +598,6 @@ function preFetchMessageContent(msgPart, uid, path) {
     }, null, true)
 }
 
-// HM_BUILD_VERSION changes on every rebuild, so keys built with it go stale
-// automatically. MSG_CACHE_PREFIX marks them so purgeStaleMessageCache() can find
-// and remove the old ones without touching unrelated sessionStorage keys.
 const MSG_CACHE_PREFIX = 'msg_cache_';
 
 function getMessageStorageKey(uid, listPath = getListPathParam()) {

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -598,9 +598,35 @@ function preFetchMessageContent(msgPart, uid, path) {
     }, null, true)
 }
 
+// HM_BUILD_VERSION changes on every rebuild, so keys built with it go stale
+// automatically. MSG_CACHE_PREFIX marks them so purgeStaleMessageCache() can find
+// and remove the old ones without touching unrelated sessionStorage keys.
+const MSG_CACHE_PREFIX = 'msg_cache_';
+
 function getMessageStorageKey(uid, listPath = getListPathParam()) {
-    return uid + '_' + listPath;
+    const version = (typeof HM_BUILD_VERSION !== 'undefined' && HM_BUILD_VERSION) ? HM_BUILD_VERSION : 'dev';
+    return MSG_CACHE_PREFIX + version + '_' + uid + '_' + listPath;
 }
+
+/**
+ * Deletes any cached message entry written under an older HM_BUILD_VERSION.
+ * Runs once per page load.
+ */
+function purgeStaleMessageCache() {
+    const version = (typeof HM_BUILD_VERSION !== 'undefined' && HM_BUILD_VERSION) ? HM_BUILD_VERSION : 'dev';
+    const currentPrefix = MSG_CACHE_PREFIX + version + '_';
+    const staleKeys = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+        const key = sessionStorage.key(i);
+        if (key && key.indexOf(MSG_CACHE_PREFIX) === 0 && key.indexOf(currentPrefix) !== 0) {
+            staleKeys.push(key);
+        }
+    }
+    staleKeys.forEach(function (key) {
+        Hm_Utils.remove_from_local_storage(key);
+    });
+}
+purgeStaleMessageCache();
 
 async function markPrefetchedMessagesAsRead(uid) {
     const listPath = getListPathParam();

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -497,8 +497,11 @@ function combine_includes($js, $js_compress, $css, $css_compress, $settings) {
             $settings['encrypt_local_storage'])) {
             $js_lib .= file_get_contents("third_party/forge.min.js");
         }
+        /* Fresh identifier baked into every build, exposed as the JS global
+         * HM_BUILD_VERSION. Helps remove/invalidate cached pages after every rebuild. */
+        $build_version_js = 'var HM_BUILD_VERSION = ' . json_encode(Hm_Crypt::unique_id(16)) . ";\n";
         file_put_contents('tmp.js', $js);
-        $js_out = $js_lib.compress($js, $js_compress, 'tmp.js');
+        $js_out = $js_lib.$build_version_js.compress($js, $js_compress, 'tmp.js');
         $js_hash = build_integrity_hash($js_out);
         file_put_contents('site.js', $js_out);
         unlink('./tmp.js');


### PR DESCRIPTION
## 🍰 Pullrequest

Message page content couldn't be refreshed even after rebuilding the app or clearing the browser cache. 

This PR makes cache keys depending on the last js build:

- `scripts/config_gen.php`: `combine_includes()` now stamps a fresh `HM_BUILD_VERSION` identifier into the bundled `site.js` on every build.
- `modules/imap/site.js`: `getMessageStorageKey()` prefixes cache keys with `HM_BUILD_VERSION`, so entries written under a previous build no longer match after a rebuild. `purgeStaleMessageCache()` runs once per page load and actively deletes any leftover `msg_cache_*` entries from an older build.

Result: rebuilding the app is now enough on its own to guarantee fresh message page content.

### Related
- #1686

### Todo
- [X] None