### PR TITLE
fix(other): fix proxy-related login loop and cookie domain mismatch

### DIFF
--- a/lib/module.php
+++ b/lib/module.php
@@ -235,15 +235,34 @@ trait Hm_Handler_Validate {
         if ($target == 'none') {
             $target = false;
         }
-        $server_vars = [
-            'HTTP_REFERER' => 'source',
-            'HTTP_ORIGIN' => 'source',
-            'HTTP_HOST' => 'target',
-            'HTTP_X_FORWARDED_HOST' => 'target'
-        ];
-        foreach ($server_vars as $header => $type) {
-            if (!empty($request->server[$header])) {
-                $$type = $request->server[$header];
+        if (!empty($request->server['HTTP_HOST'])) {
+            $target = $request->server['HTTP_HOST'];
+        }
+        if (!empty($request->server['HTTP_X_FORWARDED_HOST'])) {
+            $target = trim(explode(',', $request->server['HTTP_X_FORWARDED_HOST'])[0]);
+        }
+
+        $origin = !empty($request->server['HTTP_ORIGIN']) ? $request->server['HTTP_ORIGIN'] : false;
+        $referer = !empty($request->server['HTTP_REFERER']) ? $request->server['HTTP_REFERER'] : false;
+        $source = $origin ?: $referer;
+
+        // Some proxies rewrite Origin to localhost while Referer still has the public host.
+        if ($origin && $referer && $target) {
+            $origin_parts = parse_url($origin);
+            $referer_parts = parse_url($referer);
+            if (is_array($origin_parts) && array_key_exists('host', $origin_parts) &&
+                is_array($referer_parts) && array_key_exists('host', $referer_parts)) {
+                $origin_host = $origin_parts['host'];
+                if (array_key_exists('port', $origin_parts)) {
+                    $origin_host .= ':'.$origin_parts['port'];
+                }
+                $referer_host = $referer_parts['host'];
+                if (array_key_exists('port', $referer_parts)) {
+                    $referer_host .= ':'.$referer_parts['port'];
+                }
+                if ($origin_host !== $target && $referer_host === $target) {
+                    $source = $referer;
+                }
             }
         }
         return [$source, $target];

--- a/lib/session_base.php
+++ b/lib/session_base.php
@@ -298,8 +298,14 @@ abstract class Hm_Session {
         if ($domain == 'none') {
             return '';
         }
+        if (!$domain && array_key_exists('HTTP_X_FORWARDED_HOST', $request->server)) {
+            $domain = trim(explode(',', $request->server['HTTP_X_FORWARDED_HOST'])[0]);
+        }
         if (!$domain && array_key_exists('HTTP_HOST', $request->server)) {
             $domain = $request->server['HTTP_HOST'];
+        }
+        if ($domain && preg_match('/:\d+$/', $domain, $matches)) {
+            $domain = str_replace($matches[0], '', $domain);
         }
         return $domain;
     }

--- a/lib/session_base.php
+++ b/lib/session_base.php
@@ -44,8 +44,8 @@ trait Hm_Session_Fingerprint {
             return;
         }
         $id = $this->build_fingerprint($request->server);
-        $fingerprint = $this->get('fingerprint', null);
-        if ($fingerprint === false) {
+        $fingerprint = $this->get('fingerprint', false);
+        if ($fingerprint === false || $fingerprint === null) {
             $this->set_fingerprint($request);
             return;
         }

--- a/lib/session_php.php
+++ b/lib/session_php.php
@@ -199,7 +199,10 @@ class Hm_PHP_Session extends Hm_PHP_Session_Data {
             $this->get_key($request);
             $this->existing = true;
             $this->start($request);
-            $this->check_fingerprint($request);
+            // Only enforce fingerprint for active sessions.
+            if ($this->is_active()) {
+                $this->check_fingerprint($request);
+            }
             $this->restore_long_session($request);
         }
         return $this->is_active();

--- a/lib/session_php.php
+++ b/lib/session_php.php
@@ -243,12 +243,24 @@ class Hm_PHP_Session extends Hm_PHP_Session_Data {
             $path = $request->path;
         }
         $domain = $this->site_config->get('cookie_domain', false);
+        if (!$domain && array_key_exists('HTTP_X_FORWARDED_HOST', $request->server)) {
+            $domain = trim(explode(',', $request->server['HTTP_X_FORWARDED_HOST'])[0]);
+        }
         if (!$domain && array_key_exists('HTTP_HOST', $request->server)) {
-            $host = parse_url($request->server['HTTP_HOST'],  PHP_URL_HOST);
+            $host = parse_url($request->server['HTTP_HOST'], PHP_URL_HOST);
             if (trim((string) $host)) {
                 $domain = $host;
             } else {
                 $domain = $request->server['HTTP_HOST'];
+            }
+        }
+        if ($domain) {
+            $host = parse_url($domain, PHP_URL_HOST);
+            if (trim((string) $host)) {
+                $domain = $host;
+            }
+            if (preg_match('/:\d+$/', $domain, $matches)) {
+                $domain = str_replace($matches[0], '', $domain);
             }
         }
         if ($domain == 'none') {

--- a/tests/phpunit/session.php
+++ b/tests/phpunit/session.php
@@ -183,8 +183,11 @@ class Hm_Test_PHP_Session extends TestCase {
         $request = new Hm_Mock_Request('HTTP');
         $request->server['HTTP_HOST'] = 'test';
         $this->assertEquals(array(false, 'asdf', 'test'), $session->set_session_params($request));
+        $request->server['HTTP_X_FORWARDED_HOST'] = 'proxy.test:8080, internal.test';
+        $this->assertEquals(array(false, 'asdf', 'proxy.test'), $session->set_session_params($request));
         $request->tls = true;
         $request->path = 'test';
+        $request->server['HTTP_X_FORWARDED_HOST'] = 'test';
         $this->assertEquals(array(true, 'test', 'test'), $session->set_session_params($request));
         $session->destroy($request);
 


### PR DESCRIPTION
## Summary

This PR fixes login loops observed when Cypht is deployed behind reverse proxies where public and internal host headers differ.

### Issues

In proxied environments, request metadata can be inconsistent across headers:

* Origin may be rewritten to localhost while Referer contains the public host.
* Internal HTTP host can differ from externally visible forwarded host.
* Session fingerprint checks could run against non-active sessions with incomplete state.

This could cause repeated logout behavior and return users to the login form.

### Root cause

* Origin validation used strict source/target matching without proxy-aware source selection.
* Cookie domain fallback could resolve to internal host instead of forwarded/public host.
* Fingerprint validation could execute too early for certain existing session states.

### About COOKIE_DOMAIN behavior

* This PR improves fallback behavior when COOKIE_DOMAIN is not explicitly set, by preferring forwarded/public host values.
* Explicit COOKIE_DOMAIN remains authoritative and is still respected.
* For dynamic preview domains (such as github.dev-style hosts), COOKIE_DOMAIN=none may still be the safest operational setting because it forces host-only cookies and avoids accidental binding to internal hostnames.
* This PR reduces the need for COOKIE_DOMAIN=none in some trusted proxy deployments, but does not remove that option when host rewriting is inconsistent.

Related issue: https://github.com/cypht-org/cypht/issues/1989