### PR TITLE
fix(docker): fix Docker UI when ENABLE_DEBUG is enabled

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -18,8 +18,6 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
-      args:
-        WITH_DEBUG: true
     volumes:
       - ./data/users:/var/lib/hm3/users
       - ./data/attachments:/var/lib/hm3/attachments

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -28,6 +28,19 @@ fi
 chown www-data:www-data ${ATTACHMENT_DIR}
 chown -R www-data:www-data /var/lib/nginx
 
+# When LOG_FILE is set, ensure its directory exists and is writable
+if [ -n "${LOG_FILE}" ]; then
+    case "${LOG_FILE}" in
+        /*) LOG_PATH="${LOG_FILE}" ;;
+        *)  LOG_PATH="${APP_DIR}/${LOG_FILE}" ;;
+    esac
+    LOG_DIR=$(dirname "${LOG_PATH}")
+    mkdir -p "${LOG_DIR}"
+    chown www-data:www-data "${LOG_DIR}"
+    touch "${LOG_PATH}"
+    chown www-data:www-data "${LOG_PATH}"
+fi
+
 rm -r /var/www
 ln -s $(pwd)/site /var/www
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -44,5 +44,23 @@ fi
 rm -r /var/www
 ln -s $(pwd)/site /var/www
 
+# DEBUG_MODE serves per-module JS/CSS (and vendor/third_party assets) from WEB_ROOT.
+# Docker's nginx document root is site/, which only contains the production bundle
+# plus a subset of assets - breaking the UI (Offline banner, missing sidebar/home).
+# Link the live source trees into site/ when debug is enabled via the ENABLE_DEBUG
+# environment variable.
+case "$(printf '%s' "${ENABLE_DEBUG}" | tr '[:upper:]' '[:lower:]')" in
+    true|1|yes)
+        echo "ENABLE_DEBUG enabled: linking modules/vendor/third_party into site/"
+        for path in modules vendor third_party; do
+            target="${APP_DIR}/site/${path}"
+            if [ -e "${target}" ] && [ ! -L "${target}" ]; then
+                rm -rf "${target}"
+            fi
+            ln -sfn "${APP_DIR}/${path}" "${target}"
+        done
+        ;;
+esac
+
 # Start services
 exec /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
## Summary

- When `ENABLE_DEBUG=true`, Cypht serves per-module JS/CSS instead of the combined `site.js` / `site.css`. Docker’s nginx document root is `site/`, so we encounter a 404 status for those assets and this breaks AJAX and shows Offline with a missing sidebar/home.
- The entrypoint now symlinks `modules`, `vendor`, and `third_party` into `site/` when `ENABLE_DEBUG` is set.
- If `LOG_FILE` is set, the entrypoint creates and chowns that path for php-fpm.
- Removes the unused `WITH_DEBUG` build arg from `docker-compose.dev.yaml` (never consumed by the Dockerfile).
