### PR TITLE
fix(backend): check select_mailbox() result in get_mailbox_page()

### DIFF
--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -2561,7 +2561,15 @@ if (!class_exists('Hm_IMAP')) {
 
             /* select the mailbox if need be */
             if (!$this->selected_mailbox || $this->selected_mailbox['name'] != $mailbox) {
-                $this->select_mailbox($mailbox);
+                /* Bail out if the mailbox cannot be selected. Without this check the
+                 * SORT/SEARCH/FETCH commands below run against whatever mailbox is still
+                 * selected on the connection, so a failed switch either returns an empty
+                 * list or - worse - messages from the previously selected mailbox.
+                 * Same contract as Hm_Mailbox::get_messages(), which already returns
+                 * [0, []] when select_folder() fails. */
+                if (!$this->select_mailbox($mailbox)) {
+                    return array(0, array());
+                }
             }
 
             /* use the SORT extension if we can */

--- a/tests/phpunit/modules/imap/hm_imap.php
+++ b/tests/phpunit/modules/imap/hm_imap.php
@@ -532,6 +532,40 @@ class Hm_Test_Hm_IMAP extends TestCase {
         $this->assertEquals($res, $list);
     }
     /**
+     * A failed mailbox switch must not fall through to SORT/SEARCH/FETCH.
+     *
+     * get_mailbox_page() used to call select_mailbox() without checking the result.
+     * Those commands carry no mailbox argument - they act on whatever is selected on
+     * the connection. So when the switch failed, the page was either empty or built
+     * from the *previously* selected mailbox, and the caller had no way to tell.
+     *
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function test_get_mailbox_page_bails_out_when_select_fails() {
+        /* Anonymous class so it is only resolved at runtime, after setUp() has
+         * required hm-imap.php. Makes select_mailbox() fail without needing a broken
+         * server or a hand-crafted IMAP fixture. */
+        $imap = new class extends Hm_IMAP {
+            public $select_calls = 0;
+            public function select_mailbox($mailbox) {
+                $this->select_calls++;
+                return false;
+            }
+        };
+        $imap->connect($this->config);
+        /* The connection sits on INBOX ... */
+        $imap->selected_mailbox = array('name' => 'INBOX', 'detail' => array());
+        /* ... and switching away from it fails. */
+        $res = $imap->get_mailbox_page('Spam', 'ARRIVAL', false, 'ALL');
+
+        $this->assertEquals(1, $imap->select_calls, 'select_mailbox() should be attempted once');
+        $this->assertEquals(array(0, array()), $res, 'must not return messages from the old mailbox');
+        /* Guard against the empty result being a coincidence: the mailbox we could not
+         * select must not be recorded as the selected one. */
+        $this->assertEquals('INBOX', $imap->selected_mailbox['name']);
+    }
+    /**
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */


### PR DESCRIPTION
`get_mailbox_page()` calls `select_mailbox()` without checking the result. The SORT/SEARCH/FETCH commands that follow carry no mailbox argument — they operate on whichever mailbox is currently selected on the connection. When the switch fails, the function keeps going and either returns an empty page or, if another mailbox is still selected, returns messages from *that* mailbox under the requested name. The caller has no way to tell either case from a genuinely empty folder.

This returns `[0, []]` when the select fails, matching what `Hm_Mailbox::get_messages()` already does when `select_folder()` fails, so callers that expect `$messages[1]` keep working.

**How I ran into it**

Debugging an account that consistently returned zero messages. In that particular case the mailbox really was empty, so this was not the root cause — but the silent fall-through cost several rounds of investigation before that was clear, and the wrong-mailbox path is a correctness issue in its own right.

**On the test**

I added a regression test using an anonymous subclass to force `select_mailbox()` to fail, so it needs neither a broken server nor a hand-crafted IMAP fixture.

I could not get it to run green, and not because of the test:

- the `modules_imap` suite is commented out in `tests/phpunit/phpunit.xml` (lines 141-142), so the IMAP tests do not run in CI at all;
- the file it points at is `./modules/imap/hm-imap.php`, but the test file is `hm_imap.php`;
- running the file directly fails on duplicate class declarations (`HTMLToText`, `Test_Uid_Cache`) because `setUp()` uses `require` rather than `require_once` — this hits the existing `test_get_mailbox_page` too, not just my addition.

Happy to drop the test from this PR, or to look at reviving the suite separately — whichever you prefer. I did not want to bundle that into a nine-line fix.